### PR TITLE
fix goreleaser problem from v0.4.0 

### DIFF
--- a/.github/workflows/lint-tests-release.yml
+++ b/.github/workflows/lint-tests-release.yml
@@ -116,7 +116,6 @@ jobs:
           distribution: goreleaser
           version: latest
           args: release --rm-dist
-          workdir: ./subnet-evm/
         env:
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-tests-release.yml
+++ b/.github/workflows/lint-tests-release.yml
@@ -91,6 +91,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          path: subnet-evm
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
@@ -115,6 +116,7 @@ jobs:
           distribution: goreleaser
           version: latest
           args: release --rm-dist
+          workdir: ./subnet-evm/
         env:
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-tests-release.yml
+++ b/.github/workflows/lint-tests-release.yml
@@ -116,6 +116,7 @@ jobs:
           distribution: goreleaser
           version: latest
           args: release --rm-dist
+          workdir: ./subnet-evm/
         env:
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Goreleaser failing on real releases. there is a check for the git repositoty to not being dirty, and  that seems to only be checked when doing the release, not when doing snapshots. That's why it was not seen before.
The repo was dirty because osxcross was inside it. this PR sets osxcross and subnet-evm side by side.