### PR TITLE
[AV-1895] remove useless check for nil clusterInfo

### DIFF
--- a/tests/e2e/runner/runner.go
+++ b/tests/e2e/runner/runner.go
@@ -95,10 +95,6 @@ done:
 			return "", "", err
 		}
 
-		if resp.ClusterInfo == nil {
-			continue
-		}
-
 		if !resp.ClusterInfo.Healthy {
 			continue
 		}


### PR DESCRIPTION
Part of E2E code that calls ANR Health() function. If the error is nil, then the field ClusterInfo of the return value, will not be nil.