### PR TITLE
*: make tx pool configurable

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -184,21 +184,37 @@ type TxPoolConfig struct {
 	Lifetime time.Duration // Maximum amount of time non-executable transaction are queued
 }
 
+const (
+	DefaultTxPoolJournal   = "transactions.rlp"
+	DefaultTxPoolRejournal = time.Hour
+
+	DefaultTxPoolPriceLimit = 1
+	DefaultTxPoolPriceBump  = 10
+
+	DefaultTxPoolAccountSlots = 16
+	// urgent + floating queue capacity with 4:1 ratio
+	DefaultTxPoolGlobalSlots  = 4096 + 1024
+	DefaultTxPoolAccountQueue = 64
+	DefaultTxPoolGlobalQueue  = 1024
+
+	DefaultTxPoolLifetime = 3 * time.Hour
+)
+
 // DefaultTxPoolConfig contains the default configurations for the transaction
 // pool.
 var DefaultTxPoolConfig = TxPoolConfig{
-	Journal:   "transactions.rlp",
-	Rejournal: time.Hour,
+	Journal:   DefaultTxPoolJournal,
+	Rejournal: DefaultTxPoolRejournal,
 
-	PriceLimit: 1,
-	PriceBump:  10,
+	PriceLimit: DefaultTxPoolPriceLimit,
+	PriceBump:  DefaultTxPoolPriceBump,
 
-	AccountSlots: 16,
-	GlobalSlots:  4096 + 1024, // urgent + floating queue capacity with 4:1 ratio
-	AccountQueue: 64,
-	GlobalQueue:  1024,
+	AccountSlots: DefaultTxPoolAccountSlots,
+	GlobalSlots:  DefaultTxPoolGlobalSlots,
+	AccountQueue: DefaultTxPoolAccountQueue,
+	GlobalQueue:  DefaultTxPoolGlobalQueue,
 
-	Lifetime: 3 * time.Hour,
+	Lifetime: DefaultTxPoolLifetime,
 }
 
 // sanitize checks the provided user configurations and changes anything that's

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -184,37 +184,21 @@ type TxPoolConfig struct {
 	Lifetime time.Duration // Maximum amount of time non-executable transaction are queued
 }
 
-const (
-	DefaultTxPoolJournal   = "transactions.rlp"
-	DefaultTxPoolRejournal = time.Hour
-
-	DefaultTxPoolPriceLimit = 1
-	DefaultTxPoolPriceBump  = 10
-
-	DefaultTxPoolAccountSlots = 16
-	// urgent + floating queue capacity with 4:1 ratio
-	DefaultTxPoolGlobalSlots  = 4096 + 1024
-	DefaultTxPoolAccountQueue = 64
-	DefaultTxPoolGlobalQueue  = 1024
-
-	DefaultTxPoolLifetime = 3 * time.Hour
-)
-
 // DefaultTxPoolConfig contains the default configurations for the transaction
 // pool.
 var DefaultTxPoolConfig = TxPoolConfig{
-	Journal:   DefaultTxPoolJournal,
-	Rejournal: DefaultTxPoolRejournal,
+	Journal:   "transactions.rlp",
+	Rejournal: time.Hour,
 
-	PriceLimit: DefaultTxPoolPriceLimit,
-	PriceBump:  DefaultTxPoolPriceBump,
+	PriceLimit: 1,
+	PriceBump:  10,
 
-	AccountSlots: DefaultTxPoolAccountSlots,
-	GlobalSlots:  DefaultTxPoolGlobalSlots,
-	AccountQueue: DefaultTxPoolAccountQueue,
-	GlobalQueue:  DefaultTxPoolGlobalQueue,
+	AccountSlots: 16,
+	GlobalSlots:  4096 + 1024, // urgent + floating queue capacity with 4:1 ratio
+	AccountQueue: 64,
+	GlobalQueue:  1024,
 
-	Lifetime: DefaultTxPoolLifetime,
+	Lifetime: 3 * time.Hour,
 }
 
 // sanitize checks the provided user configurations and changes anything that's

--- a/plugin/evm/config.go
+++ b/plugin/evm/config.go
@@ -212,14 +212,14 @@ func (c *Config) SetDefaults() {
 	c.RPCTxFeeCap = defaultRpcTxFeeCap
 	c.MetricsExpensiveEnabled = defaultMetricsExpensiveEnabled
 
-	c.TxPoolJournal = core.DefaultTxPoolJournal
-	c.TxPoolRejournal = Duration{Duration: core.DefaultTxPoolRejournal}
-	c.TxPoolPriceLimit = core.DefaultTxPoolPriceLimit
-	c.TxPoolPriceBump = core.DefaultTxPoolPriceBump
-	c.TxPoolAccountSlots = core.DefaultTxPoolAccountSlots
-	c.TxPoolGlobalSlots = core.DefaultTxPoolGlobalSlots
-	c.TxPoolAccountQueue = core.DefaultTxPoolAccountQueue
-	c.TxPoolGlobalQueue = core.DefaultTxPoolGlobalQueue
+	c.TxPoolJournal = core.DefaultTxPoolConfig.Journal
+	c.TxPoolRejournal = Duration{Duration: core.DefaultTxPoolConfig.Rejournal}
+	c.TxPoolPriceLimit = core.DefaultTxPoolConfig.PriceLimit
+	c.TxPoolPriceBump = core.DefaultTxPoolConfig.PriceBump
+	c.TxPoolAccountSlots = core.DefaultTxPoolConfig.AccountSlots
+	c.TxPoolGlobalSlots = core.DefaultTxPoolConfig.GlobalSlots
+	c.TxPoolAccountQueue = core.DefaultTxPoolConfig.AccountQueue
+	c.TxPoolGlobalQueue = core.DefaultTxPoolConfig.GlobalQueue
 
 	c.APIMaxDuration.Duration = defaultApiMaxDuration
 	c.WSCPURefillRate.Duration = defaultWsCpuRefillRate

--- a/plugin/evm/config.go
+++ b/plugin/evm/config.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/ava-labs/subnet-evm/core"
 	"github.com/ava-labs/subnet-evm/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/spf13/cast"
@@ -123,7 +124,19 @@ type Config struct {
 	MetricsExpensiveEnabled bool `json:"metrics-expensive-enabled"` // Debug-level metrics that might impact runtime performance
 
 	// API Settings
-	LocalTxsEnabled          bool          `json:"local-txs-enabled"`
+	LocalTxsEnabled bool `json:"local-txs-enabled"`
+
+	TxPoolJournal   string   `json:"tx-pool-journal"`
+	TxPoolRejournal Duration `json:"tx-pool-rejournal"`
+
+	TxPoolPriceLimit uint64 `json:"tx-pool-price-limit"`
+	TxPoolPriceBump  uint64 `json:"tx-pool-price-bump"`
+
+	TxPoolAccountSlots uint64 `json:"tx-pool-account-slots"`
+	TxPoolGlobalSlots  uint64 `json:"tx-pool-global-slots"`
+	TxPoolAccountQueue uint64 `json:"tx-pool-account-queue"`
+	TxPoolGlobalQueue  uint64 `json:"tx-pool-global-queue"`
+
 	APIMaxDuration           Duration      `json:"api-max-duration"`
 	WSCPURefillRate          Duration      `json:"ws-cpu-refill-rate"`
 	WSCPUMaxStored           Duration      `json:"ws-cpu-max-stored"`
@@ -198,6 +211,16 @@ func (c *Config) SetDefaults() {
 	c.RPCGasCap = defaultRpcGasCap
 	c.RPCTxFeeCap = defaultRpcTxFeeCap
 	c.MetricsExpensiveEnabled = defaultMetricsExpensiveEnabled
+
+	c.TxPoolJournal = core.DefaultTxPoolJournal
+	c.TxPoolRejournal = Duration{Duration: core.DefaultTxPoolRejournal}
+	c.TxPoolPriceLimit = core.DefaultTxPoolPriceLimit
+	c.TxPoolPriceBump = core.DefaultTxPoolPriceBump
+	c.TxPoolAccountSlots = core.DefaultTxPoolAccountSlots
+	c.TxPoolGlobalSlots = core.DefaultTxPoolGlobalSlots
+	c.TxPoolAccountQueue = core.DefaultTxPoolAccountQueue
+	c.TxPoolGlobalQueue = core.DefaultTxPoolGlobalQueue
+
 	c.APIMaxDuration.Duration = defaultApiMaxDuration
 	c.WSCPURefillRate.Duration = defaultWsCpuRefillRate
 	c.WSCPUMaxStored.Duration = defaultWsCpuMaxStored

--- a/plugin/evm/config_test.go
+++ b/plugin/evm/config_test.go
@@ -22,8 +22,8 @@ func TestUnmarshalConfig(t *testing.T) {
 	}{
 		{
 			"string durations parsed",
-			[]byte(`{"api-max-duration": "1m", "continuous-profiler-frequency": "2m"}`),
-			Config{APIMaxDuration: Duration{1 * time.Minute}, ContinuousProfilerFrequency: Duration{2 * time.Minute}},
+			[]byte(`{"api-max-duration": "1m", "continuous-profiler-frequency": "2m", "tx-pool-rejournal": "3m30s"}`),
+			Config{APIMaxDuration: Duration{1 * time.Minute}, ContinuousProfilerFrequency: Duration{2 * time.Minute}, TxPoolRejournal: Duration{3*time.Minute + 30*time.Second}},
 			false,
 		},
 		{
@@ -34,8 +34,8 @@ func TestUnmarshalConfig(t *testing.T) {
 		},
 		{
 			"nanosecond durations parsed",
-			[]byte(`{"api-max-duration": 5000000000, "continuous-profiler-frequency": 5000000000}`),
-			Config{APIMaxDuration: Duration{5 * time.Second}, ContinuousProfilerFrequency: Duration{5 * time.Second}},
+			[]byte(`{"api-max-duration": 5000000000, "continuous-profiler-frequency": 5000000000, "tx-pool-rejournal": 9000000000}`),
+			Config{APIMaxDuration: Duration{5 * time.Second}, ContinuousProfilerFrequency: Duration{5 * time.Second}, TxPoolRejournal: Duration{9 * time.Second}},
 			false,
 		},
 		{
@@ -43,6 +43,21 @@ func TestUnmarshalConfig(t *testing.T) {
 			[]byte(`{"api-max-duration": "bad-duration"}`),
 			Config{},
 			true,
+		},
+
+		{
+			"tx pool configurations",
+			[]byte(`{"tx-pool-journal": "hello", "tx-pool-price-limit": 1, "tx-pool-price-bump": 2, "tx-pool-account-slots": 3, "tx-pool-global-slots": 4, "tx-pool-account-queue": 5, "tx-pool-global-queue": 6}`),
+			Config{
+				TxPoolJournal:      "hello",
+				TxPoolPriceLimit:   1,
+				TxPoolPriceBump:    2,
+				TxPoolAccountSlots: 3,
+				TxPoolGlobalSlots:  4,
+				TxPoolAccountQueue: 5,
+				TxPoolGlobalQueue:  6,
+			},
+			false,
 		},
 
 		{

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -311,8 +311,18 @@ func (vm *VM) Initialize(
 	vm.ethConfig.RPCGasCap = vm.config.RPCGasCap
 	vm.ethConfig.RPCEVMTimeout = vm.config.APIMaxDuration.Duration
 	vm.ethConfig.RPCTxFeeCap = vm.config.RPCTxFeeCap
-	vm.ethConfig.TxPool.NoLocals = !vm.config.LocalTxsEnabled
+
 	vm.ethConfig.TxPool.Locals = vm.config.PriorityRegossipAddresses
+	vm.ethConfig.TxPool.NoLocals = !vm.config.LocalTxsEnabled
+	vm.ethConfig.TxPool.Journal = vm.config.TxPoolJournal
+	vm.ethConfig.TxPool.Rejournal = vm.config.TxPoolRejournal.Duration
+	vm.ethConfig.TxPool.PriceLimit = vm.config.TxPoolPriceLimit
+	vm.ethConfig.TxPool.PriceBump = vm.config.TxPoolPriceBump
+	vm.ethConfig.TxPool.AccountSlots = vm.config.TxPoolAccountSlots
+	vm.ethConfig.TxPool.GlobalSlots = vm.config.TxPoolGlobalSlots
+	vm.ethConfig.TxPool.AccountQueue = vm.config.TxPoolAccountQueue
+	vm.ethConfig.TxPool.GlobalQueue = vm.config.TxPoolGlobalQueue
+
 	vm.ethConfig.AllowUnfinalizedQueries = vm.config.AllowUnfinalizedQueries
 	vm.ethConfig.AllowUnprotectedTxs = vm.config.AllowUnprotectedTxs
 	vm.ethConfig.AllowUnprotectedTxHashes = vm.config.AllowUnprotectedTxHashes


### PR DESCRIPTION
## Why this should be merged

To avoid making manual patches for load testing: https://github.com/ava-labs/subnet-evm/tree/fix-load-test

## How this works

Can be set via chain config

## How this was tested

Unit tests.