### PR TITLE
GetBlockIDAtHeight: return database.ErrNotFound

### DIFF
--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -674,10 +674,12 @@ func (vm *VM) VerifyHeightIndex() error {
 // GetBlockIDAtHeight retrieves the blkID of the canonical block at [blkHeight]
 // if [blkHeight] is less than the height of the last accepted block, this will return
 // a canonical block. Otherwise, it may return a blkID that has not yet been accepted.
+// Note: Engine's interface requires this function returns database.ErrNotFound
+// if a block is not found.
 func (vm *VM) GetBlockIDAtHeight(blkHeight uint64) (ids.ID, error) {
 	ethBlock := vm.blockChain.GetBlockByNumber(blkHeight)
 	if ethBlock == nil {
-		return ids.ID{}, fmt.Errorf("could not find block at height: %d", blkHeight)
+		return ids.ID{}, database.ErrNotFound
 	}
 
 	return ids.ID(ethBlock.Hash()), nil


### PR DESCRIPTION
This PR updates GetBlockIDAtHeight to return the correct error expected by the engine's interface.
This was causing an issue where nodes that have state synced would not be able to parse some ancestors during bootstrapping.