### PR TITLE
use ubuntu 20.04 for making releases

### DIFF
--- a/.github/workflows/lint-tests-release.yml
+++ b/.github/workflows/lint-tests-release.yml
@@ -89,7 +89,7 @@ jobs:
 
   release:
     # needs: [lint_test, unit_test, e2e_test, simulator_test]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Git checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
## Why this should be merged

subnet-evm as it is currently compiled for release, uses ubuntu-latest libraries not compatible with ubuntu 20.04

## How this works

## How this was tested
