### PR TITLE
use ubuntu 20.04 for making releases

### DIFF
--- a/.github/workflows/lint-tests-release.yml
+++ b/.github/workflows/lint-tests-release.yml
@@ -89,7 +89,7 @@ jobs:
 
   release:
     # needs: [lint_test, unit_test, e2e_test, simulator_test]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Git checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
## Why this should be merged

Ubuntu latest environment started to migrate further into 22.04, and the binaries compiled on it are incompatible with 20.04 at a dynamic lib level.
Compiling using 20.04 gets a binary that is ok for 20.04 and also for 22.04 due to the later supporting old binaries. 

## How this works

## How this was tested
