### PR TITLE
Add Inner to ethdb.Batch interface

### DIFF
--- a/core/rawdb/table.go
+++ b/core/rawdb/table.go
@@ -168,6 +168,11 @@ func (b *tableBatch) Reset() {
 	b.batch.Reset()
 }
 
+// Inner returns itself
+func (b *tableBatch) Inner() ethdb.Batch {
+	return b
+}
+
 // tableReplayer is a wrapper around a batch replayer which truncates
 // the added prefix.
 type tableReplayer struct {

--- a/ethdb/batch.go
+++ b/ethdb/batch.go
@@ -46,6 +46,10 @@ type Batch interface {
 
 	// Replay replays the batch contents.
 	Replay(w KeyValueWriter) error
+
+	// Inner implements the AvalancheGo batch interface
+	// Returns the underlying batch on the base database if one exists. Otherwise returns itself.
+	Inner() Batch
 }
 
 // Batcher wraps the NewBatch method of a backing data store.

--- a/ethdb/leveldb/leveldb.go
+++ b/ethdb/leveldb/leveldb.go
@@ -505,6 +505,11 @@ func (b *batch) Replay(w ethdb.KeyValueWriter) error {
 	return b.b.Replay(&replayer{writer: w})
 }
 
+// Inner returns itself
+func (b *batch) Inner() ethdb.Batch {
+	return b
+}
+
 // replayer is a small wrapper to implement the correct replay methods.
 type replayer struct {
 	writer  ethdb.KeyValueWriter

--- a/ethdb/memorydb/memorydb.go
+++ b/ethdb/memorydb/memorydb.go
@@ -275,6 +275,11 @@ func (b *batch) Replay(w ethdb.KeyValueWriter) error {
 	return nil
 }
 
+// Inner returns itself
+func (b *batch) Inner() ethdb.Batch {
+	return b
+}
+
 // iterator can walk over the (potentially partial) keyspace of a memory key
 // value store. Internally it is a deep copy of the entire iterated state,
 // sorted by keys.

--- a/plugin/evm/database.go
+++ b/plugin/evm/database.go
@@ -53,3 +53,6 @@ func (batch Batch) ValueSize() int { return batch.Batch.Size() }
 
 // Replay implements ethdb.Batch
 func (batch Batch) Replay(w ethdb.KeyValueWriter) error { return batch.Batch.Replay(w) }
+
+// Inner implements ethdb.Batch
+func (batch Batch) Inner() ethdb.Batch { return batch }

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -766,6 +766,7 @@ func (b *spongeBatch) ValueSize() int                      { return 100 }
 func (b *spongeBatch) Write() error                        { return nil }
 func (b *spongeBatch) Reset()                              {}
 func (b *spongeBatch) Replay(w ethdb.KeyValueWriter) error { return nil }
+func (b *spongeBatch) Inner() ethdb.Batch                  { return b }
 
 // TestCommitSequence tests that the trie.Commit operation writes the elements of the trie
 // in the expected order, and calls the callbacks in the expected order.


### PR DESCRIPTION
## Why this should be merged

This PR will allow the `ethdb.Batch` to implement the AvalancheGo `database.Batch` interface so that we can apply an `ethdb.Batch` alongside shared memory operations.

## How this works

This works by implementing the `Inner()` function from the AvalancheGo `database.Batch` interface. This needs to return a `database.Batch` interface from AvalancheGo not the `ethdb.Batch` interface type.

## How this was tested

This is intended as a no-op change, so this was tested via CI.
