### PR TITLE
refactor(Dockerfile):  Set default values. Remove unused argument

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,19 @@
 
 # ============= Setting up base Stage ================
 # Set required AVALANCHE_VERSION parameter in build image script
-ARG AVALANCHE_VERSION
+ARG AVALANCHE_VERSION=v1.7.6
+
+# VMID generated (https://github.com/ava-labs/subnet-cli#subnet-cli-create-vmid) 
+ARG VMID=srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy
 
 # ============= Compilation Stage ================
 FROM golang:1.17.4-buster AS builder
+
+# Declare ARGs in order to inherit global values above
+# Pass in SUBNET_EVM_COMMIT as an arg to allow the build script to set this externally. If ommited the latest commit ID will be used
+ARG SUBNET_EVM_COMMIT
+ARG VMID
+
 RUN apt-get update && apt-get install -y --no-install-recommends bash=5.0-4 git=1:2.20.1-2+deb10u3 make=4.2.1-1.2 gcc=4:8.3.0-1 musl-dev=1.1.21-2 ca-certificates=20200601~deb10u2 linux-headers-amd64
 
 WORKDIR /build
@@ -20,14 +29,13 @@ RUN go mod download
 # Copy the code into the container
 COPY . .
 
-# Pass in SUBNET_EVM_COMMIT as an arg to allow the build script to set this externally
-ARG SUBNET_EVM_COMMIT
-ARG CURRENT_BRANCH
-
-RUN export SUBNET_EVM_COMMIT=$SUBNET_EVM_COMMIT && export CURRENT_BRANCH=$CURRENT_BRANCH && ./scripts/build.sh /build/srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy
+RUN export SUBNET_EVM_COMMIT=$SUBNET_EVM_COMMIT && ./scripts/build.sh /build/$VMID
 
 # ============= Cleanup Stage ================
 FROM avaplatform/avalanchego:$AVALANCHE_VERSION AS builtImage
 
+# Declare ARGs in order to inherit global values above
+ARG VMID
+
 # Copy the evm binary into the correct location in the container
-COPY --from=builder /build/srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy /avalanchego/build/plugins/srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy
+COPY --from=builder /build/$VMID /avalanchego/build/plugins/$VMID

--- a/scripts/build_image.sh
+++ b/scripts/build_image.sh
@@ -17,4 +17,3 @@ echo "Building Docker Image: $dockerhub_repo:$build_image_id based of $avalanche
 docker build -t "$dockerhub_repo:$build_image_id" "$SUBNET_EVM_PATH" -f "$SUBNET_EVM_PATH/Dockerfile" \
   --build-arg AVALANCHE_VERSION="$avalanche_version" \
   --build-arg SUBNET_EVM_COMMIT="$subnet_evm_commit" \
-  --build-arg CURRENT_BRANCH="$current_branch"

--- a/scripts/constants.sh
+++ b/scripts/constants.sh
@@ -6,9 +6,6 @@ GOPATH="$(go env GOPATH)"
 # Avalabs docker hub
 dockerhub_repo="avaplatform/avalanchego"
 
-# Current branch
-current_branch=${CURRENT_BRANCH:-$(git describe --tags --exact-match 2> /dev/null || git symbolic-ref -q --short HEAD || git rev-parse --short HEAD)}
-echo "Using branch: ${current_branch}"
 
 # Image build id
 # Use an abbreviated version of the full commit to tag the image.


### PR DESCRIPTION
1. Setting some arg defaults. We need this to simplify the requirements for clients and avoid introduction of extra config files.
2. I could not find in the repo where `CURRENT_BRANCH` argument is used, therefore removing it.
