### PR TITLE
Go min v1.17.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 ARG AVALANCHE_VERSION
 
 # ============= Compilation Stage ================
-FROM golang:1.17.4-buster AS builder
+FROM golang:1.17.9-buster AS builder
 RUN apt-get update && apt-get install -y --no-install-recommends bash=5.0-4 git=1:2.20.1-2+deb10u3 make=4.2.1-1.2 gcc=4:8.3.0-1 musl-dev=1.1.21-2 ca-certificates=20200601~deb10u2 linux-headers-amd64
 
 WORKDIR /build

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,6 +4,29 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+go_version_minimum="1.17.9"
+
+go_version() {
+    go version | sed -nE -e 's/[^0-9.]+([0-9.]+).+/\1/p'
+}
+
+version_lt() {
+    # Return true if $1 is a lower version than than $2,
+    local ver1=$1
+    local ver2=$2
+    # Reverse sort the versions, if the 1st item != ver1 then ver1 < ver2
+    if  [[ $(echo -e -n "$ver1\n$ver2\n" | sort -rV | head -n1) != "$ver1" ]]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+if version_lt "$(go_version)" "$go_version_minimum"; then
+    echo "AvalancheGo requires Go >= $go_version_minimum, Go $(go_version) found." >&2
+    exit 1
+fi
+
 # Avalanche root directory
 SUBNET_EVM_PATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -23,7 +23,7 @@ version_lt() {
 }
 
 if version_lt "$(go_version)" "$go_version_minimum"; then
-    echo "AvalancheGo requires Go >= $go_version_minimum, Go $(go_version) found." >&2
+    echo "SubnetEVM requires Go >= $go_version_minimum, Go $(go_version) found." >&2
     exit 1
 fi
 


### PR DESCRIPTION
This PR bumps the minimum go version in the build script and Dockerfile v1.17.9. These do not exist yet, so this is in anticipation of v1.17.9 being released today.