### PR TITLE
add reward manager key string

### DIFF
--- a/params/precompile_config.go
+++ b/params/precompile_config.go
@@ -38,6 +38,8 @@ func (k precompileKey) String() string {
 		return "txAllowList"
 	case feeManagerKey:
 		return "feeManager"
+	case rewardManagerKey:
+		return "rewardManager"
 		// ADD YOUR PRECOMPILE HERE
 		/*
 			case {yourPrecompile}Key:


### PR DESCRIPTION
## Why this should be merged

Prints out reward manager key

## How this works

Adds reward manager key to String method of precompileKeys

## How this was tested

Reactivated the precompile and seen key is properly shown.
