### PR TITLE
Add comment to clarify log line won't index out of bounds

### DIFF
--- a/plugin/evm/log.go
+++ b/plugin/evm/log.go
@@ -75,7 +75,7 @@ func SubnetEVMJSONFormat(alias string) log.Format {
 			if !ok {
 				props[errorKey] = fmt.Sprintf("%+v is not a string key", r.Ctx[i])
 			} else {
-				props[k] = formatJSONValue(r.Ctx[i+1]) // The number of arguments is normalized prior to this to prevent index out of bounds
+				props[k] = formatJSONValue(r.Ctx[i+1]) // The number of arguments is normalized from the geth logger to prevent an index out of bounds here
 			}
 		}
 

--- a/plugin/evm/log.go
+++ b/plugin/evm/log.go
@@ -75,8 +75,8 @@ func SubnetEVMJSONFormat(alias string) log.Format {
 			if !ok {
 				props[errorKey] = fmt.Sprintf("%+v is not a string key", r.Ctx[i])
 			} else {
-                                // The number of arguments is normalized from the geth logger 
-                                // to ensure that this will not cause an index out of bounds error
+				// The number of arguments is normalized from the geth logger
+				// to ensure that this will not cause an index out of bounds error
 				props[k] = formatJSONValue(r.Ctx[i+1])
 			}
 		}

--- a/plugin/evm/log.go
+++ b/plugin/evm/log.go
@@ -75,7 +75,9 @@ func SubnetEVMJSONFormat(alias string) log.Format {
 			if !ok {
 				props[errorKey] = fmt.Sprintf("%+v is not a string key", r.Ctx[i])
 			} else {
-				props[k] = formatJSONValue(r.Ctx[i+1]) // The number of arguments is normalized from the geth logger to prevent an index out of bounds here
+                                // The number of arguments is normalized from the geth logger 
+                                // to ensure that this will not cause an index out of bounds error
+				props[k] = formatJSONValue(r.Ctx[i+1])
 			}
 		}
 

--- a/plugin/evm/log.go
+++ b/plugin/evm/log.go
@@ -75,7 +75,7 @@ func SubnetEVMJSONFormat(alias string) log.Format {
 			if !ok {
 				props[errorKey] = fmt.Sprintf("%+v is not a string key", r.Ctx[i])
 			} else {
-				props[k] = formatJSONValue(r.Ctx[i+1])
+				props[k] = formatJSONValue(r.Ctx[i+1]) // The number of arguments is normalized prior to this to prevent index out of bounds
 			}
 		}
 


### PR DESCRIPTION
This PR adds a small comment to state that a suspicious line will not cause an index out of bounds because the arguments will be normalized in advance.