### PR TITLE
precompile: add formatted errors to precompile verify

### DIFF
--- a/precompile/config_test.go
+++ b/precompile/config_test.go
@@ -84,7 +84,7 @@ func TestVerifyPrecompileUpgrades(t *testing.T) {
 					common.HexToAddress("0x01"): math.NewHexOrDecimal256(123),
 					common.HexToAddress("0x02"): nil,
 				}),
-			expectedError: ErrAmountNil.Error(),
+			expectedError: "initial mint cannot contain nil",
 		},
 		{
 			name: "negative amount in native minter config",
@@ -93,7 +93,7 @@ func TestVerifyPrecompileUpgrades(t *testing.T) {
 					common.HexToAddress("0x01"): math.NewHexOrDecimal256(123),
 					common.HexToAddress("0x02"): math.NewHexOrDecimal256(-1),
 				}),
-			expectedError: ErrAmountNonPositive.Error(),
+			expectedError: "initial mint cannot contain invalid amount",
 		},
 	}
 	for _, tt := range tests {

--- a/precompile/contract_native_minter.go
+++ b/precompile/contract_native_minter.go
@@ -28,10 +28,8 @@ var (
 	// Singleton StatefulPrecompiledContract for minting native assets by permissioned callers.
 	ContractNativeMinterPrecompile StatefulPrecompiledContract = createNativeMinterPrecompile(ContractNativeMinterAddress)
 
-	mintSignature        = CalculateFunctionSelector("mintNativeCoin(address,uint256)") // address, amount
-	ErrCannotMint        = errors.New("non-enabled cannot mint")
-	ErrAmountNil         = errors.New("initial mint amount cannot be nil")
-	ErrAmountNonPositive = errors.New("initial mint amount must be positive")
+	mintSignature = CalculateFunctionSelector("mintNativeCoin(address,uint256)") // address, amount
+	ErrCannotMint = errors.New("non-enabled cannot mint")
 )
 
 // ContractNativeMinterConfig wraps [AllowListConfig] and uses it to implement the StatefulPrecompileConfig
@@ -93,13 +91,13 @@ func (c *ContractNativeMinterConfig) Verify() error {
 		return err
 	}
 	// ensure that all of the initial mint values in the map are non-nil positive values
-	for _, amount := range c.InitialMint {
+	for addr, amount := range c.InitialMint {
 		if amount == nil {
-			return ErrAmountNil
+			return fmt.Errorf("initial mint cannot contain nil amount for address %s", addr)
 		}
 		bigIntAmount := (*big.Int)(amount)
 		if bigIntAmount.Sign() < 1 {
-			return ErrAmountNonPositive
+			return fmt.Errorf("initial mint cannot contain invalid amount %v for address %s", bigIntAmount, addr)
 		}
 	}
 	return nil

--- a/precompile/fee_config_manager.go
+++ b/precompile/fee_config_manager.go
@@ -133,10 +133,11 @@ func (c *FeeConfigManagerConfig) Verify() error {
 	if err := c.AllowListConfig.Verify(); err != nil {
 		return err
 	}
-	if c.InitialFeeConfig != nil {
-		return c.InitialFeeConfig.Verify()
+	if c.InitialFeeConfig == nil {
+		return nil
 	}
-	return nil
+
+	return c.InitialFeeConfig.Verify()
 }
 
 // GetFeeConfigManagerStatus returns the role of [address] for the fee config manager list.


### PR DESCRIPTION
This PR updates two error messages to a formatted error including the relevant address to make fixing the error easier for users.