### PR TITLE
fix nil assert state functions panic in test

### DIFF
--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -216,7 +216,10 @@ func TestStatefulPrecompilesConfigure(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			test.assertState(t, statedb)
+
+			if test.assertState != nil {
+				test.assertState(t, statedb)
+			}
 		})
 	}
 }

--- a/core/stateful_precompile_test.go
+++ b/core/stateful_precompile_test.go
@@ -286,7 +286,9 @@ func TestContractDeployerAllowListRun(t *testing.T) {
 			assert.Equal(t, uint64(0), remainingGas)
 			assert.Equal(t, test.expectedRes, ret)
 
-			test.assertState(t, state)
+			if test.assertState != nil {
+				test.assertState(t, state)
+			}
 		})
 	}
 }
@@ -519,7 +521,9 @@ func TestTxAllowListRun(t *testing.T) {
 			assert.Equal(t, uint64(0), remainingGas)
 			assert.Equal(t, test.expectedRes, ret)
 
-			test.assertState(t, state)
+			if test.assertState != nil {
+				test.assertState(t, state)
+			}
 		})
 	}
 }
@@ -769,7 +773,9 @@ func TestContractNativeMinterRun(t *testing.T) {
 			assert.Equal(t, uint64(0), remainingGas)
 			assert.Equal(t, test.expectedRes, ret)
 
-			test.assertState(t, state)
+			if test.assertState != nil {
+				test.assertState(t, state)
+			}
 		})
 	}
 }
@@ -1049,7 +1055,9 @@ func TestFeeConfigManagerRun(t *testing.T) {
 			assert.Equal(t, uint64(0), remainingGas)
 			assert.Equal(t, test.expectedRes, ret)
 
-			test.assertState(t, state)
+			if test.assertState != nil {
+				test.assertState(t, state)
+			}
 		})
 	}
 }


### PR DESCRIPTION
`assertState` can throw panic if no such function is defined in tests. This PR fixes this behavior by adding a nil check