### PR TITLE
add allowfeerecipients in genesis & add coinbase to chain config

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,29 @@ The Subnet EVM is compatible with almost all Ethereum tooling, including [Remix,
 - Removed Multicoin Contract and State
 - Removed DAO Hardfork Support
 
+## Setting a Custom Fee Recipient
+By default, all fees are burned (sent to the blackhole address). However, it is
+possible to enable block producers to set a fee recipient (get compensated for
+blocks they produce).
+
+To enabke this feature, you'll need to add the following to your
+genesis file:
+```json
+{
+  "allowFeeRecipients":true
+}
+```
+
+Next, you'll need to update your VM config with the following:
+```json
+{
+  "feeRecipient":"<YOU 0x-ADDRESS>"
+}
+```
+
+_Note: If you enable this feature but a validator doesn't specify
+a "feeRecipient", the fees will be burned in blocks they produce._
+
 ## Run Local Network
 [`scripts/run.sh`](scripts/run.sh) automatically installs [avalanchego], sets up a local network,
 and creates a `subnet-evm` genesis file.

--- a/chain/subnet_evm.go
+++ b/chain/subnet_evm.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ava-labs/subnet-evm/node"
 	"github.com/ava-labs/subnet-evm/rpc"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 var BlackholeAddr = common.Address{
@@ -44,7 +45,12 @@ func NewETHChain(config *eth.Config, nodecfg *node.Config, chainDB ethdb.Databas
 		return nil, fmt.Errorf("failed to create backend: %w", err)
 	}
 	chain := &ETHChain{backend: backend}
-	backend.SetEtherbase(config.Miner.Etherbase)
+	if config.Miner.Etherbase == (common.Address{}) { // used for testing
+		log.Warn("Etherbase not set. Falling back to blackhole address.")
+		backend.SetEtherbase(BlackholeAddr)
+	} else {
+		backend.SetEtherbase(config.Miner.Etherbase)
+	}
 	return chain, nil
 }
 

--- a/chain/subnet_evm.go
+++ b/chain/subnet_evm.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ava-labs/subnet-evm/node"
 	"github.com/ava-labs/subnet-evm/rpc"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 var BlackholeAddr = common.Address{
@@ -44,7 +45,16 @@ func NewETHChain(config *eth.Config, nodecfg *node.Config, chainDB ethdb.Databas
 		return nil, fmt.Errorf("failed to create backend: %w", err)
 	}
 	chain := &ETHChain{backend: backend}
-	backend.SetEtherbase(BlackholeAddr)
+	if config.Genesis.Config.AllowFeeRecipients {
+		if (config.Miner.Etherbase == common.Address{}) {
+			log.Warn("Chain enabled AllowFeeRecipients, but chain config has not specified any coinbase address. Defaulting to the blackhole address.")
+			backend.SetEtherbase(BlackholeAddr)
+		} else {
+			backend.SetEtherbase(config.Miner.Etherbase)
+		}
+	} else {
+		backend.SetEtherbase(BlackholeAddr)
+	}
 	return chain, nil
 }
 

--- a/chain/subnet_evm.go
+++ b/chain/subnet_evm.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ava-labs/subnet-evm/node"
 	"github.com/ava-labs/subnet-evm/rpc"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/log"
 )
 
 var BlackholeAddr = common.Address{
@@ -45,16 +44,7 @@ func NewETHChain(config *eth.Config, nodecfg *node.Config, chainDB ethdb.Databas
 		return nil, fmt.Errorf("failed to create backend: %w", err)
 	}
 	chain := &ETHChain{backend: backend}
-	if config.Genesis.Config.AllowFeeRecipients {
-		if (config.Miner.Etherbase == common.Address{}) {
-			log.Warn("Chain enabled AllowFeeRecipients, but chain config has not specified any coinbase address. Defaulting to the blackhole address.")
-			backend.SetEtherbase(BlackholeAddr)
-		} else {
-			backend.SetEtherbase(config.Miner.Etherbase)
-		}
-	} else {
-		backend.SetEtherbase(BlackholeAddr)
-	}
+	backend.SetEtherbase(config.Miner.Etherbase)
 	return chain, nil
 }
 

--- a/params/config.go
+++ b/params/config.go
@@ -112,7 +112,7 @@ type ChainConfig struct {
 	SubnetEVMTimestamp *big.Int `json:"subnetEVMTimestamp,omitempty"` // A placeholder for the latest avalanche forks (nil = no fork, 0 = already activated)
 
 	FeeConfig          *FeeConfig `json:"feeConfig,omitempty"`
-	AllowFeeRecipients bool       `json:"allowFeeRecipients"` // Allows fees to be collected by block builders.
+	AllowFeeRecipients bool       `json:"allowFeeRecipients,omitempty"` // Allows fees to be collected by block builders.
 }
 
 type FeeConfig struct {

--- a/params/config.go
+++ b/params/config.go
@@ -27,6 +27,7 @@
 package params
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
@@ -78,10 +79,11 @@ var (
 		MuirGlacierBlock:    big.NewInt(0),
 		SubnetEVMTimestamp:  big.NewInt(0),
 		FeeConfig:           DefaultFeeConfig,
+		AllowFeeRecipients:  false,
 	}
 
-	TestChainConfig        = &ChainConfig{big.NewInt(1), big.NewInt(0), big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), DefaultFeeConfig}
-	TestPreSubnetEVMConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, DefaultFeeConfig}
+	TestChainConfig        = &ChainConfig{big.NewInt(1), big.NewInt(0), big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), DefaultFeeConfig, false}
+	TestPreSubnetEVMConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, DefaultFeeConfig, false}
 )
 
 // ChainConfig is the core config which determines the blockchain settings.
@@ -109,7 +111,8 @@ type ChainConfig struct {
 
 	SubnetEVMTimestamp *big.Int `json:"subnetEVMTimestamp,omitempty"` // A placeholder for the latest avalanche forks (nil = no fork, 0 = already activated)
 
-	FeeConfig *FeeConfig `json:"feeConfig,omitempty"`
+	FeeConfig          *FeeConfig `json:"feeConfig,omitempty"`
+	AllowFeeRecipients bool       `json:"allowFeeRecipients"` // Allows fees to be collected by block builders.
 }
 
 type FeeConfig struct {
@@ -127,7 +130,11 @@ type FeeConfig struct {
 
 // String implements the fmt.Stringer interface.
 func (c *ChainConfig) String() string {
-	return fmt.Sprintf("{ChainID: %v Homestead: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v Petersburg: %v Istanbul: %v, Muir Glacier: %v, Subnet EVM: %v, Engine: Dummy Consensus Engine}",
+	feeBytes, err := json.Marshal(c.FeeConfig)
+	if err != nil {
+		feeBytes = []byte("cannot unmarshal FeeConfig")
+	}
+	return fmt.Sprintf("{ChainID: %v Homestead: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v Petersburg: %v Istanbul: %v, Muir Glacier: %v, Subnet EVM: %v, FeeConfig: %v, AllowFeeRecipients: %v, Engine: Dummy Consensus Engine}",
 		c.ChainID,
 		c.HomesteadBlock,
 		c.EIP150Block,
@@ -139,6 +146,8 @@ func (c *ChainConfig) String() string {
 		c.IstanbulBlock,
 		c.MuirGlacierBlock,
 		c.SubnetEVMTimestamp,
+		string(feeBytes),
+		c.AllowFeeRecipients,
 	)
 }
 

--- a/plugin/evm/block_verification.go
+++ b/plugin/evm/block_verification.go
@@ -181,8 +181,8 @@ func (blockValidatorSubnetEVM) SyntacticVerify(b *Block) error {
 	if uncleHash != ethHeader.UncleHash {
 		return errUncleHashMismatch
 	}
-	// Coinbase must be zero on C-Chain
-	if b.ethBlock.Coinbase() != subnetEVM.BlackholeAddr {
+	// Coinbase must be zero, if AllowFeeRecipients is not enabled
+	if !b.vm.chainConfig.AllowFeeRecipients && b.ethBlock.Coinbase() != subnetEVM.BlackholeAddr {
 		return errInvalidBlock
 	}
 	// Block must not have any uncles

--- a/plugin/evm/config.go
+++ b/plugin/evm/config.go
@@ -96,7 +96,7 @@ type Config struct {
 	LogLevel string `json:"log-level"`
 
 	// Address for Tx Fees
-	Coinbase string `json:"coinbase"`
+	FeeRecipient string `json:"feeRecipient"`
 }
 
 // EthAPIs returns an array of strings representing the Eth APIs that should be enabled

--- a/plugin/evm/config.go
+++ b/plugin/evm/config.go
@@ -95,7 +95,7 @@ type Config struct {
 	// Log level
 	LogLevel string `json:"log-level"`
 
-	// Address for Tx Fees
+	// Address for Tx Fees (must be empty if not supported by blockchain)
 	FeeRecipient string `json:"feeRecipient"`
 }
 

--- a/plugin/evm/config.go
+++ b/plugin/evm/config.go
@@ -94,6 +94,9 @@ type Config struct {
 
 	// Log level
 	LogLevel string `json:"log-level"`
+
+	// Address for Tx Fees
+	Coinbase string `json:"coinbase"`
 }
 
 // EthAPIs returns an array of strings representing the Eth APIs that should be enabled

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -249,6 +249,11 @@ func (vm *VM) Initialize(
 	ethConfig.Pruning = vm.config.Pruning
 	ethConfig.SnapshotAsync = vm.config.SnapshotAsync
 	ethConfig.SnapshotVerify = vm.config.SnapshotVerify
+	if common.IsHexAddress(vm.config.Coinbase) {
+		address := common.HexToAddress(vm.config.Coinbase)
+		log.Info("Setting coinbase", "address", address)
+		ethConfig.Miner.Etherbase = address
+	}
 
 	vm.chainConfig = g.Config
 	vm.networkID = ethConfig.NetworkId

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	schain "github.com/ava-labs/subnet-evm/chain"
 	subnetEVM "github.com/ava-labs/subnet-evm/chain"
 	"github.com/ava-labs/subnet-evm/core"
 	"github.com/ava-labs/subnet-evm/core/types"
@@ -249,10 +250,15 @@ func (vm *VM) Initialize(
 	ethConfig.Pruning = vm.config.Pruning
 	ethConfig.SnapshotAsync = vm.config.SnapshotAsync
 	ethConfig.SnapshotVerify = vm.config.SnapshotVerify
-	if common.IsHexAddress(vm.config.Coinbase) {
-		address := common.HexToAddress(vm.config.Coinbase)
-		log.Info("Setting coinbase", "address", address)
+	if common.IsHexAddress(vm.config.FeeRecipient) {
+		address := common.HexToAddress(vm.config.FeeRecipient)
+		log.Info("Setting fee recipient", "address", address)
 		ethConfig.Miner.Etherbase = address
+	} else {
+		if g.Config.AllowFeeRecipients {
+			log.Warn("Chain enabled AllowFeeRecipients, but chain config has not specified any coinbase address. Defaulting to the blackhole address.")
+		}
+		ethConfig.Miner.Etherbase = schain.BlackholeAddr
 	}
 
 	vm.chainConfig = g.Config


### PR DESCRIPTION
This PR adds a mechanism to redirect fees to addresses instead of burning them by sending to a blackhole address

Adds`allowRedirectFees` bool flag to genesis chain configs.
Adds a configurable `coinbase` address to chain configs. 
Block builders can specify their `coinbase` addresses to collect fees if chain activates `allowRedirectFees` in the genesis.