### PR TITLE
Update AddLog function signature to support usage from precompiles

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -213,6 +213,9 @@ func (s *StateDB) Error() error {
 	return s.dbErr
 }
 
+// AddLog adds a log with the specified parameters to the statedb
+// Note: blockNumber is a required argument because StateDB does not
+// know the current block number.
 func (s *StateDB) AddLog(addr common.Address, topics []common.Hash, data []byte, blockNumber uint64) {
 	log := &types.Log{
 		Address:     addr,

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -213,7 +213,13 @@ func (s *StateDB) Error() error {
 	return s.dbErr
 }
 
-func (s *StateDB) AddLog(log *types.Log) {
+func (s *StateDB) AddLog(addr common.Address, topics []common.Hash, data []byte, blockNumber uint64) {
+	log := &types.Log{
+		Address:     addr,
+		Topics:      topics,
+		Data:        data,
+		BlockNumber: blockNumber,
+	}
 	s.journal.append(addLogChange{txhash: s.thash})
 
 	log.TxHash = s.thash

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -40,7 +40,6 @@ import (
 	"testing/quick"
 
 	"github.com/ava-labs/subnet-evm/core/rawdb"
-	"github.com/ava-labs/subnet-evm/core/types"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -325,7 +324,7 @@ func newTestAction(addr common.Address, r *rand.Rand) testAction {
 			fn: func(a testAction, s *StateDB) {
 				data := make([]byte, 2)
 				binary.BigEndian.PutUint16(data, uint16(a.args[0]))
-				s.AddLog(&types.Log{Address: addr, Data: data})
+				s.AddLog(addr, nil, data, 0)
 			},
 			args: make([]int64, 1),
 		},

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -29,7 +29,6 @@ package vm
 import (
 	"sync/atomic"
 
-	"github.com/ava-labs/subnet-evm/core/types"
 	"github.com/ava-labs/subnet-evm/params"
 	"github.com/ava-labs/subnet-evm/vmerrs"
 	"github.com/ethereum/go-ethereum/common"
@@ -859,14 +858,12 @@ func makeLog(size int) executionFunc {
 		}
 
 		d := scope.Memory.GetCopy(int64(mStart.Uint64()), int64(mSize.Uint64()))
-		interpreter.evm.StateDB.AddLog(&types.Log{
-			Address: scope.Contract.Address(),
-			Topics:  topics,
-			Data:    d,
-			// This is a non-consensus field, but assigned here because
-			// core/state doesn't know the current block number.
-			BlockNumber: interpreter.evm.Context.BlockNumber.Uint64(),
-		})
+		interpreter.evm.StateDB.AddLog(
+			scope.Contract.Address(),
+			topics,
+			d,
+			interpreter.evm.Context.BlockNumber.Uint64(),
+		)
 
 		return nil, nil
 	}

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -81,7 +81,7 @@ type StateDB interface {
 	RevertToSnapshot(int)
 	Snapshot() int
 
-	AddLog(*types.Log)
+	AddLog(addr common.Address, topics []common.Hash, data []byte, blockNumber uint64)
 	AddPreimage(common.Hash, []byte)
 
 	ForEachStorage(common.Address, func(common.Hash, common.Hash) bool) error

--- a/precompile/contract.go
+++ b/precompile/contract.go
@@ -58,6 +58,8 @@ type StateDB interface {
 	CreateAccount(common.Address)
 	Exist(common.Address) bool
 
+	AddLog(addr common.Address, topics []common.Hash, data []byte, blockNumber uint64)
+
 	Suicide(common.Address) bool
 	Finalise(deleteEmptyObjects bool)
 }


### PR DESCRIPTION
## Why this should be merged

This PR updates the function signature of statedb `AddLog(...)` function to:
```
AddLog(addr common.Address, topics []common.Hash, data []byte, blockNumber uint64)
```

Previously, a fully formed log was passed directly in with only these params populated. This PR is intended to avoid needing to import `core/types/` package into the `precompile/` package which currently creates a circular import.

## How this was tested

This is intended as a no-op change, so no unit tests were added.
