### PR TITLE
Add CallFromPrecompile to PrecompileAccessibleState

### DIFF
--- a/core/stateful_precompile_test.go
+++ b/core/stateful_precompile_test.go
@@ -60,6 +60,10 @@ func (m *mockAccessibleState) GetBlockContext() precompile.BlockContext { return
 
 func (m *mockAccessibleState) GetSnowContext() *snow.Context { return m.snowContext }
 
+func (m *mockAccessibleState) CallFromPrecompile(caller common.Address, addr common.Address, input []byte, gas uint64, value *big.Int) (ret []byte, leftOverGas uint64, err error) {
+	return nil, 0, nil
+}
+
 // This test is added within the core package so that it can import all of the required code
 // without creating any import cycles
 func TestContractDeployerAllowListRun(t *testing.T) {

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -307,6 +307,11 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 	return ret, gas, err
 }
 
+// CallFromPrecompile invokes Call to execute the contract with the given input parameters.
+func (evm *EVM) CallFromPrecompile(caller common.Address, addr common.Address, input []byte, gas uint64, value *big.Int) (ret []byte, leftOverGas uint64, err error) {
+	return evm.Call(AccountRef(caller), addr, input, gas, value)
+}
+
 // CallCode executes the contract associated with the addr with the given input
 // as parameters. It also handles any necessary value transfer required and takes
 // the necessary steps to create accounts and reverses the state in case of an

--- a/precompile/contract.go
+++ b/precompile/contract.go
@@ -23,6 +23,7 @@ type PrecompileAccessibleState interface {
 	GetStateDB() StateDB
 	GetBlockContext() BlockContext
 	GetSnowContext() *snow.Context
+	CallFromPrecompile(caller common.Address, addr common.Address, input []byte, gas uint64, value *big.Int) (ret []byte, leftOverGas uint64, err error)
 }
 
 // BlockContext defines an interface that provides information to a stateful precompile


### PR DESCRIPTION
This PR adds a method `CallFromPrecompile` to the interface PrecompileAccessibleState.
- CallFromPrecompile creates an `AccountRef`, which implements ContractRef, then invokes `Call` for the contract
