### PR TITLE
Bump version to v0.4.2

### DIFF
--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Set up the versions to be used
-subnet_evm_version=${SUBNET_EVM_VERSION:-'v0.4.1'}
+subnet_evm_version=${SUBNET_EVM_VERSION:-'v0.4.2'}
 # Don't export them as they're used in the context of other calls
 avalanche_version=${AVALANCHE_VERSION:-'v1.9.1'}
 network_runner_version=${NETWORK_RUNNER_VERSION:-'bb4b661ac88ebe50ab719424eecc1a55e01e7019'}


### PR DESCRIPTION
This PR bumps the version to v0.4.2 to start the next release cycle.