### PR TITLE
Add get chain config api

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -623,7 +623,7 @@ func (s *PublicBlockChainAPI) GetChainConfig(ctx context.Context) GetChainConfig
 	return resp
 }
 
-func (s *PublicBlockChainAPI) GetActivePrecompileUpgradesAt(ctx context.Context, blockTimestamp *big.Int) params.PrecompileUpgrade {
+func (s *PublicBlockChainAPI) GetActivePrecompilesAt(ctx context.Context, blockTimestamp *big.Int) params.PrecompileUpgrade {
 	if blockTimestamp == nil {
 		blockTimestampInt := s.b.CurrentHeader().Time
 		blockTimestamp = new(big.Int).SetUint64(blockTimestampInt)

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -628,7 +628,7 @@ func (s *PublicBlockChainAPI) GetActivePrecompilesAt(ctx context.Context, blockT
 		blockTimestampInt := s.b.CurrentHeader().Time
 		blockTimestamp = new(big.Int).SetUint64(blockTimestampInt)
 	}
-	return s.b.ChainConfig().GetActivePrecompileUpgrades(blockTimestamp)
+	return s.b.ChainConfig().GetActivePrecompiles(blockTimestamp)
 }
 
 type FeeConfigResult struct {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -609,6 +609,18 @@ func (s *PublicBlockChainAPI) ChainId() (*hexutil.Big, error) {
 	return nil, fmt.Errorf("chain not synced beyond EIP-155 replay-protection fork block")
 }
 
+func (s *PublicBlockChainAPI) GetUpgrades(ctx context.Context) *params.UpgradeConfig {
+	return &s.b.ChainConfig().UpgradeConfig
+}
+
+func (s *PublicBlockChainAPI) GetActivatedPrecompiles(ctx context.Context, blockTimestamp *big.Int) params.PrecompileUpgrade {
+	if blockTimestamp == nil {
+		blockTimestampInt := s.b.CurrentHeader().Time
+		blockTimestamp = new(big.Int).SetUint64(blockTimestampInt)
+	}
+	return s.b.ChainConfig().GetActivePrecompileUpgrades(blockTimestamp)
+}
+
 type FeeConfigResult struct {
 	FeeConfig     commontype.FeeConfig `json:"feeConfig"`
 	LastChangedAt *big.Int             `json:"lastChangedAt,omitempty"`

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -609,8 +609,18 @@ func (s *PublicBlockChainAPI) ChainId() (*hexutil.Big, error) {
 	return nil, fmt.Errorf("chain not synced beyond EIP-155 replay-protection fork block")
 }
 
-func (s *PublicBlockChainAPI) GetUpgrades(ctx context.Context) *params.UpgradeConfig {
-	return &s.b.ChainConfig().UpgradeConfig
+type GetChainConfigResponse struct {
+	*params.ChainConfig
+	params.UpgradeConfig `json:"upgrades"`
+}
+
+func (s *PublicBlockChainAPI) GetChainConfig(ctx context.Context) GetChainConfigResponse {
+	config := s.b.ChainConfig()
+	resp := GetChainConfigResponse{
+		ChainConfig:   config,
+		UpgradeConfig: config.UpgradeConfig,
+	}
+	return resp
 }
 
 func (s *PublicBlockChainAPI) GetActivatedPrecompiles(ctx context.Context, blockTimestamp *big.Int) params.PrecompileUpgrade {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -623,7 +623,7 @@ func (s *PublicBlockChainAPI) GetChainConfig(ctx context.Context) GetChainConfig
 	return resp
 }
 
-func (s *PublicBlockChainAPI) GetActivatedPrecompiles(ctx context.Context, blockTimestamp *big.Int) params.PrecompileUpgrade {
+func (s *PublicBlockChainAPI) GetActivePrecompileUpgradesAt(ctx context.Context, blockTimestamp *big.Int) params.PrecompileUpgrade {
 	if blockTimestamp == nil {
 		blockTimestampInt := s.b.CurrentHeader().Time
 		blockTimestamp = new(big.Int).SetUint64(blockTimestampInt)

--- a/params/precompile_config.go
+++ b/params/precompile_config.go
@@ -209,6 +209,15 @@ func (c *ChainConfig) Get{YourPrecompile}Config(blockTimestamp *big.Int) *precom
 }
 */
 
+func (c *ChainConfig) GetActivePrecompileUpgrades(blockTimestamp *big.Int) PrecompileUpgrade {
+	return PrecompileUpgrade{
+		ContractDeployerAllowListConfig: c.GetContractDeployerAllowListConfig(blockTimestamp),
+		ContractNativeMinterConfig:      c.GetContractNativeMinterConfig(blockTimestamp),
+		TxAllowListConfig:               c.GetTxAllowListConfig(blockTimestamp),
+		FeeManagerConfig:                c.GetFeeConfigManagerConfig(blockTimestamp),
+	}
+}
+
 // CheckPrecompilesCompatible checks if [precompileUpgrades] are compatible with [c] at [headTimestamp].
 // Returns a ConfigCompatError if upgrades already forked at [headTimestamp] are missing from
 // [precompileUpgrades]. Upgrades not already forked may be modified or absent from [precompileUpgrades].

--- a/params/precompile_config.go
+++ b/params/precompile_config.go
@@ -210,12 +210,20 @@ func (c *ChainConfig) Get{YourPrecompile}Config(blockTimestamp *big.Int) *precom
 */
 
 func (c *ChainConfig) GetActivePrecompileUpgrades(blockTimestamp *big.Int) PrecompileUpgrade {
-	return PrecompileUpgrade{
-		ContractDeployerAllowListConfig: c.GetContractDeployerAllowListConfig(blockTimestamp),
-		ContractNativeMinterConfig:      c.GetContractNativeMinterConfig(blockTimestamp),
-		TxAllowListConfig:               c.GetTxAllowListConfig(blockTimestamp),
-		FeeManagerConfig:                c.GetFeeConfigManagerConfig(blockTimestamp),
+	pu := PrecompileUpgrade{}
+	if config := c.GetContractDeployerAllowListConfig(blockTimestamp); config != nil && !config.Disable {
+		pu.ContractDeployerAllowListConfig = config
 	}
+	if config := c.GetContractNativeMinterConfig(blockTimestamp); config != nil && !config.Disable {
+		pu.ContractNativeMinterConfig = config
+	}
+	if config := c.GetTxAllowListConfig(blockTimestamp); config != nil && !config.Disable {
+		pu.TxAllowListConfig = config
+	}
+	if config := c.GetFeeConfigManagerConfig(blockTimestamp); config != nil && !config.Disable {
+		pu.FeeManagerConfig = config
+	}
+	return pu
 }
 
 // CheckPrecompilesCompatible checks if [precompileUpgrades] are compatible with [c] at [headTimestamp].

--- a/params/precompile_config.go
+++ b/params/precompile_config.go
@@ -209,7 +209,7 @@ func (c *ChainConfig) Get{YourPrecompile}Config(blockTimestamp *big.Int) *precom
 }
 */
 
-func (c *ChainConfig) GetActivePrecompileUpgrades(blockTimestamp *big.Int) PrecompileUpgrade {
+func (c *ChainConfig) GetActivePrecompiles(blockTimestamp *big.Int) PrecompileUpgrade {
 	pu := PrecompileUpgrade{}
 	if config := c.GetContractDeployerAllowListConfig(blockTimestamp); config != nil && !config.Disable {
 		pu.ContractDeployerAllowListConfig = config
@@ -223,6 +223,11 @@ func (c *ChainConfig) GetActivePrecompileUpgrades(blockTimestamp *big.Int) Preco
 	if config := c.GetFeeConfigManagerConfig(blockTimestamp); config != nil && !config.Disable {
 		pu.FeeManagerConfig = config
 	}
+	// ADD YOUR PRECOMPILE HERE
+	// if config := c.{YourPrecompile}Config(blockTimestamp); config != nil && !config.Disable {
+	// 	pu.{YourPrecompile}Config = config
+	// }
+
 	return pu
 }
 


### PR DESCRIPTION
Adds 2 API requests

## eth_getChainConfig
Returns chain config with upgrades. Takes no parameters.
Reques:
```
{
    "jsonrpc": "2.0",
    "method": "eth_getChainConfig",
    "params": [],
    "id": 1
}
```
Response:
```
{
    "jsonrpc": "2.0",
    "id": 1,
    "result": {
        "chainId": 43214,
        "feeConfig": {
            "gasLimit": 8000000,
            "targetBlockRate": 2,
            "minBaseFee": 33000000000,
            "targetGas": 15000000,
            "baseFeeChangeDenominator": 36,
            "minBlockGasCost": 0,
            "maxBlockGasCost": 1000000,
            "blockGasCostStep": 200000
        },
        "allowFeeRecipients": true,
        "homesteadBlock": 0,
        "eip150Block": 0,
        "eip150Hash": "0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0",
        "eip155Block": 0,
        "eip158Block": 0,
        "byzantiumBlock": 0,
        "constantinopleBlock": 0,
        "petersburgBlock": 0,
        "istanbulBlock": 0,
        "muirGlacierBlock": 0,
        "subnetEVMTimestamp": 0,
        "contractDeployerAllowListConfig": {
            "adminAddresses": [
                "0x8db97c7cece249c2b98bdc0226cc4c2a57bf52fc"
            ],
            "blockTimestamp": 0
        },
        "contractNativeMinterConfig": {
            "adminAddresses": [
                "0x8db97c7cece249c2b98bdc0226cc4c2a57bf52fc"
            ],
            "blockTimestamp": 0
        },
        "feeManagerConfig": {
            "adminAddresses": [
                "0x8db97c7cece249c2b98bdc0226cc4c2a57bf52fc"
            ],
            "blockTimestamp": 0
        },
        "upgrades": {
            "precompileUpgrades": [
                {
                    "feeManagerConfig": {
                        "adminAddresses": null,
                        "blockTimestamp": 1661541259,
                        "disable": true
                    }
                },
                {
                    "feeManagerConfig": {
                        "adminAddresses": null,
                        "blockTimestamp": 1661541269
                    }
                }
            ]
        }
    }
}
```

## eth_getActivatedPrecompiles

Returns activated precompiles at a specific timestamp. If no timestamp is provided returns latest block timestamp.
#### Example-1 
Request with no params (current block TS)
Request :
```
{
    "jsonrpc": "2.0",
    "method": "eth_getActivatedPrecompiles",
    "params": [],
    "id": 1
}
```
Response:
```
{
    "jsonrpc": "2.0",
    "id": 1,
    "result": {
        "contractDeployerAllowListConfig": {
            "adminAddresses": [
                "0x8db97c7cece249c2b98bdc0226cc4c2a57bf52fc"
            ],
            "blockTimestamp": 0
        },
        "contractNativeMinterConfig": {
            "adminAddresses": [
                "0x8db97c7cece249c2b98bdc0226cc4c2a57bf52fc"
            ],
            "blockTimestamp": 0
        },
        "feeManagerConfig": {
            "adminAddresses": [
                "0x8db97c7cece249c2b98bdc0226cc4c2a57bf52fc"
            ],
            "blockTimestamp": 0
        }
    }
}
```

#### Example 2
Request with future TS
Request :
```
{
    "jsonrpc": "2.0",
    "method": "eth_getActivatedPrecompiles",
    "params": [1693049880],
    "id": 1
}
```
Response:
```{
    "jsonrpc": "2.0",
    "id": 1,
    "result": {
        "contractDeployerAllowListConfig": {
            "adminAddresses": [
                "0x8db97c7cece249c2b98bdc0226cc4c2a57bf52fc"
            ],
            "blockTimestamp": 0
        },
        "contractNativeMinterConfig": {
            "adminAddresses": [
                "0x8db97c7cece249c2b98bdc0226cc4c2a57bf52fc"
            ],
            "blockTimestamp": 0
        },
        "feeManagerConfig": {
            "adminAddresses": null,
            "blockTimestamp": 1661524733
        }
    }
}
```