### PR TITLE
Set precompile code

### DIFF
--- a/precompile/contract.go
+++ b/precompile/contract.go
@@ -26,6 +26,8 @@ type StateDB interface {
 	GetState(common.Address, common.Hash) common.Hash
 	SetState(common.Address, common.Hash, common.Hash)
 
+	SetCode(common.Address, []byte)
+
 	SetNonce(common.Address, uint64)
 	GetNonce(common.Address) uint64
 

--- a/precompile/stateful_precompile_config.go
+++ b/precompile/stateful_precompile_config.go
@@ -52,7 +52,7 @@ func CheckConfigure(parentTimestamp *big.Int, currentTimestamp *big.Int, config 
 		// Set the code of the precompile's address to a non-zero length byte slice to ensure that the precompile
 		// can be called from within Solidity contracts. Solidity adds a check before invoking a contract to ensure
 		// that it does not attempt to invoke a non-existent contract.
-		state.SetCode(config.Address(), []byte{0x01})
+		state.SetCode(config.Address(), []byte{0x1})
 		config.Configure(state)
 	}
 }

--- a/precompile/stateful_precompile_config.go
+++ b/precompile/stateful_precompile_config.go
@@ -49,6 +49,10 @@ func CheckConfigure(parentTimestamp *big.Int, currentTimestamp *big.Int, config 
 		// Set the nonce of the precompile's address (as is done when a contract is created) to ensure
 		// that it is marked as non-empty and will not be cleaned up when the statedb is finalized.
 		state.SetNonce(config.Address(), 1)
+		// Set the code of the precompile's address to a non-zero length byte slice to ensure that the precompile
+		// can be called from within Solidity contracts. Solidity adds a check before invoking a contract to ensure
+		// that it does not attempt to invoke a non-existent contract.
+		state.SetCode(config.Address(), []byte{0x00})
 		config.Configure(state)
 	}
 }

--- a/precompile/stateful_precompile_config.go
+++ b/precompile/stateful_precompile_config.go
@@ -52,7 +52,7 @@ func CheckConfigure(parentTimestamp *big.Int, currentTimestamp *big.Int, config 
 		// Set the code of the precompile's address to a non-zero length byte slice to ensure that the precompile
 		// can be called from within Solidity contracts. Solidity adds a check before invoking a contract to ensure
 		// that it does not attempt to invoke a non-existent contract.
-		state.SetCode(config.Address(), []byte{0x00})
+		state.SetCode(config.Address(), []byte{0x01})
 		config.Configure(state)
 	}
 }


### PR DESCRIPTION
This PR sets the code of stateful precompiles when they are configured to 0x00. This ensures that the precompile will pass the check to ensure that there is a non-zero length contract at the called address when Solidity makes a call to another contract.