### PR TITLE
apt-get update to try to fix this

### DIFF
--- a/.github/workflows/lint-tests-release.yml
+++ b/.github/workflows/lint-tests-release.yml
@@ -101,9 +101,10 @@ jobs:
         with:
           go-version: 1.18
       - name: Set up arm64 cross compiler
-        run: |
-          sudo apt-get -y update
-          sudo apt-get -y install gcc-aarch64-linux-gnu
+        run: sudo apt-get -y install gcc-aarch64-linux-gnu
+        #run: |
+        #  sudo apt-get -y update
+        #  sudo apt-get -y install gcc-aarch64-linux-gnu
       - name: Checkout osxcross
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/lint-tests-release.yml
+++ b/.github/workflows/lint-tests-release.yml
@@ -101,10 +101,9 @@ jobs:
         with:
           go-version: 1.18
       - name: Set up arm64 cross compiler
-        run: sudo apt-get -y install gcc-aarch64-linux-gnu
-        #run: |
-        #  sudo apt-get -y update
-        #  sudo apt-get -y install gcc-aarch64-linux-gnu
+        run: |
+          sudo apt-get -y update
+          sudo apt-get -y install gcc-aarch64-linux-gnu
       - name: Checkout osxcross
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/lint-tests-release.yml
+++ b/.github/workflows/lint-tests-release.yml
@@ -101,7 +101,9 @@ jobs:
         with:
           go-version: 1.18
       - name: Set up arm64 cross compiler
-        run: sudo apt-get -y install gcc-aarch64-linux-gnu
+        run: |
+          sudo apt-get -y update
+          sudo apt-get -y install gcc-aarch64-linux-gnu
       - name: Checkout osxcross
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
## Why this should be merged

Update on ubuntu-latest on CI left dependency inconsistencies that produce failure when trying to install gcc arm compiler. An update of dependencies with apt-get update fix the situation and may be a good add on to the CI to prevent future failures with simular eason.

## How this works

## How this was tested
