### PR TITLE
bump macos sdk

### DIFF
--- a/.github/workflows/lint-tests-release.yml
+++ b/.github/workflows/lint-tests-release.yml
@@ -107,10 +107,13 @@ jobs:
         run: |
           sudo apt-get -y install clang llvm-dev libxml2-dev uuid-dev libssl-dev bash patch make tar xz-utils bzip2 gzip sed cpio libbz2-dev
           cd osxcross
-          wget https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX11.3.sdk.tar.xz -O tarballs/MacOSX11.3.sdk.tar.xz
-          echo cd4f08a75577145b8f05245a2975f7c81401d75e9535dcffbb879ee1deefcbf4 tarballs/MacOSX11.3.sdk.tar.xz | sha256sum -c -
+          wget https://github.com/joseluisq/macosx-sdks/releases/download/12.3/$MACOS_SDK_FNAME -O tarballs/$MACOS_SDK_FNAME
+          echo $MACOS_SDK_CHECKSUM tarballs/$MACOS_SDK_FNAME | sha256sum -c -
           UNATTENDED=1 ./build.sh
           echo $PWD/target/bin >> $GITHUB_PATH
+        env:
+          MACOS_SDK_FNAME: MacOSX12.3.sdk.tar.xz
+          MACOS_SDK_CHECKSUM: 3abd261ceb483c44295a6623fdffe5d44fc4ac2c872526576ec5ab5ad0f6e26c
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:


### PR DESCRIPTION
osxcross started failling with 
```
In file included from ../../../../go/pkg/mod/github.com/zondax/hid@v0.9.1-0.20220302062450-5552068d2266/hid_enabled.go:38:
./hidapi/mac/hid.c:693:34: error: use of undeclared identifier 'kIOMainPortDefault'
        entry = IORegistryEntryFromPath(kIOMainPortDefault, path);
```
this is due to usage of obsolete macos SDK. This PR updates it to 12.3