### PR TITLE
Abstract allow list and separate contract allow list

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ subnet, you can provide an `AllowList` configuration in your genesis file:
       "targetBlockRate": 2,
       "blockGasCostStep": 500000
     },
-    "allowListConfig": {
+    "contractDeployerAllowListConfig": {
       "blockTimestamp": 0,
       "adminAddresses":["0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC"]
     }

--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -182,15 +182,17 @@ func TestStatefulPrecompilesConfigure(t *testing.T) {
 		"allow list enabled in genesis": {
 			getConfig: func() *params.ChainConfig {
 				config := *params.TestChainConfig
-				config.AllowListConfig = precompile.AllowListConfig{
-					BlockTimestamp:  big.NewInt(0),
-					AllowListAdmins: []common.Address{addr},
+				config.ContractDeployerAllowListConfig = precompile.ContractDeployerAllowListConfig{
+					AllowListConfig: precompile.AllowListConfig{
+						BlockTimestamp:  big.NewInt(0),
+						AllowListAdmins: []common.Address{addr},
+					},
 				}
 				return &config
 			},
 			assertState: func(t *testing.T, sdb *state.StateDB) {
-				assert.Equal(t, precompile.AllowListAdmin, precompile.GetAllowListStatus(sdb, addr), "unexpected allow list status for modified address")
-				assert.Equal(t, uint64(1), sdb.GetNonce(precompile.AllowListAddress))
+				assert.Equal(t, precompile.AllowListAdmin, precompile.GetContractDeployerAllowListStatus(sdb, addr), "unexpected allow list status for modified address")
+				assert.Equal(t, uint64(1), sdb.GetNonce(precompile.ContractDeployerAllowListAddress))
 			},
 		},
 	} {

--- a/core/stateful_precompile_test.go
+++ b/core/stateful_precompile_test.go
@@ -22,7 +22,7 @@ func (m *mockAccessibleState) GetStateDB() precompile.StateDB { return m.state }
 
 // This test is added within the core package so that it can import all of the required code
 // without creating any import cycles
-func TestAllowListConfigure(t *testing.T) {
+func TestContractDeployerAllowListConfigure(t *testing.T) {
 	type test struct {
 		caller         common.Address
 		precompileAddr common.Address
@@ -43,7 +43,7 @@ func TestAllowListConfigure(t *testing.T) {
 	for name, test := range map[string]test{
 		"set admin": {
 			caller:         adminAddr,
-			precompileAddr: precompile.AllowListAddress,
+			precompileAddr: precompile.ContractDeployerAllowListAddress,
 			input: func() []byte {
 				input, err := precompile.PackModifyAllowList(noRoleAddr, precompile.AllowListAdmin)
 				if err != nil {
@@ -54,20 +54,20 @@ func TestAllowListConfigure(t *testing.T) {
 			suppliedGas: precompile.ModifyAllowListGasCost,
 			readOnly:    false,
 			setupState: func(state *state.StateDB) {
-				precompile.SetAllowListRole(state, adminAddr, precompile.AllowListAdmin)
+				precompile.SetContractDeployerAllowListStatus(state, adminAddr, precompile.AllowListAdmin)
 			},
 			expectedRes: []byte{},
 			assertState: func(t *testing.T, state *state.StateDB) {
-				res := precompile.GetAllowListStatus(state, adminAddr)
+				res := precompile.GetContractDeployerAllowListStatus(state, adminAddr)
 				assert.Equal(t, precompile.AllowListAdmin, res)
 
-				res = precompile.GetAllowListStatus(state, noRoleAddr)
+				res = precompile.GetContractDeployerAllowListStatus(state, noRoleAddr)
 				assert.Equal(t, precompile.AllowListAdmin, res)
 			},
 		},
 		"set deployer": {
 			caller:         adminAddr,
-			precompileAddr: precompile.AllowListAddress,
+			precompileAddr: precompile.ContractDeployerAllowListAddress,
 			input: func() []byte {
 				input, err := precompile.PackModifyAllowList(noRoleAddr, precompile.AllowListEnabled)
 				if err != nil {
@@ -78,20 +78,20 @@ func TestAllowListConfigure(t *testing.T) {
 			suppliedGas: precompile.ModifyAllowListGasCost,
 			readOnly:    false,
 			setupState: func(state *state.StateDB) {
-				precompile.SetAllowListRole(state, adminAddr, precompile.AllowListAdmin)
+				precompile.SetContractDeployerAllowListStatus(state, adminAddr, precompile.AllowListAdmin)
 			},
 			expectedRes: []byte{},
 			assertState: func(t *testing.T, state *state.StateDB) {
-				res := precompile.GetAllowListStatus(state, adminAddr)
+				res := precompile.GetContractDeployerAllowListStatus(state, adminAddr)
 				assert.Equal(t, precompile.AllowListAdmin, res)
 
-				res = precompile.GetAllowListStatus(state, noRoleAddr)
+				res = precompile.GetContractDeployerAllowListStatus(state, noRoleAddr)
 				assert.Equal(t, precompile.AllowListEnabled, res)
 			},
 		},
 		"set no role": {
 			caller:         adminAddr,
-			precompileAddr: precompile.AllowListAddress,
+			precompileAddr: precompile.ContractDeployerAllowListAddress,
 			input: func() []byte {
 				input, err := precompile.PackModifyAllowList(adminAddr, precompile.AllowListNoRole)
 				if err != nil {
@@ -102,17 +102,17 @@ func TestAllowListConfigure(t *testing.T) {
 			suppliedGas: precompile.ModifyAllowListGasCost,
 			readOnly:    false,
 			setupState: func(state *state.StateDB) {
-				precompile.SetAllowListRole(state, adminAddr, precompile.AllowListAdmin)
+				precompile.SetContractDeployerAllowListStatus(state, adminAddr, precompile.AllowListAdmin)
 			},
 			expectedRes: []byte{},
 			assertState: func(t *testing.T, state *state.StateDB) {
-				res := precompile.GetAllowListStatus(state, adminAddr)
+				res := precompile.GetContractDeployerAllowListStatus(state, adminAddr)
 				assert.Equal(t, precompile.AllowListNoRole, res)
 			},
 		},
 		"set no role from non-admin": {
 			caller:         noRoleAddr,
-			precompileAddr: precompile.AllowListAddress,
+			precompileAddr: precompile.ContractDeployerAllowListAddress,
 			input: func() []byte {
 				input, err := precompile.PackModifyAllowList(adminAddr, precompile.AllowListNoRole)
 				if err != nil {
@@ -127,7 +127,7 @@ func TestAllowListConfigure(t *testing.T) {
 		},
 		"set deployer from non-admin": {
 			caller:         noRoleAddr,
-			precompileAddr: precompile.AllowListAddress,
+			precompileAddr: precompile.ContractDeployerAllowListAddress,
 			input: func() []byte {
 				input, err := precompile.PackModifyAllowList(adminAddr, precompile.AllowListEnabled)
 				if err != nil {
@@ -142,7 +142,7 @@ func TestAllowListConfigure(t *testing.T) {
 		},
 		"set admin from non-admin": {
 			caller:         noRoleAddr,
-			precompileAddr: precompile.AllowListAddress,
+			precompileAddr: precompile.ContractDeployerAllowListAddress,
 			input: func() []byte {
 				input, err := precompile.PackModifyAllowList(adminAddr, precompile.AllowListAdmin)
 				if err != nil {
@@ -157,7 +157,7 @@ func TestAllowListConfigure(t *testing.T) {
 		},
 		"set no role with readOnly enabled": {
 			caller:         adminAddr,
-			precompileAddr: precompile.AllowListAddress,
+			precompileAddr: precompile.ContractDeployerAllowListAddress,
 			input: func() []byte {
 				input, err := precompile.PackModifyAllowList(adminAddr, precompile.AllowListNoRole)
 				if err != nil {
@@ -168,13 +168,13 @@ func TestAllowListConfigure(t *testing.T) {
 			suppliedGas: precompile.ModifyAllowListGasCost,
 			readOnly:    true,
 			setupState: func(state *state.StateDB) {
-				precompile.SetAllowListRole(state, adminAddr, precompile.AllowListAdmin)
+				precompile.SetContractDeployerAllowListStatus(state, adminAddr, precompile.AllowListAdmin)
 			},
 			expectedErr: precompile.ErrReadOnlyModifyAllowList.Error(),
 		},
 		"read allow list no role": {
 			caller:         adminAddr,
-			precompileAddr: precompile.AllowListAddress,
+			precompileAddr: precompile.ContractDeployerAllowListAddress,
 			input: func() []byte {
 				return precompile.PackReadAllowList(noRoleAddr)
 			},
@@ -183,41 +183,41 @@ func TestAllowListConfigure(t *testing.T) {
 			setupState:  func(state *state.StateDB) {},
 			expectedRes: common.Hash(precompile.AllowListNoRole).Bytes(),
 			assertState: func(t *testing.T, state *state.StateDB) {
-				res := precompile.GetAllowListStatus(state, adminAddr)
+				res := precompile.GetContractDeployerAllowListStatus(state, adminAddr)
 				assert.Equal(t, precompile.AllowListNoRole, res)
 			},
 		},
 		"read allow list admin role": {
 			caller:         adminAddr,
-			precompileAddr: precompile.AllowListAddress,
+			precompileAddr: precompile.ContractDeployerAllowListAddress,
 			input: func() []byte {
 				return precompile.PackReadAllowList(noRoleAddr)
 			},
 			suppliedGas: precompile.ModifyAllowListGasCost,
 			readOnly:    false,
 			setupState: func(state *state.StateDB) {
-				precompile.SetAllowListRole(state, adminAddr, precompile.AllowListAdmin)
+				precompile.SetContractDeployerAllowListStatus(state, adminAddr, precompile.AllowListAdmin)
 			},
 			expectedRes: common.Hash(precompile.AllowListNoRole).Bytes(),
 			assertState: func(t *testing.T, state *state.StateDB) {
-				res := precompile.GetAllowListStatus(state, adminAddr)
+				res := precompile.GetContractDeployerAllowListStatus(state, adminAddr)
 				assert.Equal(t, precompile.AllowListAdmin, res)
 			},
 		},
 		"read allow list with readOnly enabled": {
 			caller:         adminAddr,
-			precompileAddr: precompile.AllowListAddress,
+			precompileAddr: precompile.ContractDeployerAllowListAddress,
 			input: func() []byte {
 				return precompile.PackReadAllowList(noRoleAddr)
 			},
 			suppliedGas: precompile.ModifyAllowListGasCost,
 			readOnly:    true,
 			setupState: func(state *state.StateDB) {
-				precompile.SetAllowListRole(state, adminAddr, precompile.AllowListAdmin)
+				precompile.SetContractDeployerAllowListStatus(state, adminAddr, precompile.AllowListAdmin)
 			},
 			expectedRes: common.Hash(precompile.AllowListNoRole).Bytes(),
 			assertState: func(t *testing.T, state *state.StateDB) {
-				res := precompile.GetAllowListStatus(state, adminAddr)
+				res := precompile.GetContractDeployerAllowListStatus(state, adminAddr)
 				assert.Equal(t, precompile.AllowListAdmin, res)
 			},
 		},
@@ -230,7 +230,7 @@ func TestAllowListConfigure(t *testing.T) {
 			}
 			test.setupState(state)
 
-			ret, _, err := precompile.AllowListPrecompile.Run(&mockAccessibleState{state: state}, test.caller, test.precompileAddr, test.input(), test.suppliedGas, test.readOnly)
+			ret, _, err := precompile.ContractDeployerAllowListPrecompile.Run(&mockAccessibleState{state: state}, test.caller, test.precompileAddr, test.input(), test.suppliedGas, test.readOnly)
 			if len(test.expectedErr) != 0 {
 				if err == nil {
 					assert.Failf(t, "run expectedly passed without error", "expected error %q", test.expectedErr)

--- a/core/test_blockchain.go
+++ b/core/test_blockchain.go
@@ -1516,10 +1516,12 @@ func TestStatefulPrecompiles(t *testing.T, create func(db ethdb.Database, chainC
 	genesisBalance := new(big.Int).Mul(big.NewInt(1000000), big.NewInt(params.Ether))
 	config := *params.TestChainConfig
 	// Set all of the required config parameters
-	config.AllowListConfig = precompile.AllowListConfig{
-		BlockTimestamp: big.NewInt(0),
-		AllowListAdmins: []common.Address{
-			addr1,
+	config.ContractDeployerAllowListConfig = precompile.ContractDeployerAllowListConfig{
+		AllowListConfig: precompile.AllowListConfig{
+			BlockTimestamp: big.NewInt(0),
+			AllowListAdmins: []common.Address{
+				addr1,
+			},
 		},
 	}
 	gspec := &Genesis{
@@ -1555,7 +1557,7 @@ func TestStatefulPrecompiles(t *testing.T, create func(db ethdb.Database, chainC
 				tx := types.NewTx(&types.DynamicFeeTx{
 					ChainID:   params.TestChainConfig.ChainID,
 					Nonce:     gen.TxNonce(addr1),
-					To:        &precompile.AllowListAddress,
+					To:        &precompile.ContractDeployerAllowListAddress,
 					Gas:       3_000_000,
 					Value:     common.Big0,
 					GasFeeCap: feeCap,
@@ -1570,22 +1572,22 @@ func TestStatefulPrecompiles(t *testing.T, create func(db ethdb.Database, chainC
 				gen.AddTx(signedTx)
 			},
 			verifyState: func(sdb *state.StateDB) error {
-				res := precompile.GetAllowListStatus(sdb, addr1)
+				res := precompile.GetContractDeployerAllowListStatus(sdb, addr1)
 				if precompile.AllowListAdmin != res {
 					return fmt.Errorf("unexpected allow list status for addr1 %s, expected %s", res, precompile.AllowListAdmin)
 				}
-				res = precompile.GetAllowListStatus(sdb, addr2)
+				res = precompile.GetContractDeployerAllowListStatus(sdb, addr2)
 				if precompile.AllowListAdmin != res {
 					return fmt.Errorf("unexpected allow list status for addr2 %s, expected %s", res, precompile.AllowListAdmin)
 				}
 				return nil
 			},
 			verifyGenesis: func(sdb *state.StateDB) {
-				res := precompile.GetAllowListStatus(sdb, addr1)
+				res := precompile.GetContractDeployerAllowListStatus(sdb, addr1)
 				if precompile.AllowListAdmin != res {
 					t.Fatalf("unexpected allow list status for addr1 %s, expected %s", res, precompile.AllowListAdmin)
 				}
-				res = precompile.GetAllowListStatus(sdb, addr2)
+				res = precompile.GetContractDeployerAllowListStatus(sdb, addr2)
 				if precompile.AllowListNoRole != res {
 					t.Fatalf("unexpected allow list status for addr2 %s, expected %s", res, precompile.AllowListNoRole)
 				}

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -484,8 +484,8 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 		return nil, common.Address{}, 0, ErrContractAddressCollision
 	}
 	// If the allow list is enabled, check that [evm.TxContext.Origin] has permission to deploy a contract.
-	if evm.chainRules.IsAllowListEnabled {
-		allowListRole := precompile.GetAllowListStatus(evm.StateDB, evm.TxContext.Origin)
+	if evm.chainRules.IsContractDeployerAllowListEnabled {
+		allowListRole := precompile.GetContractDeployerAllowListStatus(evm.StateDB, evm.TxContext.Origin)
 		if !allowListRole.IsEnabled() {
 			return nil, common.Address{}, 0, fmt.Errorf("tx.origin %s is not authorized to deploy a contract", evm.TxContext.Origin)
 		}

--- a/params/config.go
+++ b/params/config.go
@@ -138,7 +138,7 @@ func (c *ChainConfig) String() string {
 	if err != nil {
 		feeBytes = []byte("cannot unmarshal FeeConfig")
 	}
-	return fmt.Sprintf("{ChainID: %v Homestead: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v Petersburg: %v Istanbul: %v, Muir Glacier: %v, Subnet EVM: %v, FeeConfig: %v, AllowFeeRecipients: %v, Engine: Dummy Consensus Engine}",
+	return fmt.Sprintf("{ChainID: %v Homestead: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v Petersburg: %v Istanbul: %v, Muir Glacier: %v, Subnet EVM: %v, FeeConfig: %v, AllowFeeRecipients: %v, ContractDeployerAllowListConfig: %v, Engine: Dummy Consensus Engine}",
 		c.ChainID,
 		c.HomesteadBlock,
 		c.EIP150Block,
@@ -152,6 +152,7 @@ func (c *ChainConfig) String() string {
 		c.SubnetEVMTimestamp,
 		string(feeBytes),
 		c.AllowFeeRecipients,
+		c.ContractDeployerAllowListConfig,
 	)
 }
 

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -2199,9 +2199,11 @@ func TestBuildAllowListActivationBlock(t *testing.T) {
 	if err := genesis.UnmarshalJSON([]byte(genesisJSONSubnetEVM)); err != nil {
 		t.Fatal(err)
 	}
-	genesis.Config.AllowListConfig = precompile.AllowListConfig{
-		BlockTimestamp:  big.NewInt(time.Now().Unix()),
-		AllowListAdmins: testEthAddrs,
+	genesis.Config.ContractDeployerAllowListConfig = precompile.ContractDeployerAllowListConfig{
+		AllowListConfig: precompile.AllowListConfig{
+			BlockTimestamp:  big.NewInt(time.Now().Unix()),
+			AllowListAdmins: testEthAddrs,
+		},
 	}
 	genesisJSON, err := genesis.MarshalJSON()
 	if err != nil {
@@ -2227,7 +2229,7 @@ func TestBuildAllowListActivationBlock(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	role := precompile.GetAllowListStatus(genesisState, testEthAddrs[0])
+	role := precompile.GetContractDeployerAllowListStatus(genesisState, testEthAddrs[0])
 	if role != precompile.AllowListNoRole {
 		t.Fatalf("Expected allow list status to be set to no role: %s, but found: %s", precompile.AllowListNoRole, role)
 	}
@@ -2279,7 +2281,7 @@ func TestBuildAllowListActivationBlock(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	role = precompile.GetAllowListStatus(blkState, testEthAddrs[0])
+	role = precompile.GetContractDeployerAllowListStatus(blkState, testEthAddrs[0])
 	if role != precompile.AllowListAdmin {
 		t.Fatalf("Expected allow list status to be set to Admin: %s, but found: %s", precompile.AllowListAdmin, role)
 	}

--- a/precompile/allow_list.go
+++ b/precompile/allow_list.go
@@ -154,7 +154,7 @@ func writeAllowList(evm PrecompileAccessibleState, precompileAddr common.Address
 
 // createAllowListSetter returns an execution function for setting the allow list status of the input address argument to [role].
 // This execution function is speciifc to [precompileAddr].
-func createAllowListSetter(precompileAddr common.Address, role AllowListRole) func(evm PrecompileAccessibleState, callerAddr common.Address, addr common.Address, input []byte, suppliedGas uint64, readOnly bool) (ret []byte, remainingGas uint64, err error) {
+func createAllowListSetter(precompileAddr common.Address, role AllowListRole) RunStatefulPrecompileFunc {
 	return func(evm PrecompileAccessibleState, callerAddr, addr common.Address, input []byte, suppliedGas uint64, readOnly bool) (ret []byte, remainingGas uint64, err error) {
 		if len(input) != common.HashLength {
 			return nil, remainingGas, fmt.Errorf("invalid input length for modifying allow list: %d", len(input))

--- a/precompile/contract_deployer_allow_list.go
+++ b/precompile/contract_deployer_allow_list.go
@@ -1,0 +1,42 @@
+// (c) 2019-2020, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package precompile
+
+import "github.com/ethereum/go-ethereum/common"
+
+var (
+	_ StatefulPrecompileConfig = &ContractDeployerAllowListConfig{}
+	// Singleton StatefulPrecompiledContract for W/R access to the contract deployer allow list.
+	ContractDeployerAllowListPrecompile StatefulPrecompiledContract = createAllowListPrecompile(ContractDeployerAllowListAddress)
+)
+
+type ContractDeployerAllowListConfig struct {
+	AllowListConfig
+}
+
+func (c *ContractDeployerAllowListConfig) Address() common.Address {
+	return ContractDeployerAllowListAddress
+}
+
+func (c *ContractDeployerAllowListConfig) Configure(state StateDB) {
+	c.AllowListConfig.Configure(state, ContractDeployerAllowListAddress)
+}
+
+// Contract returns the singleton stateful precompiled contract to be used for the allow list.
+func (c *ContractDeployerAllowListConfig) Contract() StatefulPrecompiledContract {
+	return ContractDeployerAllowListPrecompile
+}
+
+// GetContractDeployerAllowListStatus returns the role of [address] for the contract deployer
+// allow list.
+func GetContractDeployerAllowListStatus(stateDB StateDB, address common.Address) AllowListRole {
+	return getAllowListStatus(stateDB, ContractDeployerAllowListAddress, address)
+}
+
+// SetContractDeployerAllowListStatus sets the permissions of [address] to [role] for the
+// contract deployer allow list.
+// assumes [role] has already been verified as valid.
+func SetContractDeployerAllowListStatus(stateDB StateDB, address common.Address, role AllowListRole) {
+	setAllowListRole(stateDB, ContractDeployerAllowListAddress, address, role)
+}

--- a/precompile/contract_deployer_allow_list.go
+++ b/precompile/contract_deployer_allow_list.go
@@ -11,14 +11,18 @@ var (
 	ContractDeployerAllowListPrecompile StatefulPrecompiledContract = createAllowListPrecompile(ContractDeployerAllowListAddress)
 )
 
+// ContractDeployerAllowListConfig wraps [AllowListConfig] and uses it to implement the StatefulPrecompileConfig
+// interface while adding in the contract deployer specific precompile address.
 type ContractDeployerAllowListConfig struct {
 	AllowListConfig
 }
 
+// Address returns the address of the contract deployer allow list.
 func (c *ContractDeployerAllowListConfig) Address() common.Address {
 	return ContractDeployerAllowListAddress
 }
 
+// Configure configures [state] with the desired admins based on [c].
 func (c *ContractDeployerAllowListConfig) Configure(state StateDB) {
 	c.AllowListConfig.Configure(state, ContractDeployerAllowListAddress)
 }

--- a/precompile/params.go
+++ b/precompile/params.go
@@ -20,9 +20,9 @@ const (
 // that their own modifications do not conflict with stateful precompiles that may be added to subnet-evm
 // in the future.
 var (
-	AllowListAddress = common.HexToAddress("0x0200000000000000000000000000000000000000")
+	ContractDeployerAllowListAddress = common.HexToAddress("0x0200000000000000000000000000000000000000")
 
 	UsedAddresses = []common.Address{
-		AllowListAddress,
+		ContractDeployerAllowListAddress,
 	}
 )


### PR DESCRIPTION
This PR separates the allow list into a module that can be easily used to implement future types of allow lists to restrict resources. It then moves the contract deployer allow list to a separate file that relies on this module.