### PR TITLE
Block Acceptor from Flattening during Verification

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -73,6 +73,7 @@ var (
 	blockContentValidationTimer = metrics.NewRegisteredTimer("chain/block/validations/content", nil)
 	blockStateInitTimer         = metrics.NewRegisteredTimer("chain/block/inits/state", nil)
 	blockExecutionTimer         = metrics.NewRegisteredTimer("chain/block/executions", nil)
+	blockTrieOpsTimer           = metrics.NewRegisteredTimer("chain/block/trie", nil)
 	blockStateValidationTimer   = metrics.NewRegisteredTimer("chain/block/validations/state", nil)
 	blockWriteTimer             = metrics.NewRegisteredTimer("chain/block/writes", nil)
 
@@ -1177,6 +1178,7 @@ func (bc *BlockChain) insertBlock(block *types.Block, writes bool) error {
 	trieproc := statedb.SnapshotAccountReads + statedb.AccountReads + statedb.AccountUpdates
 	trieproc += statedb.SnapshotStorageReads + statedb.StorageReads + statedb.StorageUpdates
 	blockExecutionTimer.Update(time.Since(substart) - trieproc - triehash)
+	blockTrieOpsTimer.Update(trieproc + triehash)
 
 	// Validate the state using the default validator
 	substart = time.Now()

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -71,7 +71,7 @@ var (
 
 	blockInsertTimer            = metrics.NewRegisteredTimer("chain/block/inserts", nil)
 	blockContentValidationTimer = metrics.NewRegisteredTimer("chain/block/validations/content", nil)
-	blockStateInitTimer         = metrics.NewRegisteredTimer("chain/block/state/inits", nil)
+	blockStateInitTimer         = metrics.NewRegisteredTimer("chain/block/inits/state", nil)
 	blockExecutionTimer         = metrics.NewRegisteredTimer("chain/block/executions", nil)
 	blockStateValidationTimer   = metrics.NewRegisteredTimer("chain/block/validations/state", nil)
 	blockWriteTimer             = metrics.NewRegisteredTimer("chain/block/writes", nil)

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -44,6 +44,7 @@ import (
 )
 
 var emptyCodeHash = crypto.Keccak256(nil)
+var logged = 0
 
 type Code []byte
 
@@ -240,7 +241,10 @@ func (s *stateObject) GetCommittedState(db Database, key common.Hash) common.Has
 		snapErr := err
 		enc, err = s.getTrie(db).TryGet(key.Bytes())
 		if metrics.EnabledExpensive {
-			log.Warn("reading storage from trie", "snap missing", s.db.snap == nil, "err", snapErr)
+			if logged < 1000 {
+				log.Warn("reading storage from trie", "snap missing", s.db.snap == nil, "err", snapErr)
+				logged++
+			}
 			s.db.StorageReads += time.Since(start)
 		}
 		if err != nil {

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -39,6 +39,7 @@ import (
 	"github.com/ava-labs/subnet-evm/trie"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
@@ -238,6 +239,7 @@ func (s *stateObject) GetCommittedState(db Database, key common.Hash) common.Has
 		start := time.Now()
 		enc, err = s.getTrie(db).TryGet(key.Bytes())
 		if metrics.EnabledExpensive {
+			log.Warn("reading storage from trie", "snap exists", s.db.snap == nil, "err", err)
 			s.db.StorageReads += time.Since(start)
 		}
 		if err != nil {

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -239,7 +239,7 @@ func (s *stateObject) GetCommittedState(db Database, key common.Hash) common.Has
 		start := time.Now()
 		enc, err = s.getTrie(db).TryGet(key.Bytes())
 		if metrics.EnabledExpensive {
-			log.Warn("reading storage from trie", "snap exists", s.db.snap == nil, "err", err)
+			log.Warn("reading storage from trie", "snap missing", s.db.snap == nil, "err", err)
 			s.db.StorageReads += time.Since(start)
 		}
 		if err != nil {

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -39,12 +39,10 @@ import (
 	"github.com/ava-labs/subnet-evm/trie"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
 var emptyCodeHash = crypto.Keccak256(nil)
-var logged = 0
 
 type Code []byte
 
@@ -238,13 +236,8 @@ func (s *stateObject) GetCommittedState(db Database, key common.Hash) common.Has
 	// If the snapshot is unavailable or reading from it fails, load from the database.
 	if s.db.snap == nil || err != nil {
 		start := time.Now()
-		snapErr := err
 		enc, err = s.getTrie(db).TryGet(key.Bytes())
 		if metrics.EnabledExpensive {
-			if logged < 1000 {
-				log.Warn("reading storage from trie", "snap missing", s.db.snap == nil, "err", snapErr)
-				logged++
-			}
 			s.db.StorageReads += time.Since(start)
 		}
 		if err != nil {

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -237,9 +237,10 @@ func (s *stateObject) GetCommittedState(db Database, key common.Hash) common.Has
 	// If the snapshot is unavailable or reading from it fails, load from the database.
 	if s.db.snap == nil || err != nil {
 		start := time.Now()
+		snapErr := err
 		enc, err = s.getTrie(db).TryGet(key.Bytes())
 		if metrics.EnabledExpensive {
-			log.Warn("reading storage from trie", "snap missing", s.db.snap == nil, "err", err)
+			log.Warn("reading storage from trie", "snap missing", s.db.snap == nil, "err", snapErr)
 			s.db.StorageReads += time.Since(start)
 		}
 		if err != nil {

--- a/utils/metered_cache.go
+++ b/utils/metered_cache.go
@@ -44,7 +44,7 @@ func dirSize(path string) (int64, error) {
 		if !info.IsDir() {
 			size += info.Size()
 		}
-		return err
+		return nil
 	})
 	return size, err
 }

--- a/utils/metered_cache.go
+++ b/utils/metered_cache.go
@@ -5,11 +5,15 @@ package utils
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"sync/atomic"
 	"time"
 
 	"github.com/VictoriaMetrics/fastcache"
 	"github.com/ava-labs/subnet-evm/metrics"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 // MeteredCache wraps *fastcache.Cache and periodically pulls stats from it.
@@ -31,6 +35,20 @@ type MeteredCache struct {
 	updateFrequency uint64
 }
 
+func dirSize(path string) (int64, error) {
+	var size int64
+	err := filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			size += info.Size()
+		}
+		return err
+	})
+	return size, err
+}
+
 // NewMeteredCache returns a new MeteredCache that will update stats to the
 // provided namespace once per each [updateFrequency] operations.
 // Note: if [updateFrequency] is passed as 0, it will be treated as 1.
@@ -39,6 +57,8 @@ func NewMeteredCache(size int, journal string, namespace string, updateFrequency
 	if journal == "" {
 		cache = fastcache.New(size)
 	} else {
+		dirSize, err := dirSize(journal)
+		log.Info("attempting to load cache from disk", "path", journal, "dirSize", common.StorageSize(dirSize), "err", err)
 		cache = fastcache.LoadFromFileOrNew(journal, size)
 	}
 	if updateFrequency == 0 {


### PR DESCRIPTION
This PR adds a lock prior to calling `Flatten` on the snapshot in the async acceptor queue to fix an issue where the snapshot may be marked as stale while we are processing a block.

If the disk snapshot is marked as stale, it can result in the processing block falling back to read from the trie instead of the snapshot during block execution and result in a significant slowdown.