### PR TITLE
Using a placeholder if we're not able to find Git commit info in build script

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -45,11 +45,6 @@ else
     exit 1
 fi
 
-# Check if SUBNET_EVM_COMMIT is set, if not retrieve the last commit from the repo.
-# This is used in the Dockerfile to allow a commit hash to be passed in without
-# including the .git/ directory within the Docker image.
-subnet_evm_commit=${SUBNET_EVM_COMMIT:-$( git rev-list -1 HEAD )}
-
 # Build Subnet EVM, which is run as a subprocess
-echo "Building Subnet EVM Version: $subnet_evm_version; GitCommit: $subnet_evm_commit at $binary_path"
+echo "Building Subnet EVM Version: $subnet_evm_version at $binary_path"
 go build -ldflags "-X github.com/ava-labs/subnet-evm/plugin/evm.GitCommit=$subnet_evm_commit -X github.com/ava-labs/subnet-evm/plugin/evm.Version=$subnet_evm_version $static_ld_flags" -o "$binary_path" "plugin/"*.go

--- a/scripts/constants.sh
+++ b/scripts/constants.sh
@@ -6,16 +6,25 @@ GOPATH="$(go env GOPATH)"
 # Avalabs docker hub
 dockerhub_repo="avaplatform/avalanchego"
 
-# Current branch
-current_branch=${CURRENT_BRANCH:-$(git describe --tags --exact-match 2> /dev/null || git symbolic-ref -q --short HEAD || git rev-parse --short HEAD)}
+# if this isn't a git repository (say building from a release), don't set our git constants.
+if [ ! -d .git ]
+then
+    current_branch=""
+    subnet_evm_commit=""
+    subnet_evm_commit_id=""
+else
+    # Current branch
+    current_branch=${CURRENT_BRANCH:-$(git describe --tags --exact-match 2> /dev/null || git symbolic-ref -q --short HEAD || git rev-parse --short HEAD || :)}
+
+    # Image build id
+    #
+    # Use an abbreviated version of the full commit to tag the image.
+    # WARNING: this will use the most recent commit even if there are un-committed changes present
+    subnet_evm_commit="$(git --git-dir="$SUBNET_EVM_PATH/.git" rev-parse HEAD || :)"
+    subnet_evm_commit_id="${subnet_evm_commit::8}"
+fi
+
 echo "Using branch: ${current_branch}"
-
-# Image build id
-# Use an abbreviated version of the full commit to tag the image.
-
-# WARNING: this will use the most recent commit even if there are un-committed changes present
-subnet_evm_commit="$(git --git-dir="$SUBNET_EVM_PATH/.git" rev-parse HEAD)"
-subnet_evm_commit_id="${subnet_evm_commit::8}"
 
 build_image_id=${BUILD_IMAGE_ID:-"$avalanche_version-$subnet_evm_commit_id"}
 


### PR DESCRIPTION
Testing:

Current branch head: 
```
➜  subnet-evm git:(remove-git-build-script) ./scripts/build.sh
Using branch: remove-git-build-script
Building Subnet EVM Version: v0.2.5; GitCommit: 84508375452a3330ce1e7754e07a2c036125d868 at /Users/joshua.kim/go/src/github.com/ava-labs/avalanchego/build/plugins/srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy
```

Then setup a dummy repository with not git info like so: `cp -r subnet-evm /tmp && cd /tmp/subnet-evm`

Output:
```
➜  subnet-evm ./scripts/build.sh
Using branch: unknown
Building Subnet EVM Version: v0.2.5; GitCommit: unknown at /Users/joshua.kim/go/src/github.com/ava-labs/avalanchego/build/plugins/srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy
```

