### PR TITLE
Add WAGMI upgrade json to networks dir

### DIFF
--- a/.github/workflows/json-lint.yml
+++ b/.github/workflows/json-lint.yml
@@ -1,0 +1,22 @@
+name: JSON Network Config Check
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "*"
+  pull_request:
+
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      BASE: ./networks
+    steps:
+      - uses: actions/checkout@v3
+      - name: json-syntax-check
+        uses: limitusus/json-syntax-check@v1.0.3
+        with:
+          pattern: "\\.json$"

--- a/networks/11111/upgrade.json
+++ b/networks/11111/upgrade.json
@@ -1,0 +1,10 @@
+{
+    "precompileUpgrades": [
+        {
+            "feeManagerConfig": {
+                "adminAddresses": ["0x6f0f6DA1852857d7789f68a28bba866671f3880D"],
+                "blockTimestamp": 1660658400
+            }
+        }
+    ]
+}


### PR DESCRIPTION
This PR adds the upgrade bytes used for WAGMI into the networks directory. The upgrade bytes are given here:

```json
{
    "precompileUpgrades": [
        {
            "feeManagerConfig": {
                "adminAddresses": ["0x6f0f6DA1852857d7789f68a28bba866671f3880D"],
                "blockTimestamp": "1660658400"
            }
        }
    ]
}
```

and activated today August 16, 2022 as given by the specified block timestamp.