### PR TITLE
Ci improvements

### DIFF
--- a/.github/workflows/lint-and-tests.yml
+++ b/.github/workflows/lint-and-tests.yml
@@ -29,5 +29,7 @@ jobs:
         shell: bash
       - run: ./scripts/build.sh ./build/subnetevm
         shell: bash
-      - run: ./scripts/build_test.sh
+      - run: ./scripts/build_test.sh -race
+        shell: bash
+      - run: ./scripts/coverage.sh
         shell: bash

--- a/accounts/keystore/account_cache_test.go
+++ b/accounts/keystore/account_cache_test.go
@@ -28,6 +28,7 @@ package keystore
 
 import (
 	"fmt"
+	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -60,45 +61,45 @@ var (
 	}
 )
 
-// TODO: fix flaky test
-// func TestWatchNewFile(t *testing.T) {
-// 	t.Parallel()
-//
-// 	dir, ks := tmpKeyStore(t, false)
-// 	defer os.RemoveAll(dir)
-//
-// 	// Ensure the watcher is started before adding any files.
-// 	ks.Accounts()
-// 	time.Sleep(2000 * time.Millisecond)
-//
-// 	// Move in the files.
-// 	wantAccounts := make([]accounts.Account, len(cachetestAccounts))
-// 	for i := range cachetestAccounts {
-// 		wantAccounts[i] = accounts.Account{
-// 			Address: cachetestAccounts[i].Address,
-// 			URL:     accounts.URL{Scheme: KeyStoreScheme, Path: filepath.Join(dir, filepath.Base(cachetestAccounts[i].URL.Path))},
-// 		}
-// 		if err := cp.CopyFile(wantAccounts[i].URL.Path, cachetestAccounts[i].URL.Path); err != nil {
-// 			t.Fatal(err)
-// 		}
-// 	}
-//
-// 	// ks should see the accounts.
-// 	var list []accounts.Account
-// 	for {
-// 		list = ks.Accounts()
-// 		if reflect.DeepEqual(list, wantAccounts) {
-// 			// ks should have also received change notifications
-// 			select {
-// 			case <-ks.changes:
-// 			default:
-// 				t.Fatalf("wasn't notified of new accounts")
-// 			}
-// 			return
-// 		}
-// 		time.Sleep(500 * time.Millisecond)
-// 	}
-// }
+func TestWatchNewFile(t *testing.T) {
+	t.Skip("FLAKY")
+	t.Parallel()
+
+	dir, ks := tmpKeyStore(t, false)
+	defer os.RemoveAll(dir)
+
+	// Ensure the watcher is started before adding any files.
+	ks.Accounts()
+	time.Sleep(2000 * time.Millisecond)
+
+	// Move in the files.
+	wantAccounts := make([]accounts.Account, len(cachetestAccounts))
+	for i := range cachetestAccounts {
+		wantAccounts[i] = accounts.Account{
+			Address: cachetestAccounts[i].Address,
+			URL:     accounts.URL{Scheme: KeyStoreScheme, Path: filepath.Join(dir, filepath.Base(cachetestAccounts[i].URL.Path))},
+		}
+		if err := cp.CopyFile(wantAccounts[i].URL.Path, cachetestAccounts[i].URL.Path); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// ks should see the accounts.
+	var list []accounts.Account
+	for {
+		list = ks.Accounts()
+		if reflect.DeepEqual(list, wantAccounts) {
+			// ks should have also received change notifications
+			select {
+			case <-ks.changes:
+			default:
+				t.Fatalf("wasn't notified of new accounts")
+			}
+			return
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+}
 
 func TestWatchNoDir(t *testing.T) {
 	t.Parallel()
@@ -306,112 +307,111 @@ func TestCacheFind(t *testing.T) {
 	}
 }
 
-// TODO: fix flaky test
-// func waitForAccounts(wantAccounts []accounts.Account, ks *KeyStore) error {
-// 	var list []accounts.Account
-// 	for d := 200 * time.Millisecond; d < 8*time.Second; d *= 2 {
-// 		list = ks.Accounts()
-// 		if reflect.DeepEqual(list, wantAccounts) {
-// 			// ks should have also received change notifications
-// 			select {
-// 			case <-ks.changes:
-// 			default:
-// 				return fmt.Errorf("wasn't notified of new accounts")
-// 			}
-// 			return nil
-// 		}
-// 		time.Sleep(d)
-// 	}
-// 	return fmt.Errorf("\ngot  %v\nwant %v", list, wantAccounts)
-// }
-//
-//
+func waitForAccounts(wantAccounts []accounts.Account, ks *KeyStore) error {
+	var list []accounts.Account
+	for d := 200 * time.Millisecond; d < 8*time.Second; d *= 2 {
+		list = ks.Accounts()
+		if reflect.DeepEqual(list, wantAccounts) {
+			// ks should have also received change notifications
+			select {
+			case <-ks.changes:
+			default:
+				return fmt.Errorf("wasn't notified of new accounts")
+			}
+			return nil
+		}
+		time.Sleep(d)
+	}
+	return fmt.Errorf("\ngot  %v\nwant %v", list, wantAccounts)
+}
+
 // TestUpdatedKeyfileContents tests that updating the contents of a keystore file
 // is noticed by the watcher, and the account cache is updated accordingly
-// func TestUpdatedKeyfileContents(t *testing.T) {
-// 	t.Parallel()
-//
-// 	// Create a temporary kesytore to test with
-// 	rand.Seed(time.Now().UnixNano())
-// 	dir := filepath.Join(os.TempDir(), fmt.Sprintf("eth-keystore-watch-test-%d-%d", os.Getpid(), rand.Int()))
-// 	ks := NewKeyStore(dir, LightScryptN, LightScryptP)
-//
-// 	list := ks.Accounts()
-// 	if len(list) > 0 {
-// 		t.Error("initial account list not empty:", list)
-// 	}
-// 	time.Sleep(100 * time.Millisecond)
-//
-// 	// Create the directory and copy a key file into it.
-// 	os.MkdirAll(dir, 0700)
-// 	defer os.RemoveAll(dir)
-// 	file := filepath.Join(dir, "aaa")
-//
-// 	// Place one of our testfiles in there
-// 	if err := cp.CopyFile(file, cachetestAccounts[0].URL.Path); err != nil {
-// 		t.Fatal(err)
-// 	}
-//
-// 	// ks should see the account.
-// 	wantAccounts := []accounts.Account{cachetestAccounts[0]}
-// 	wantAccounts[0].URL = accounts.URL{Scheme: KeyStoreScheme, Path: file}
-// 	if err := waitForAccounts(wantAccounts, ks); err != nil {
-// 		t.Error(err)
-// 		return
-// 	}
-//
-// 	// needed so that modTime of `file` is different to its current value after forceCopyFile
-// 	time.Sleep(1000 * time.Millisecond)
-//
-// 	// Now replace file contents
-// 	if err := forceCopyFile(file, cachetestAccounts[1].URL.Path); err != nil {
-// 		t.Fatal(err)
-// 		return
-// 	}
-// 	wantAccounts = []accounts.Account{cachetestAccounts[1]}
-// 	wantAccounts[0].URL = accounts.URL{Scheme: KeyStoreScheme, Path: file}
-// 	if err := waitForAccounts(wantAccounts, ks); err != nil {
-// 		t.Errorf("First replacement failed")
-// 		t.Error(err)
-// 		return
-// 	}
-//
-// 	// needed so that modTime of `file` is different to its current value after forceCopyFile
-// 	time.Sleep(1000 * time.Millisecond)
-//
-// 	// Now replace file contents again
-// 	if err := forceCopyFile(file, cachetestAccounts[2].URL.Path); err != nil {
-// 		t.Fatal(err)
-// 		return
-// 	}
-// 	wantAccounts = []accounts.Account{cachetestAccounts[2]}
-// 	wantAccounts[0].URL = accounts.URL{Scheme: KeyStoreScheme, Path: file}
-// 	if err := waitForAccounts(wantAccounts, ks); err != nil {
-// 		t.Errorf("Second replacement failed")
-// 		t.Error(err)
-// 		return
-// 	}
-//
-// 	// needed so that modTime of `file` is different to its current value after ioutil.WriteFile
-// 	time.Sleep(1000 * time.Millisecond)
-//
-// 	// Now replace file contents with crap
-// 	if err := ioutil.WriteFile(file, []byte("foo"), 0644); err != nil {
-// 		t.Fatal(err)
-// 		return
-// 	}
-// 	if err := waitForAccounts([]accounts.Account{}, ks); err != nil {
-// 		t.Errorf("Emptying account file failed")
-// 		t.Error(err)
-// 		return
-// 	}
-// }
-//
-// // forceCopyFile is like cp.CopyFile, but doesn't complain if the destination exists.
-// func forceCopyFile(dst, src string) error {
-// 	data, err := ioutil.ReadFile(src)
-// 	if err != nil {
-// 		return err
-// 	}
-// 	return ioutil.WriteFile(dst, data, 0644)
-// }
+func TestUpdatedKeyfileContents(t *testing.T) {
+	t.Skip("FLAKY")
+	t.Parallel()
+
+	// Create a temporary kesytore to test with
+	rand.Seed(time.Now().UnixNano())
+	dir := filepath.Join(os.TempDir(), fmt.Sprintf("eth-keystore-watch-test-%d-%d", os.Getpid(), rand.Int()))
+	ks := NewKeyStore(dir, LightScryptN, LightScryptP)
+
+	list := ks.Accounts()
+	if len(list) > 0 {
+		t.Error("initial account list not empty:", list)
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	// Create the directory and copy a key file into it.
+	os.MkdirAll(dir, 0700)
+	defer os.RemoveAll(dir)
+	file := filepath.Join(dir, "aaa")
+
+	// Place one of our testfiles in there
+	if err := cp.CopyFile(file, cachetestAccounts[0].URL.Path); err != nil {
+		t.Fatal(err)
+	}
+
+	// ks should see the account.
+	wantAccounts := []accounts.Account{cachetestAccounts[0]}
+	wantAccounts[0].URL = accounts.URL{Scheme: KeyStoreScheme, Path: file}
+	if err := waitForAccounts(wantAccounts, ks); err != nil {
+		t.Error(err)
+		return
+	}
+
+	// needed so that modTime of `file` is different to its current value after forceCopyFile
+	time.Sleep(1000 * time.Millisecond)
+
+	// Now replace file contents
+	if err := forceCopyFile(file, cachetestAccounts[1].URL.Path); err != nil {
+		t.Fatal(err)
+		return
+	}
+	wantAccounts = []accounts.Account{cachetestAccounts[1]}
+	wantAccounts[0].URL = accounts.URL{Scheme: KeyStoreScheme, Path: file}
+	if err := waitForAccounts(wantAccounts, ks); err != nil {
+		t.Errorf("First replacement failed")
+		t.Error(err)
+		return
+	}
+
+	// needed so that modTime of `file` is different to its current value after forceCopyFile
+	time.Sleep(1000 * time.Millisecond)
+
+	// Now replace file contents again
+	if err := forceCopyFile(file, cachetestAccounts[2].URL.Path); err != nil {
+		t.Fatal(err)
+		return
+	}
+	wantAccounts = []accounts.Account{cachetestAccounts[2]}
+	wantAccounts[0].URL = accounts.URL{Scheme: KeyStoreScheme, Path: file}
+	if err := waitForAccounts(wantAccounts, ks); err != nil {
+		t.Errorf("Second replacement failed")
+		t.Error(err)
+		return
+	}
+
+	// needed so that modTime of `file` is different to its current value after ioutil.WriteFile
+	time.Sleep(1000 * time.Millisecond)
+
+	// Now replace file contents with crap
+	if err := ioutil.WriteFile(file, []byte("foo"), 0644); err != nil {
+		t.Fatal(err)
+		return
+	}
+	if err := waitForAccounts([]accounts.Account{}, ks); err != nil {
+		t.Errorf("Emptying account file failed")
+		t.Error(err)
+		return
+	}
+}
+
+// forceCopyFile is like cp.CopyFile, but doesn't complain if the destination exists.
+func forceCopyFile(dst, src string) error {
+	data, err := ioutil.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(dst, data, 0644)
+}

--- a/plugin/evm/tx_gossiping_test.go
+++ b/plugin/evm/tx_gossiping_test.go
@@ -77,6 +77,7 @@ func getValidTxs(key *ecdsa.PrivateKey, count int, gasPrice *big.Int) []*types.T
 // to ease up UT, which target only VM behaviors in response to subnet-evm mempool
 // signals
 func TestMempoolTxsAddedTxsGossipedAfterActivation(t *testing.T) {
+	t.Skip("FLAKY")
 	assert := assert.New(t)
 
 	key, err := crypto.GenerateKey()
@@ -162,6 +163,7 @@ func TestMempoolTxsAddedTxsGossipedAfterActivation(t *testing.T) {
 
 // show that locally issued eth txs are chunked correctly
 func TestMempoolTxsAddedTxsGossipedAfterActivationChunking(t *testing.T) {
+	t.Skip("FLAKY")
 	assert := assert.New(t)
 
 	key, err := crypto.GenerateKey()
@@ -221,6 +223,7 @@ func TestMempoolTxsAddedTxsGossipedAfterActivationChunking(t *testing.T) {
 // show that a geth tx discovered from gossip is requested to the same node that
 // gossiped it
 func TestMempoolTxsAppGossipHandling(t *testing.T) {
+	t.Skip("FLAKY")
 	assert := assert.New(t)
 
 	key, err := crypto.GenerateKey()

--- a/rpc/websocket_test.go
+++ b/rpc/websocket_test.go
@@ -205,6 +205,7 @@ func TestClientWebsocketLargeMessage(t *testing.T) {
 }
 
 func TestClientWebsocketSevered(t *testing.T) {
+	t.Skip("FLAKY")
 	var (
 		server = wsPingTestServer(t, nil)
 		ctx    = context.Background()

--- a/scripts/build_test.sh
+++ b/scripts/build_test.sh
@@ -6,4 +6,6 @@ set -o pipefail
 
 export GOGC=25
 
-go test -v -failfast -race -timeout="25m" -coverprofile="coverage.out" -covermode="atomic" ./...
+# We pass in the arguments to this script directly to enable easily passing parameters such as enabling race detection,
+# parallelism, and test coverage.
+go test -coverprofile=coverage.out -covermode=atomic -timeout="30m" ./... $@

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [ ! -f "coverage.out" ]; then
+  echo "no coverage file"
+  exit 0
+fi
+
+totalCoverage=`go tool cover -func=coverage.out | grep total | grep -Eo '[0-9]+\.[0-9]+'`
+echo "Current test coverage : $totalCoverage %"
+echo "========================================"
+
+go tool cover -func=coverage.out
+


### PR DESCRIPTION
This PR marks a few identified flaky tests as flaky so we can skip over them until we can fix them.

Additionally, this adds a coverage.sh script from coreth and modifies the build_test.sh script to take in arbitrary arguments. This is a change from coreth that's used to pass in different arguments when running on different OSs so that we do not need to run with race detection enabled on multiple GH Actions and to optimize the runtime.