### PR TITLE
add more osxcross dependencies

### DIFF
--- a/.github/workflows/lint-tests-release.yml
+++ b/.github/workflows/lint-tests-release.yml
@@ -105,6 +105,7 @@ jobs:
           path: osxcross
       - name: Build osxcross
         run: |
+          sudo apt-get -y install clang llvm-dev libxml2-dev uuid-dev libssl-dev bash patch make tar xz-utils bzip2 gzip sed cpio libbz2-dev
           cd osxcross
           wget https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX11.3.sdk.tar.xz -O tarballs/MacOSX11.3.sdk.tar.xz
           echo cd4f08a75577145b8f05245a2975f7c81401d75e9535dcffbb879ee1deefcbf4 tarballs/MacOSX11.3.sdk.tar.xz | sha256sum -c -


### PR DESCRIPTION
Adds dependencies required for cross-compiling MacOS build with reference to required dependencies here: https://tenbaht.github.io/sduino/developer/cross-compile-for-osx/