### PR TITLE
Pack topics

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 
 # review whenever someone opens a pull request.
 
-- @ceyonur @darioush @patrick-ogrady @aaronbuchwald
+* @ceyonur @darioush @patrick-ogrady @aaronbuchwald
 
 # These owners will be the owner of the contract-examples sub-directory.
 

--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -97,7 +97,7 @@ func (abi ABI) Pack(name string, args ...interface{}) ([]byte, error) {
 // the event ABI specification.
 // https://docs.soliditylang.org/en/v0.8.17/abi-spec.html#indexed-event-encoding.
 // Note: PackEvent does not support array (fixed or dynamic-size) or struct types.
-func (abi ABI) PackEvent(name string, args []interface{}) ([]common.Hash, []byte, error) {
+func (abi ABI) PackEvent(name string, args ...interface{}) ([]common.Hash, []byte, error) {
 	event, exist := abi.Events[name]
 	if !exist {
 		return nil, nil, fmt.Errorf("event '%s' not found", name)

--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -91,7 +91,7 @@ func (abi ABI) Pack(name string, args ...interface{}) ([]byte, error) {
 	return append(method.ID, arguments...), nil
 }
 
-// PackEvent packs the given event name to conform the ABI.
+// PackEvent packs the given event name and arguments to conform the ABI.
 // Returns the topics for the event including the event signature (if non-anonymous event) and
 // hashes derived from indexed arguments and the packed data of non-indexed args according to
 // the event ABI specification.

--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -96,7 +96,7 @@ func (abi ABI) Pack(name string, args ...interface{}) ([]byte, error) {
 // hashes derived from indexed arguments and the packed data of non-indexed args according to
 // the event ABI specification.
 // https://docs.soliditylang.org/en/v0.8.17/abi-spec.html#indexed-event-encoding.
-// Note: PackEvent does not support array(both fixed size and dynamic-size) and struct types.
+// Note: PackEvent does not support array (fixed or dynamic-size) or struct types.
 func (abi ABI) PackEvent(name string, args []interface{}) ([]common.Hash, []byte, error) {
 	event, exist := abi.Events[name]
 	if !exist {

--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -101,7 +101,7 @@ func (abi ABI) PackEvent(name string, indexedArgs []interface{}, nonIndexedArgs 
 	if !exist {
 		return nil, nil, fmt.Errorf("event '%s' not found", name)
 	}
-	arguments, err := event.Inputs.Pack(nonIndexedArgs...)
+	arguments, err := event.Inputs.NonIndexed().Pack(nonIndexedArgs...)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/accounts/abi/abi_test.go
+++ b/accounts/abi/abi_test.go
@@ -39,7 +39,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/crypto"
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 const jsondata = `

--- a/accounts/abi/abi_test.go
+++ b/accounts/abi/abi_test.go
@@ -1255,7 +1255,7 @@ func TestABI_PackEvent(t *testing.T) {
 				t.Error(err)
 			}
 
-			topics, data, err := abi.PackEvent(test.name, test.args)
+			topics, data, err := abi.PackEvent(test.name, test.args...)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/accounts/abi/abi_test.go
+++ b/accounts/abi/abi_test.go
@@ -1260,8 +1260,8 @@ func TestABI_PackEvent(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			assert.DeepEqual(t, test.expectedTopics, topics)
-			assert.DeepEqual(t, test.expectedData, data)
+			assert.EqualValues(t, test.expectedTopics, topics)
+			assert.EqualValues(t, test.expectedData, data)
 		})
 	}
 }

--- a/accounts/abi/abi_test.go
+++ b/accounts/abi/abi_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/crypto"
+	"gotest.tools/assert"
 )
 
 const jsondata = `
@@ -1166,6 +1167,87 @@ func TestUnpackRevert(t *testing.T) {
 			if c.expect != got {
 				t.Fatalf("Output mismatch, want %v, got %v", c.expect, got)
 			}
+		})
+	}
+}
+
+func TestABI_PackEvent(t *testing.T) {
+	tests := []struct {
+		name           string
+		json           string
+		event          string
+		indexedArgs    []interface{}
+		nonIndexedArgs []interface{}
+		expectedTopics []common.Hash
+		expectedData   []byte
+	}{
+		{
+			name: "received",
+			json: `[
+			{"type":"event","name":"received","anonymous":false,"inputs":[
+				{"indexed":false,"name":"sender","type":"address"},
+				{"indexed":false,"name":"amount","type":"uint256"},
+				{"indexed":false,"name":"memo","type":"bytes"}
+				]
+			}]`,
+			event:       "received(address,uint256,bytes)",
+			indexedArgs: nil,
+			nonIndexedArgs: []interface{}{
+				common.HexToAddress("0x376c47978271565f56DEB45495afa69E59c16Ab2"),
+				big.NewInt(1),
+				[]byte{0x88},
+			},
+			expectedTopics: []common.Hash{
+				common.HexToHash("0x75fd880d39c1daf53b6547ab6cb59451fc6452d27caa90e5b6649dd8293b9eed"),
+			},
+			expectedData: common.Hex2Bytes("000000000000000000000000376c47978271565f56deb45495afa69e59c16ab20000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000018800000000000000000000000000000000000000000000000000000000000000"),
+		}, {
+			name: "Transfer",
+			json: `[
+				{ "constant": true, "inputs": [], "name": "name", "outputs": [ { "name": "", "type": "string" } ], "payable": false, "stateMutability": "view", "type": "function" },
+				{ "constant": false, "inputs": [ { "name": "_spender", "type": "address" }, { "name": "_value", "type": "uint256" } ], "name": "approve", "outputs": [ { "name": "", "type": "bool" } ], "payable": false, "stateMutability": "nonpayable", "type": "function" },
+				{ "constant": true, "inputs": [], "name": "totalSupply", "outputs": [ { "name": "", "type": "uint256" } ], "payable": false, "stateMutability": "view", "type": "function" },
+				{ "constant": false, "inputs": [ { "name": "_from", "type": "address" }, { "name": "_to", "type": "address" }, { "name": "_value", "type": "uint256" } ], "name": "transferFrom", "outputs": [ { "name": "", "type": "bool" } ], "payable": false, "stateMutability": "nonpayable", "type": "function" },
+				{ "constant": true, "inputs": [], "name": "decimals", "outputs": [ { "name": "", "type": "uint8" } ], "payable": false, "stateMutability": "view", "type": "function" },
+				{ "constant": true, "inputs": [ { "name": "_owner", "type": "address" } ], "name": "balanceOf", "outputs": [ { "name": "balance", "type": "uint256" } ], "payable": false, "stateMutability": "view", "type": "function" },
+				{ "constant": true, "inputs": [], "name": "symbol", "outputs": [ { "name": "", "type": "string" } ], "payable": false, "stateMutability": "view", "type": "function" },
+				{ "constant": false, "inputs": [ { "name": "_to", "type": "address" }, { "name": "_value", "type": "uint256" } ], "name": "transfer", "outputs": [ { "name": "", "type": "bool" } ], "payable": false, "stateMutability": "nonpayable", "type": "function" },
+				{ "constant": true, "inputs": [ { "name": "_owner", "type": "address" }, { "name": "_spender", "type": "address" } ], "name": "allowance", "outputs": [ { "name": "", "type": "uint256" } ], "payable": false, "stateMutability": "view", "type": "function" },
+				{ "payable": true, "stateMutability": "payable", "type": "fallback" },
+				{ "anonymous": false, "inputs": [ { "indexed": true, "name": "owner", "type": "address" }, { "indexed": true, "name": "spender", "type": "address" }, { "indexed": false, "name": "value", "type": "uint256" } ], "name": "Approval", "type": "event" },
+				{ "anonymous": false, "inputs": [ { "indexed": true, "name": "from", "type": "address" }, { "indexed": true, "name": "to", "type": "address" }, { "indexed": false, "name": "value", "type": "uint256" } ], "name": "Transfer", "type": "event" }
+			]`,
+			event: "Transfer(address,address,uint256)",
+			indexedArgs: []interface{}{
+				common.HexToAddress("0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC"),
+				common.HexToAddress("0x376c47978271565f56DEB45495afa69E59c16Ab2"),
+			},
+			nonIndexedArgs: []interface{}{
+				big.NewInt(100),
+			},
+			expectedTopics: []common.Hash{
+				common.HexToHash("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"),
+				common.HexToHash("0x0000000000000000000000008db97c7cece249c2b98bdc0226cc4c2a57bf52fc"),
+				common.HexToHash("0x000000000000000000000000376c47978271565f56deb45495afa69e59c16ab2"),
+			},
+			expectedData: common.Hex2Bytes("0000000000000000000000000000000000000000000000000000000000000064"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			abi, err := JSON(strings.NewReader(test.json))
+			if err != nil {
+				t.Error(err)
+			}
+
+			topics, data, err := abi.PackEvent(test.name, test.indexedArgs, test.nonIndexedArgs)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			assert.DeepEqual(t, test.expectedTopics, topics)
+			assert.DeepEqual(t, test.expectedData, data)
 		})
 	}
 }

--- a/accounts/abi/abi_test.go
+++ b/accounts/abi/abi_test.go
@@ -1176,8 +1176,7 @@ func TestABI_PackEvent(t *testing.T) {
 		name           string
 		json           string
 		event          string
-		indexedArgs    []interface{}
-		nonIndexedArgs []interface{}
+		args           []interface{}
 		expectedTopics []common.Hash
 		expectedData   []byte
 	}{
@@ -1190,9 +1189,8 @@ func TestABI_PackEvent(t *testing.T) {
 				{"indexed":false,"name":"memo","type":"bytes"}
 				]
 			}]`,
-			event:       "received(address,uint256,bytes)",
-			indexedArgs: nil,
-			nonIndexedArgs: []interface{}{
+			event: "received(address,uint256,bytes)",
+			args: []interface{}{
 				common.HexToAddress("0x376c47978271565f56DEB45495afa69E59c16Ab2"),
 				big.NewInt(1),
 				[]byte{0x88},
@@ -1201,6 +1199,24 @@ func TestABI_PackEvent(t *testing.T) {
 				common.HexToHash("0x75fd880d39c1daf53b6547ab6cb59451fc6452d27caa90e5b6649dd8293b9eed"),
 			},
 			expectedData: common.Hex2Bytes("000000000000000000000000376c47978271565f56deb45495afa69e59c16ab20000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000018800000000000000000000000000000000000000000000000000000000000000"),
+		},
+		{
+			name: "received",
+			json: `[
+			{"type":"event","name":"received","anonymous":true,"inputs":[
+				{"indexed":false,"name":"sender","type":"address"},
+				{"indexed":false,"name":"amount","type":"uint256"},
+				{"indexed":false,"name":"memo","type":"bytes"}
+				]
+			}]`,
+			event: "received(address,uint256,bytes)",
+			args: []interface{}{
+				common.HexToAddress("0x376c47978271565f56DEB45495afa69E59c16Ab2"),
+				big.NewInt(1),
+				[]byte{0x88},
+			},
+			expectedTopics: []common.Hash{},
+			expectedData:   common.Hex2Bytes("000000000000000000000000376c47978271565f56deb45495afa69e59c16ab20000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000018800000000000000000000000000000000000000000000000000000000000000"),
 		}, {
 			name: "Transfer",
 			json: `[
@@ -1218,11 +1234,9 @@ func TestABI_PackEvent(t *testing.T) {
 				{ "anonymous": false, "inputs": [ { "indexed": true, "name": "from", "type": "address" }, { "indexed": true, "name": "to", "type": "address" }, { "indexed": false, "name": "value", "type": "uint256" } ], "name": "Transfer", "type": "event" }
 			]`,
 			event: "Transfer(address,address,uint256)",
-			indexedArgs: []interface{}{
+			args: []interface{}{
 				common.HexToAddress("0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC"),
 				common.HexToAddress("0x376c47978271565f56DEB45495afa69E59c16Ab2"),
-			},
-			nonIndexedArgs: []interface{}{
 				big.NewInt(100),
 			},
 			expectedTopics: []common.Hash{
@@ -1241,7 +1255,7 @@ func TestABI_PackEvent(t *testing.T) {
 				t.Error(err)
 			}
 
-			topics, data, err := abi.PackEvent(test.name, test.indexedArgs, test.nonIndexedArgs)
+			topics, data, err := abi.PackEvent(test.name, test.args)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/accounts/abi/topics.go
+++ b/accounts/abi/topics.go
@@ -37,7 +37,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
-// packTopic attempts to pack rule into the corresponding hash value for a log's topic
+// packTopic packs rule into the corresponding hash value for a log's topic
 // according to the Solidity documentation:
 // https://docs.soliditylang.org/en/v0.8.17/abi-spec.html#indexed-event-encoding.
 func packTopic(rule interface{}) (common.Hash, error) {

--- a/accounts/abi/topics.go
+++ b/accounts/abi/topics.go
@@ -88,7 +88,7 @@ func packTopic(rule interface{}) (common.Hash, error) {
 		// parameters that are not value types i.e. arrays and structs are not
 		// stored directly but instead a keccak256-hash of an encoding is stored.
 		//
-		// We only convert stringS and bytes to hash, still need to deal with
+		// We only convert strings and bytes to hash, still need to deal with
 		// array(both fixed-size and dynamic-size) and struct.
 
 		// Attempt to generate the topic from funky types
@@ -106,6 +106,7 @@ func packTopic(rule interface{}) (common.Hash, error) {
 
 // PackTopics attempts to pack the array of filters into an array of corresponding topics
 // according to the Solidity documentation.
+// Note: PackTopics does not support array(both fixed size and dynamic-size) and struct types.
 func PackTopics(filter []interface{}) ([]common.Hash, error) {
 	topics := make([]common.Hash, len(filter))
 	for i, rule := range filter {

--- a/accounts/abi/topics.go
+++ b/accounts/abi/topics.go
@@ -37,71 +37,98 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
+// packTopic attempts to pack rule into the corresponding hash value for a log's topic
+// according to the Solidity documentation:
+// https://docs.soliditylang.org/en/v0.8.17/abi-spec.html#indexed-event-encoding.
+func packTopic(rule interface{}) (common.Hash, error) {
+	var topic common.Hash
+
+	// Try to generate the topic based on simple types
+	switch rule := rule.(type) {
+	case common.Hash:
+		copy(topic[:], rule[:])
+	case common.Address:
+		copy(topic[common.HashLength-common.AddressLength:], rule[:])
+	case *big.Int:
+		blob := rule.Bytes()
+		copy(topic[common.HashLength-len(blob):], blob)
+	case bool:
+		if rule {
+			topic[common.HashLength-1] = 1
+		}
+	case int8:
+		copy(topic[:], genIntType(int64(rule), 1))
+	case int16:
+		copy(topic[:], genIntType(int64(rule), 2))
+	case int32:
+		copy(topic[:], genIntType(int64(rule), 4))
+	case int64:
+		copy(topic[:], genIntType(rule, 8))
+	case uint8:
+		blob := new(big.Int).SetUint64(uint64(rule)).Bytes()
+		copy(topic[common.HashLength-len(blob):], blob)
+	case uint16:
+		blob := new(big.Int).SetUint64(uint64(rule)).Bytes()
+		copy(topic[common.HashLength-len(blob):], blob)
+	case uint32:
+		blob := new(big.Int).SetUint64(uint64(rule)).Bytes()
+		copy(topic[common.HashLength-len(blob):], blob)
+	case uint64:
+		blob := new(big.Int).SetUint64(rule).Bytes()
+		copy(topic[common.HashLength-len(blob):], blob)
+	case string:
+		hash := crypto.Keccak256Hash([]byte(rule))
+		copy(topic[:], hash[:])
+	case []byte:
+		hash := crypto.Keccak256Hash(rule)
+		copy(topic[:], hash[:])
+
+	default:
+		// todo(rjl493456442) according solidity documentation, indexed event
+		// parameters that are not value types i.e. arrays and structs are not
+		// stored directly but instead a keccak256-hash of an encoding is stored.
+		//
+		// We only convert stringS and bytes to hash, still need to deal with
+		// array(both fixed-size and dynamic-size) and struct.
+
+		// Attempt to generate the topic from funky types
+		val := reflect.ValueOf(rule)
+		switch {
+		// static byte array
+		case val.Kind() == reflect.Array && reflect.TypeOf(rule).Elem().Kind() == reflect.Uint8:
+			reflect.Copy(reflect.ValueOf(topic[:val.Len()]), val)
+		default:
+			return common.Hash{}, fmt.Errorf("unsupported indexed type: %T", rule)
+		}
+	}
+	return topic, nil
+}
+
+// PackTopics attempts to pack the array of filters into an array of corresponding topics
+// according to the Solidity documentation.
+func PackTopics(filter []interface{}) ([]common.Hash, error) {
+	topics := make([]common.Hash, len(filter))
+	for i, rule := range filter {
+		topic, err := packTopic(rule)
+		if err != nil {
+			return nil, err
+		}
+		topics[i] = topic
+	}
+
+	return topics, nil
+}
+
 // MakeTopics converts a filter query argument list into a filter topic set.
 func MakeTopics(query ...[]interface{}) ([][]common.Hash, error) {
 	topics := make([][]common.Hash, len(query))
 	for i, filter := range query {
 		for _, rule := range filter {
-			var topic common.Hash
-
-			// Try to generate the topic based on simple types
-			switch rule := rule.(type) {
-			case common.Hash:
-				copy(topic[:], rule[:])
-			case common.Address:
-				copy(topic[common.HashLength-common.AddressLength:], rule[:])
-			case *big.Int:
-				blob := rule.Bytes()
-				copy(topic[common.HashLength-len(blob):], blob)
-			case bool:
-				if rule {
-					topic[common.HashLength-1] = 1
-				}
-			case int8:
-				copy(topic[:], genIntType(int64(rule), 1))
-			case int16:
-				copy(topic[:], genIntType(int64(rule), 2))
-			case int32:
-				copy(topic[:], genIntType(int64(rule), 4))
-			case int64:
-				copy(topic[:], genIntType(rule, 8))
-			case uint8:
-				blob := new(big.Int).SetUint64(uint64(rule)).Bytes()
-				copy(topic[common.HashLength-len(blob):], blob)
-			case uint16:
-				blob := new(big.Int).SetUint64(uint64(rule)).Bytes()
-				copy(topic[common.HashLength-len(blob):], blob)
-			case uint32:
-				blob := new(big.Int).SetUint64(uint64(rule)).Bytes()
-				copy(topic[common.HashLength-len(blob):], blob)
-			case uint64:
-				blob := new(big.Int).SetUint64(rule).Bytes()
-				copy(topic[common.HashLength-len(blob):], blob)
-			case string:
-				hash := crypto.Keccak256Hash([]byte(rule))
-				copy(topic[:], hash[:])
-			case []byte:
-				hash := crypto.Keccak256Hash(rule)
-				copy(topic[:], hash[:])
-
-			default:
-				// todo(rjl493456442) according solidity documentation, indexed event
-				// parameters that are not value types i.e. arrays and structs are not
-				// stored directly but instead a keccak256-hash of an encoding is stored.
-				//
-				// We only convert stringS and bytes to hash, still need to deal with
-				// array(both fixed-size and dynamic-size) and struct.
-
-				// Attempt to generate the topic from funky types
-				val := reflect.ValueOf(rule)
-				switch {
-				// static byte array
-				case val.Kind() == reflect.Array && reflect.TypeOf(rule).Elem().Kind() == reflect.Uint8:
-					reflect.Copy(reflect.ValueOf(topic[:val.Len()]), val)
-				default:
-					return nil, fmt.Errorf("unsupported indexed type: %T", rule)
-				}
+			topic, err := packTopic(rule)
+			if err != nil {
+				return nil, err
 			}
+
 			topics[i] = append(topics[i], topic)
 		}
 	}

--- a/accounts/abi/topics.go
+++ b/accounts/abi/topics.go
@@ -129,7 +129,6 @@ func MakeTopics(query ...[]interface{}) ([][]common.Hash, error) {
 			if err != nil {
 				return nil, err
 			}
-
 			topics[i] = append(topics[i], topic)
 		}
 	}


### PR DESCRIPTION
## Why this should be merged

This PR adds `PackTopics` to the abi package to support packing events. This is intended to be made available for precompiles to pack events, so that they can create logs.

## How this works

This works by using the existing code for packing topics used in the abi package to support creating filter queries and breaks out the actual creation of a topic hash into a helper function, so that we can re-purpose it to create an array of topics as would be created by an event log rather than the type `[][]common.Hash` that would be used when creating a filter query.

## How this was tested

Adds a unit test in `abi_test.go` to test the encoding of an event without indexed args, with indexed args, and of an anonymous event.

## Reference for Event Encoding

https://docs.soliditylang.org/en/v0.8.17/abi-spec.html#indexed-event-encoding