### PR TITLE
generalize precompile specific upgrade checks

### DIFF
--- a/consensus/dummy/consensus.go
+++ b/consensus/dummy/consensus.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ava-labs/subnet-evm/core/state"
 	"github.com/ava-labs/subnet-evm/core/types"
 	"github.com/ava-labs/subnet-evm/params"
+	"github.com/ava-labs/subnet-evm/precompile"
 	"github.com/ava-labs/subnet-evm/trie"
 	"github.com/ava-labs/subnet-evm/vmerrs"
 	"github.com/ethereum/go-ethereum/common"
@@ -198,7 +199,7 @@ func (self *DummyEngine) verifyHeader(chain consensus.ChainHeaderReader, header 
 	}
 	// Ensure that coinbase is valid if reward manager is enabled
 	// If reward manager is disabled, this will be handled in syntactic verification
-	if config.IsRewardManager(timestamp) {
+	if config.IsPrecompileEnabled(precompile.RewardManagerAddress, timestamp) {
 		if err := self.verifyCoinbase(config, header, parent, chain); err != nil {
 			return err
 		}

--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -348,7 +348,7 @@ func (bc *BlockChain) SubscribeAcceptedTransactionEvent(ch chan<- NewTxsEvent) e
 func (bc *BlockChain) GetFeeConfigAt(parent *types.Header) (commontype.FeeConfig, *big.Int, error) {
 	config := bc.Config()
 	bigTime := new(big.Int).SetUint64(parent.Time)
-	if !config.IsFeeConfigManager(bigTime) {
+	if !config.IsPrecompileEnabled(precompile.FeeConfigManagerAddress, bigTime) {
 		return config.FeeConfig, common.Big0, nil
 	}
 
@@ -390,7 +390,7 @@ func (bc *BlockChain) GetCoinbaseAt(parent *types.Header) (common.Address, bool,
 		return constants.BlackholeAddr, false, nil
 	}
 
-	if !config.IsRewardManager(bigTime) {
+	if !config.IsPrecompileEnabled(precompile.RewardManagerAddress, bigTime) {
 		if bc.chainConfig.AllowFeeRecipients {
 			return common.Address{}, true, nil
 		} else {

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -249,7 +249,7 @@ func (st *StateTransition) preCheck() error {
 		}
 
 		// Check that the sender is on the tx allow list if enabled
-		if st.evm.ChainConfig().IsTxAllowList(st.evm.Context.Time) {
+		if st.evm.ChainConfig().IsPrecompileEnabled(precompile.TxAllowListAddress, st.evm.Context.Time) {
 			txAllowListRole := precompile.GetTxAllowListStatus(st.state, st.msg.From())
 			if !txAllowListRole.IsEnabled() {
 				return fmt.Errorf("%w: %s", precompile.ErrSenderAddressNotAllowListed, st.msg.From())

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -693,7 +693,7 @@ func (pool *TxPool) checkTxState(from common.Address, tx *types.Transaction) err
 
 	// If the tx allow list is enabled, return an error if the from address is not allow listed.
 	headTimestamp := big.NewInt(int64(pool.currentHead.Time))
-	if pool.chainconfig.IsTxAllowList(headTimestamp) {
+	if pool.chainconfig.IsPrecompileEnabled(precompile.TxAllowListAddress, headTimestamp) {
 		txAllowListRole := precompile.GetTxAllowListStatus(pool.currentState, from)
 		if !txAllowListRole.IsEnabled() {
 			return fmt.Errorf("%w: %s", precompile.ErrSenderAddressNotAllowListed, from)
@@ -1441,7 +1441,7 @@ func (pool *TxPool) reset(oldHead, newHead *types.Header) {
 
 	// when we reset txPool we should explicitly check if fee struct for min base fee has changed
 	// so that we can correctly drop txs with < minBaseFee from tx pool.
-	if pool.chainconfig.IsFeeConfigManager(new(big.Int).SetUint64(newHead.Time)) {
+	if pool.chainconfig.IsPrecompileEnabled(precompile.FeeConfigManagerAddress, new(big.Int).SetUint64(newHead.Time)) {
 		feeConfig, _, err := pool.chain.GetFeeConfigAt(newHead)
 		if err != nil {
 			log.Error("Failed to get fee config state", "err", err, "root", newHead.Root)

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -507,7 +507,7 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 		return nil, common.Address{}, 0, vmerrs.ErrContractAddressCollision
 	}
 	// If the allow list is enabled, check that [evm.TxContext.Origin] has permission to deploy a contract.
-	if evm.chainRules.IsContractDeployerAllowListEnabled {
+	if evm.chainRules.IsPrecompileEnabled(precompile.ContractDeployerAllowListAddress) {
 		allowListRole := precompile.GetContractDeployerAllowListStatus(evm.StateDB, evm.TxContext.Origin)
 		if !allowListRole.IsEnabled() {
 			return nil, common.Address{}, 0, fmt.Errorf("tx.origin %s is not authorized to deploy a contract", evm.TxContext.Origin)

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -39,6 +39,7 @@ import (
 	"github.com/ava-labs/subnet-evm/core"
 	"github.com/ava-labs/subnet-evm/core/types"
 	"github.com/ava-labs/subnet-evm/params"
+	"github.com/ava-labs/subnet-evm/precompile"
 	"github.com/ava-labs/subnet-evm/rpc"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
@@ -317,7 +318,7 @@ func (oracle *Oracle) suggestDynamicFees(ctx context.Context) (*big.Int, *big.In
 		feeLastChangedAt *big.Int
 		feeConfig        commontype.FeeConfig
 	)
-	if oracle.backend.ChainConfig().IsFeeConfigManager(new(big.Int).SetUint64(head.Time)) {
+	if oracle.backend.ChainConfig().IsPrecompileEnabled(precompile.FeeConfigManagerAddress, new(big.Int).SetUint64(head.Time)) {
 		feeConfig, feeLastChangedAt, err = oracle.backend.GetFeeConfigAt(head)
 		if err != nil {
 			return nil, nil, err

--- a/params/config.go
+++ b/params/config.go
@@ -272,10 +272,7 @@ func (c *ChainConfig) IsSubnetEVM(blockTimestamp *big.Int) bool {
 	return utils.IsForked(c.getNetworkUpgrades().SubnetEVMTimestamp, blockTimestamp)
 }
 
-// PRECOMPILE UPGRADES START HERE
-
-// TODO: generalize these functions with IsPrecompileEnabled(address, blockTimestamp)
-// IsContractDeployerAllowList returns whether [blockTimestamp] is either equal to the ContractDeployerAllowList fork block timestamp or greater.
+// IsPrecompileEnabled returns whether precompile with [address] is enabled at [blockTimestamp].
 func (c *ChainConfig) IsPrecompileEnabled(address common.Address, blockTimestamp *big.Int) bool {
 	config := c.GetPrecompileConfig(address, blockTimestamp)
 	return config != nil && !config.IsDisabled()

--- a/params/config.go
+++ b/params/config.go
@@ -276,42 +276,10 @@ func (c *ChainConfig) IsSubnetEVM(blockTimestamp *big.Int) bool {
 
 // TODO: generalize these functions with IsPrecompileEnabled(address, blockTimestamp)
 // IsContractDeployerAllowList returns whether [blockTimestamp] is either equal to the ContractDeployerAllowList fork block timestamp or greater.
-func (c *ChainConfig) IsContractDeployerAllowList(blockTimestamp *big.Int) bool {
-	config := c.GetPrecompileConfig(precompile.ContractDeployerAllowListAddress, blockTimestamp)
+func (c *ChainConfig) IsPrecompileEnabled(address common.Address, blockTimestamp *big.Int) bool {
+	config := c.GetPrecompileConfig(address, blockTimestamp)
 	return config != nil && !config.IsDisabled()
 }
-
-// IsContractNativeMinter returns whether [blockTimestamp] is either equal to the NativeMinter fork block timestamp or greater.
-func (c *ChainConfig) IsContractNativeMinter(blockTimestamp *big.Int) bool {
-	config := c.GetPrecompileConfig(precompile.ContractNativeMinterAddress, blockTimestamp)
-	return config != nil && !config.IsDisabled()
-}
-
-// IsTxAllowList returns whether [blockTimestamp] is either equal to the TxAllowList fork block timestamp or greater.
-func (c *ChainConfig) IsTxAllowList(blockTimestamp *big.Int) bool {
-	config := c.GetPrecompileConfig(precompile.TxAllowListAddress, blockTimestamp)
-	return config != nil && !config.IsDisabled()
-}
-
-// IsFeeConfigManager returns whether [blockTimestamp] is either equal to the FeeConfigManager fork block timestamp or greater.
-func (c *ChainConfig) IsFeeConfigManager(blockTimestamp *big.Int) bool {
-	config := c.GetPrecompileConfig(precompile.FeeConfigManagerAddress, blockTimestamp)
-	return config != nil && !config.IsDisabled()
-}
-
-// IsRewardManager returns whether [blockTimestamp] is either equal to the RewardManager fork block timestamp or greater.
-func (c *ChainConfig) IsRewardManager(blockTimestamp *big.Int) bool {
-	config := c.GetPrecompileConfig(precompile.RewardManagerAddress, blockTimestamp)
-	return config != nil && !config.IsDisabled()
-}
-
-// ADD YOUR PRECOMPILE HERE
-/*
-func (c *ChainConfig) Is{YourPrecompile}(blockTimestamp *big.Int) bool {
-	config := c.GetPrecompileConfig(precompile.{YourPrecompile}Address, blockTimestamp)
-	return config != nil && !config.IsDisabled()
-}
-*/
 
 // CheckCompatible checks whether scheduled fork transitions have been imported
 // with a mismatching chain configuration.
@@ -540,20 +508,16 @@ type Rules struct {
 	// Rules for Avalanche releases
 	IsSubnetEVM bool
 
-	// Optional stateful precompile rules
-	IsContractDeployerAllowListEnabled bool
-	IsContractNativeMinterEnabled      bool
-	IsTxAllowListEnabled               bool
-	IsFeeConfigManagerEnabled          bool
-	IsRewardManagerEnabled             bool
-	// ADD YOUR PRECOMPILE HERE
-	// Is{YourPrecompile}Enabled         bool
-
 	// Precompiles maps addresses to stateful precompiled contracts that are enabled
 	// for this rule set.
 	// Note: none of these addresses should conflict with the address space used by
 	// any existing precompiles.
 	Precompiles map[common.Address]precompile.StatefulPrecompiledContract
+}
+
+func (r *Rules) IsPrecompileEnabled(addr common.Address) bool {
+	_, ok := r.Precompiles[addr]
+	return ok
 }
 
 // Rules ensures c's ChainID is not nil.
@@ -581,13 +545,6 @@ func (c *ChainConfig) AvalancheRules(blockNum, blockTimestamp *big.Int) Rules {
 	rules := c.rules(blockNum)
 
 	rules.IsSubnetEVM = c.IsSubnetEVM(blockTimestamp)
-	rules.IsContractDeployerAllowListEnabled = c.IsContractDeployerAllowList(blockTimestamp)
-	rules.IsContractNativeMinterEnabled = c.IsContractNativeMinter(blockTimestamp)
-	rules.IsTxAllowListEnabled = c.IsTxAllowList(blockTimestamp)
-	rules.IsFeeConfigManagerEnabled = c.IsFeeConfigManager(blockTimestamp)
-	rules.IsRewardManagerEnabled = c.IsRewardManager(blockTimestamp)
-	// ADD YOUR PRECOMPILE HERE
-	// rules.Is{YourPrecompile}Enabled = c.{IsYourPrecompile}(blockTimestamp)
 
 	// Initialize the stateful precompiles that should be enabled at [blockTimestamp].
 	rules.Precompiles = make(map[common.Address]precompile.StatefulPrecompiledContract)

--- a/plugin/evm/block_verification.go
+++ b/plugin/evm/block_verification.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ava-labs/subnet-evm/constants"
 	"github.com/ava-labs/subnet-evm/core/types"
 	"github.com/ava-labs/subnet-evm/params"
+	"github.com/ava-labs/subnet-evm/precompile"
 	"github.com/ava-labs/subnet-evm/trie"
 	"github.com/ava-labs/subnet-evm/vmerrs"
 )
@@ -98,7 +99,7 @@ func (v blockValidator) SyntacticVerify(b *Block, rules params.Rules) error {
 	}
 
 	switch {
-	case rules.IsRewardManagerEnabled:
+	case rules.IsPrecompileEnabled(precompile.RewardManagerAddress):
 		// if reward manager is enabled, Coinbase depends on state.
 		// State is not available here, so skip checking the coinbase here.
 	case rules.IsSubnetEVM && b.vm.chainConfig.AllowFeeRecipients:


### PR DESCRIPTION
## Why this should be merged

Reduces mandatory manual code addition for new precompiles ("ADD YOUR PRECOMPILE HERE")

## How this works

Removes precompile specific functions from chain config and uses a generalized check function which takes precompile address.

## How this was tested

Locally tested.
