### PR TITLE
Bump go version to 1.18

### DIFF
--- a/.github/workflows/lint-tests-release.yml
+++ b/.github/workflows/lint-tests-release.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go: ["1.17"]
+        go: ["1.18"]
         os: [ubuntu-20.04]
     steps:
       - uses: actions/checkout@v2
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 8
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
@@ -76,7 +76,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.github/workflows/lint-tests-release.yml
+++ b/.github/workflows/lint-tests-release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: latest
+          version: v1.47
           working-directory: .
           args: --timeout 3m
 

--- a/.github/workflows/lint-tests-release.yml
+++ b/.github/workflows/lint-tests-release.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 8
+          go-version: 1.18
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/lint-tests-release.yml
+++ b/.github/workflows/lint-tests-release.yml
@@ -13,7 +13,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
@@ -29,8 +29,8 @@ jobs:
         go: ["1.18"]
         os: [ubuntu-20.04]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
       - run: go mod download
@@ -70,11 +70,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18
       - name: Run GoReleaser

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 ARG AVALANCHE_VERSION
 
 # ============= Compilation Stage ================
-FROM golang:1.17.9-buster AS builder
+FROM golang:1.18.5-buster AS builder
 RUN apt-get update && apt-get install -y --no-install-recommends bash=5.0-4 git=1:2.20.1-2+deb10u3 make=4.2.1-1.2 gcc=4:8.3.0-1 musl-dev=1.1.21-2 ca-certificates=20200601~deb10u2 linux-headers-amd64
 
 WORKDIR /build
@@ -15,7 +15,7 @@ WORKDIR /build
 COPY go.mod go.sum avalanchego* ./
 
 # Download avalanche dependencies using go mod
-RUN go mod download && go mod tidy -compat=1.17
+RUN go mod download && go mod tidy -compat=1.18
 
 # Copy the code into the container
 COPY . .

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ To support these changes, there have been a number of changes to the SubnetEVM b
 
 ### Clone Subnet-evm
 
-First install Go 1.17.9 or later, however as the time of writing, please don't use Go v1.18.x versions. Follow the instructions [here](https://golang.org/doc/install). You can verify by runing `go version`.
+First install Go 1.18.1 or later. Follow the instructions [here](https://golang.org/doc/install). You can verify by runing `go version`.
 
 Set `$GOPATH` environment variable properly for Go to look for Go Workspaces. Please read [this](https://go.dev/doc/gopath_code) for details. You can verify by running `echo $GOPATH`.
 

--- a/accounts/abi/bind/bind_test.go
+++ b/accounts/abi/bind/bind_test.go
@@ -2063,7 +2063,7 @@ func golangBindings(t *testing.T, overload bool) {
 	if out, err := replacer.CombinedOutput(); err != nil {
 		t.Fatalf("failed to replace binding test dependency to current source tree: %v\n%s", err, out)
 	}
-	tidier := exec.Command(gocmd, "mod", "tidy", "-compat=1.17")
+	tidier := exec.Command(gocmd, "mod", "tidy", "-compat=1.18")
 	tidier.Dir = pkg
 	if out, err := tidier.CombinedOutput(); err != nil {
 		t.Fatalf("failed to tidy Go module file: %v\n%s", err, out)

--- a/cmd/simulator/go.mod
+++ b/cmd/simulator/go.mod
@@ -1,6 +1,6 @@
 module github.com/ava-labs/subnet-evm/cmd/simulator
 
-go 1.17
+go 1.18
 
 require (
 	github.com/ava-labs/subnet-evm v0.2.6

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ava-labs/subnet-evm
 
-go 1.17
+go 1.18
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.10.0

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,7 +4,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-go_version_minimum="1.17.9"
+go_version_minimum="1.18.1"
 
 go_version() {
     go version | sed -nE -e 's/[^0-9.]+([0-9.]+).+/\1/p'

--- a/scripts/parser/go.mod
+++ b/scripts/parser/go.mod
@@ -1,6 +1,6 @@
 module github.com/ava-labs/subnet-evm/scripts/parser
 
-go 1.17
+go 1.18
 
 require (
 	github.com/fatih/color v1.13.0


### PR DESCRIPTION
This PR bumps the minimum golang version for building subnet-evm to v1.18.1.