### PR TITLE
Start v0.2.9 release cycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The Subnet EVM runs in a separate process from the main AvalancheGo process and 
 [v0.2.5] AvalancheGo@v1.7.13-v1.7.16
 [v0.2.6] AvalancheGo@v1.7.13-v1.7.16
 [v0.2.7] AvalancheGo@v1.7.13-v1.7.16
+[v0.2.8] AvalancheGo@v1.7.13-v1.7.16
 ```
 
 ## API

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Set up the versions to be used
-subnet_evm_version=${SUBNET_EVM_VERSION:-'v0.2.7'}
+subnet_evm_version=${SUBNET_EVM_VERSION:-'v0.2.9'}
 # Don't export them as they're used in the context of other calls
 avalanche_version=${AVALANCHE_VERSION:-'v1.7.16'}
 network_runner_version=${NETWORK_RUNNER_VERSION:-'v1.1.4'}


### PR DESCRIPTION
This PR starts the release cycle for v0.2.9.

- Bumps scripts/versions.sh version to v0.2.9
- Updates AvalancheGo compatibility in README (is there a better way to do this?)