### PR TITLE
Add counter for verified transactions

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -85,7 +85,8 @@ var (
 	acceptedBlockGasUsedCounter  = metrics.NewRegisteredCounter("chain/block/gas/used/accepted", nil)
 	badBlockCounter              = metrics.NewRegisteredCounter("chain/block/bad/count", nil)
 
-	acceptedTxsCounter = metrics.NewRegisteredCounter("chain/txs/accepted/count", nil)
+	acceptedTxsCounter  = metrics.NewRegisteredCounter("chain/txs/accepted", nil)
+	processedTxsCounter = metrics.NewRegisteredCounter("chain/txs/processed", nil)
 
 	ErrRefuseToCorruptArchiver = errors.New("node has operated with pruning disabled, shutting down to prevent missing tries")
 
@@ -913,7 +914,6 @@ func (bc *BlockChain) Accept(block *types.Block) error {
 	bc.addAcceptorQueue(block)
 	acceptedBlockGasUsedCounter.Inc(int64(block.GasUsed()))
 	acceptedTxsCounter.Inc(int64(len(block.Transactions())))
-
 	return nil
 }
 
@@ -1252,6 +1252,7 @@ func (bc *BlockChain) insertBlock(block *types.Block, writes bool) error {
 	)
 
 	processedBlockGasUsedCounter.Inc(int64(block.GasUsed()))
+	processedTxsCounter.Inc(int64(block.Transactions().Len()))
 	blockInsertCount.Inc(1)
 	return nil
 }


### PR DESCRIPTION
## Why this should be merged

This PR adds a metric for the number of verified transactions in the same style that we track processed and accepted gas.

## How this works

This PR adds an additional global metric for processed transactions next to accepted transactions and increments it when we finish inserting a block.
