### PR TITLE
Add uint256 role blurb on allow list to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,10 @@ If you attempt to deploy a contract but you are not an `Admin` not
 a `Deployer`, you will see something like:
 ![deploy fail](./imgs/deploy_fail.png)
 
+The allow list has three roles: `None`, `Deployer`, and `Admin`.
+
+If you call `readAllowList(addr)` then you can read the current role of `addr`, which will return a uint256 with a value of 0, 1, or 2, corresponding to the roles `None`, `Deployer`, and `Admin` respectively.
+
 
 ## Run Local Network
 [`scripts/run.sh`](scripts/run.sh) automatically installs [avalanchego], sets up a local network,

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ The allow list has three roles: `None`, `Deployer`, and `Admin`.
 
 If you call `readAllowList(addr)` then you can read the current role of `addr`, which will return a uint256 with a value of 0, 1, or 2, corresponding to the roles `None`, `Deployer`, and `Admin` respectively.
 
-WARNING: if you remove all of the admins from the allow list, it will no longer be possible to update the allow list without modifying modifying the subnet-evm to schedule a network upgrade.
+WARNING: if you remove all of the admins from the allow list, it will no longer be possible to update the allow list without modifying the subnet-evm to schedule a network upgrade.
 
 
 ## Run Local Network

--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ The allow list has three roles: `None`, `Deployer`, and `Admin`.
 
 If you call `readAllowList(addr)` then you can read the current role of `addr`, which will return a uint256 with a value of 0, 1, or 2, corresponding to the roles `None`, `Deployer`, and `Admin` respectively.
 
+WARNING: if you remove all of the admins from the allow list, it will no longer be possible to update the allow list without modifying modifying the subnet-evm to schedule a network upgrade.
+
 
 ## Run Local Network
 [`scripts/run.sh`](scripts/run.sh) automatically installs [avalanchego], sets up a local network,


### PR DESCRIPTION
This PR adds a blurb to the README which states what uint256 values correspond to the possible allow list roles.