### PR TITLE
Safe balance

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -397,11 +397,12 @@ func (s *StateDB) HasSuicided(addr common.Address) bool {
  */
 
 // AddBalance adds amount to the account associated with addr.
-func (s *StateDB) AddBalance(addr common.Address, amount *big.Int) {
+func (s *StateDB) AddBalance(addr common.Address, amount *big.Int) error {
 	stateObject := s.GetOrNewStateObject(addr)
 	if stateObject != nil {
-		stateObject.AddBalance(amount)
+		return stateObject.AddBalance(amount)
 	}
+	return nil
 }
 
 // SubBalance subtracts amount from the account associated with addr.

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -414,6 +414,7 @@ func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte
 	// This doesn't matter on Mainnet, where all empties are gone at the time of Byzantium,
 	// but is the correct thing to do and matters on other networks, in tests, and potential
 	// future scenarios
+	// This fine against overflow, since amount is zero
 	evm.StateDB.AddBalance(addr, big0)
 
 	// Invoke tracer hooks that signal entering/exiting a call frame

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -836,7 +836,9 @@ func opSelfdestruct(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext
 	}
 	beneficiary := scope.Stack.pop()
 	balance := interpreter.evm.StateDB.GetBalance(scope.Contract.Address())
-	interpreter.evm.StateDB.AddBalance(beneficiary.Bytes20(), balance)
+	if err := interpreter.evm.StateDB.AddBalance(beneficiary.Bytes20(), balance); err != nil {
+		return nil, err
+	}
 	interpreter.evm.StateDB.Suicide(scope.Contract.Address())
 	if interpreter.cfg.Debug {
 		interpreter.cfg.Tracer.CaptureEnter(SELFDESTRUCT, scope.Contract.Address(), beneficiary.Bytes20(), []byte{}, 0, balance)

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -38,7 +38,7 @@ type StateDB interface {
 	CreateAccount(common.Address)
 
 	SubBalance(common.Address, *big.Int)
-	AddBalance(common.Address, *big.Int)
+	AddBalance(common.Address, *big.Int) error
 	GetBalance(common.Address) *big.Int
 
 	GetNonce(common.Address) uint64

--- a/eth/tracers/logger/logger_test.go
+++ b/eth/tracers/logger/logger_test.go
@@ -36,11 +36,11 @@ func (dummyContractRef) SetCode(common.Hash, []byte) {}
 func (d *dummyContractRef) ForEachStorage(callback func(key, value common.Hash) bool) {
 	d.calledForEach = true
 }
-func (d *dummyContractRef) SubBalance(amount *big.Int) {}
-func (d *dummyContractRef) AddBalance(amount *big.Int) {}
-func (d *dummyContractRef) SetBalance(*big.Int)        {}
-func (d *dummyContractRef) SetNonce(uint64)            {}
-func (d *dummyContractRef) Balance() *big.Int          { return new(big.Int) }
+func (d *dummyContractRef) SubBalance(amount *big.Int)       {}
+func (d *dummyContractRef) AddBalance(amount *big.Int) error { return nil }
+func (d *dummyContractRef) SetBalance(*big.Int)              {}
+func (d *dummyContractRef) SetNonce(uint64)                  {}
+func (d *dummyContractRef) Balance() *big.Int                { return new(big.Int) }
 
 type dummyStatedb struct {
 	state.StateDB

--- a/precompile/contract.go
+++ b/precompile/contract.go
@@ -50,7 +50,7 @@ type StateDB interface {
 	GetNonce(common.Address) uint64
 
 	GetBalance(common.Address) *big.Int
-	AddBalance(common.Address, *big.Int)
+	AddBalance(common.Address, *big.Int) error
 	SubBalance(common.Address, *big.Int)
 
 	CreateAccount(common.Address)

--- a/precompile/contract_native_minter.go
+++ b/precompile/contract_native_minter.go
@@ -76,7 +76,9 @@ func (c *ContractNativeMinterConfig) Configure(_ ChainConfig, state StateDB, _ B
 	for to, amount := range c.InitialMint {
 		if amount != nil {
 			bigIntAmount := (*big.Int)(amount)
-			state.AddBalance(to, bigIntAmount)
+			if err := state.AddBalance(to, bigIntAmount); err != nil {
+				panic(fmt.Errorf("failed to mint initial balance for %s: %w", to.String(), err))
+			}
 		}
 	}
 
@@ -199,7 +201,9 @@ func mintNativeCoin(accessibleState PrecompileAccessibleState, caller common.Add
 		stateDB.CreateAccount(to)
 	}
 
-	stateDB.AddBalance(to, amount)
+	if err := stateDB.AddBalance(to, amount); err != nil {
+		return nil, remainingGas, err
+	}
 	// Return an empty output and the remaining gas
 	return []byte{}, remainingGas, nil
 }


### PR DESCRIPTION
The native contract minter can create more than uint256 amount. This PR adds an overflow check against uint256 type to `AddBalance`.  