### PR TITLE
Bump avalanchego to v1.9.5

### DIFF
--- a/cmd/simulator/go.mod
+++ b/cmd/simulator/go.mod
@@ -15,7 +15,7 @@ replace github.com/ava-labs/subnet-evm => ../..
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.10.0 // indirect
-	github.com/ava-labs/avalanchego v1.9.5-rc.0 // indirect
+	github.com/ava-labs/avalanchego v1.9.5 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.2.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.3 // indirect

--- a/cmd/simulator/go.mod
+++ b/cmd/simulator/go.mod
@@ -15,7 +15,7 @@ replace github.com/ava-labs/subnet-evm => ../..
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.10.0 // indirect
-	github.com/ava-labs/avalanchego v1.9.4 // indirect
+	github.com/ava-labs/avalanchego v1.9.5-rc.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.2.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.3 // indirect

--- a/cmd/simulator/go.sum
+++ b/cmd/simulator/go.sum
@@ -45,8 +45,8 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk5
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah4HI848JfFxHt+iPb26b4zyfspmqY0/8=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/ava-labs/avalanchego v1.9.4 h1:z5tE/vUGzUQflqv3mn6X5E1VTCZHYhuD36idOyPNRrc=
-github.com/ava-labs/avalanchego v1.9.4/go.mod h1:H4pMTYzgudfPs9WX+KXI0nCiUGNkdgPWOwm1nqzGibQ=
+github.com/ava-labs/avalanchego v1.9.5-rc.0 h1:3e/QX54BBI2rYDqI+V4xBji/AzPGUls2cXRkdEiXiNU=
+github.com/ava-labs/avalanchego v1.9.5-rc.0/go.mod h1:H4pMTYzgudfPs9WX+KXI0nCiUGNkdgPWOwm1nqzGibQ=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=

--- a/cmd/simulator/go.sum
+++ b/cmd/simulator/go.sum
@@ -45,8 +45,8 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk5
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah4HI848JfFxHt+iPb26b4zyfspmqY0/8=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/ava-labs/avalanchego v1.9.5-rc.0 h1:3e/QX54BBI2rYDqI+V4xBji/AzPGUls2cXRkdEiXiNU=
-github.com/ava-labs/avalanchego v1.9.5-rc.0/go.mod h1:H4pMTYzgudfPs9WX+KXI0nCiUGNkdgPWOwm1nqzGibQ=
+github.com/ava-labs/avalanchego v1.9.5 h1:0uykbcKFocUL7U7SO/PGrXSMLX9RSt8xo5rj84bI3YY=
+github.com/ava-labs/avalanchego v1.9.5/go.mod h1:1f/z4CBcz/VhNlOTj607dQj5ZQQaZQO/RO8sEa0EgvA=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=

--- a/compatibility.json
+++ b/compatibility.json
@@ -1,5 +1,6 @@
 {
   "rpcChainVMProtocolVersion": {
+    "v0.4.7": 21,
     "v0.4.6": 20,
     "v0.4.5": 20,
     "v0.4.4": 19,

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/VictoriaMetrics/fastcache v1.10.0
 	github.com/ava-labs/avalanche-network-runner-sdk v0.3.0
-	github.com/ava-labs/avalanchego v1.9.5-rc.1
+	github.com/ava-labs/avalanchego v1.9.5-rc.7
 	github.com/cespare/cp v0.1.0
 	github.com/creack/pty v1.1.18
 	github.com/davecgh/go-spew v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/VictoriaMetrics/fastcache v1.10.0
 	github.com/ava-labs/avalanche-network-runner-sdk v0.3.0
-	github.com/ava-labs/avalanchego v1.9.5-rc.0
+	github.com/ava-labs/avalanchego v1.9.5-rc.1
 	github.com/cespare/cp v0.1.0
 	github.com/creack/pty v1.1.18
 	github.com/davecgh/go-spew v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/VictoriaMetrics/fastcache v1.10.0
 	github.com/ava-labs/avalanche-network-runner-sdk v0.3.0
-	github.com/ava-labs/avalanchego v1.9.5-rc.7
+	github.com/ava-labs/avalanchego v1.9.5
 	github.com/cespare/cp v0.1.0
 	github.com/creack/pty v1.1.18
 	github.com/davecgh/go-spew v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/VictoriaMetrics/fastcache v1.10.0
 	github.com/ava-labs/avalanche-network-runner-sdk v0.3.0
-	github.com/ava-labs/avalanchego v1.9.4
+	github.com/ava-labs/avalanchego v1.9.5-rc.0
 	github.com/cespare/cp v0.1.0
 	github.com/creack/pty v1.1.18
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/ava-labs/avalanche-network-runner-sdk v0.3.0 h1:TVi9JEdKNU/RevYZ9PyW4pULbEdS+KQDA9Ki2DUvuAs=
 github.com/ava-labs/avalanche-network-runner-sdk v0.3.0/go.mod h1:SgKJvtqvgo/Bl/c8fxEHCLaSxEbzimYfBopcfrajxQk=
-github.com/ava-labs/avalanchego v1.9.5-rc.1 h1:eeJpDQaWjIWrU6Bb0PjkRrjW67cUlSzEPa0rqQGAA9E=
-github.com/ava-labs/avalanchego v1.9.5-rc.1/go.mod h1:97/QNxmvdCFPlbXhjBCpSseq2X7ZWEnbPIyO8OL0AlQ=
+github.com/ava-labs/avalanchego v1.9.5-rc.7 h1:BOAOjW4vBjiSAYy8PT/F6H/1sUg44tMj9hEZH8TUEDI=
+github.com/ava-labs/avalanchego v1.9.5-rc.7/go.mod h1:97/QNxmvdCFPlbXhjBCpSseq2X7ZWEnbPIyO8OL0AlQ=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=

--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/ava-labs/avalanche-network-runner-sdk v0.3.0 h1:TVi9JEdKNU/RevYZ9PyW4pULbEdS+KQDA9Ki2DUvuAs=
 github.com/ava-labs/avalanche-network-runner-sdk v0.3.0/go.mod h1:SgKJvtqvgo/Bl/c8fxEHCLaSxEbzimYfBopcfrajxQk=
-github.com/ava-labs/avalanchego v1.9.5-rc.7 h1:BOAOjW4vBjiSAYy8PT/F6H/1sUg44tMj9hEZH8TUEDI=
-github.com/ava-labs/avalanchego v1.9.5-rc.7/go.mod h1:97/QNxmvdCFPlbXhjBCpSseq2X7ZWEnbPIyO8OL0AlQ=
+github.com/ava-labs/avalanchego v1.9.5 h1:0uykbcKFocUL7U7SO/PGrXSMLX9RSt8xo5rj84bI3YY=
+github.com/ava-labs/avalanchego v1.9.5/go.mod h1:1f/z4CBcz/VhNlOTj607dQj5ZQQaZQO/RO8sEa0EgvA=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=

--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/ava-labs/avalanche-network-runner-sdk v0.3.0 h1:TVi9JEdKNU/RevYZ9PyW4pULbEdS+KQDA9Ki2DUvuAs=
 github.com/ava-labs/avalanche-network-runner-sdk v0.3.0/go.mod h1:SgKJvtqvgo/Bl/c8fxEHCLaSxEbzimYfBopcfrajxQk=
-github.com/ava-labs/avalanchego v1.9.5-rc.0 h1:3e/QX54BBI2rYDqI+V4xBji/AzPGUls2cXRkdEiXiNU=
-github.com/ava-labs/avalanchego v1.9.5-rc.0/go.mod h1:H4pMTYzgudfPs9WX+KXI0nCiUGNkdgPWOwm1nqzGibQ=
+github.com/ava-labs/avalanchego v1.9.5-rc.1 h1:eeJpDQaWjIWrU6Bb0PjkRrjW67cUlSzEPa0rqQGAA9E=
+github.com/ava-labs/avalanchego v1.9.5-rc.1/go.mod h1:97/QNxmvdCFPlbXhjBCpSseq2X7ZWEnbPIyO8OL0AlQ=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=

--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/ava-labs/avalanche-network-runner-sdk v0.3.0 h1:TVi9JEdKNU/RevYZ9PyW4pULbEdS+KQDA9Ki2DUvuAs=
 github.com/ava-labs/avalanche-network-runner-sdk v0.3.0/go.mod h1:SgKJvtqvgo/Bl/c8fxEHCLaSxEbzimYfBopcfrajxQk=
-github.com/ava-labs/avalanchego v1.9.4 h1:z5tE/vUGzUQflqv3mn6X5E1VTCZHYhuD36idOyPNRrc=
-github.com/ava-labs/avalanchego v1.9.4/go.mod h1:H4pMTYzgudfPs9WX+KXI0nCiUGNkdgPWOwm1nqzGibQ=
+github.com/ava-labs/avalanchego v1.9.5-rc.0 h1:3e/QX54BBI2rYDqI+V4xBji/AzPGUls2cXRkdEiXiNU=
+github.com/ava-labs/avalanchego v1.9.5-rc.0/go.mod h1:H4pMTYzgudfPs9WX+KXI0nCiUGNkdgPWOwm1nqzGibQ=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=

--- a/params/precompile_config.go
+++ b/params/precompile_config.go
@@ -38,6 +38,8 @@ func (k precompileKey) String() string {
 		return "txAllowList"
 	case feeManagerKey:
 		return "feeManager"
+	case rewardManagerKey:
+		return "rewardManager"
 		// ADD YOUR PRECOMPILE HERE
 		/*
 			case {yourPrecompile}Key:

--- a/plugin/evm/version.go
+++ b/plugin/evm/version.go
@@ -11,7 +11,7 @@ var (
 	// GitCommit is set by the build script
 	GitCommit string
 	// Version is the version of Subnet EVM
-	Version string = "v0.4.6"
+	Version string = "v0.4.7"
 )
 
 func init() {

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -35,13 +35,14 @@ import (
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/snow/choices"
 	"github.com/ava-labs/avalanchego/snow/consensus/snowman"
+	"github.com/ava-labs/avalanchego/snow/validators"
+	avalancheConstants "github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/formatting"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/version"
 	"github.com/ava-labs/avalanchego/vms/components/chain"
 
 	engCommon "github.com/ava-labs/avalanchego/snow/engine/common"
-	avaConstants "github.com/ava-labs/avalanchego/utils/constants"
 
 	"github.com/ava-labs/subnet-evm/consensus/dummy"
 	"github.com/ava-labs/subnet-evm/constants"
@@ -119,11 +120,17 @@ func NewContext() *snow.Context {
 	_ = aliaser.Alias(testCChainID, testCChainID.String())
 	_ = aliaser.Alias(testXChainID, "X")
 	_ = aliaser.Alias(testXChainID, testXChainID.String())
-	ctx.SNLookup = &snLookup{
-		chainsToSubnet: map[ids.ID]ids.ID{
-			avaConstants.PlatformChainID: avaConstants.PrimaryNetworkID,
-			testXChainID:                 avaConstants.PrimaryNetworkID,
-			testCChainID:                 avaConstants.PrimaryNetworkID,
+	ctx.ValidatorState = &validators.TestState{
+		GetSubnetIDF: func(_ context.Context, chainID ids.ID) (ids.ID, error) {
+			subnetID, ok := map[ids.ID]ids.ID{
+				avalancheConstants.PlatformChainID: avalancheConstants.PrimaryNetworkID,
+				testXChainID:                       avalancheConstants.PrimaryNetworkID,
+				testCChainID:                       avalancheConstants.PrimaryNetworkID,
+			}[chainID]
+			if !ok {
+				return ids.Empty, errors.New("unknown chain")
+			}
+			return subnetID, nil
 		},
 	}
 	return ctx

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Set up the versions to be used
-subnet_evm_version=${SUBNET_EVM_VERSION:-'v0.4.6'}
+subnet_evm_version=${SUBNET_EVM_VERSION:-'v0.4.7'}
 # Don't export them as they're used in the context of other calls
 avalanche_version=${AVALANCHE_VERSION:-'v1.9.5'}
 network_runner_version=${NETWORK_RUNNER_VERSION:-'35be10cd3867a94fbe960a1c14a455f179de60d9'}

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -3,7 +3,7 @@
 # Set up the versions to be used
 subnet_evm_version=${SUBNET_EVM_VERSION:-'v0.4.6'}
 # Don't export them as they're used in the context of other calls
-avalanche_version=${AVALANCHE_VERSION:-'v1.9.5-rc.1'}
+avalanche_version=${AVALANCHE_VERSION:-'v1.9.5'}
 network_runner_version=${NETWORK_RUNNER_VERSION:-'35be10cd3867a94fbe960a1c14a455f179de60d9'}
 ginkgo_version=${GINKGO_VERSION:-'v2.2.0'}
 

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -3,7 +3,7 @@
 # Set up the versions to be used
 subnet_evm_version=${SUBNET_EVM_VERSION:-'v0.4.6'}
 # Don't export them as they're used in the context of other calls
-avalanche_version=${AVALANCHE_VERSION:-'v1.9.5-rc.0'}
+avalanche_version=${AVALANCHE_VERSION:-'v1.9.5-rc.1'}
 network_runner_version=${NETWORK_RUNNER_VERSION:-'35be10cd3867a94fbe960a1c14a455f179de60d9'}
 ginkgo_version=${GINKGO_VERSION:-'v2.2.0'}
 

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -3,7 +3,7 @@
 # Set up the versions to be used
 subnet_evm_version=${SUBNET_EVM_VERSION:-'v0.4.6'}
 # Don't export them as they're used in the context of other calls
-avalanche_version=${AVALANCHE_VERSION:-'v1.9.4'}
+avalanche_version=${AVALANCHE_VERSION:-'v1.9.5-rc.0'}
 network_runner_version=${NETWORK_RUNNER_VERSION:-'35be10cd3867a94fbe960a1c14a455f179de60d9'}
 ginkgo_version=${GINKGO_VERSION:-'v2.2.0'}
 


### PR DESCRIPTION
This PR bumps the avalanchego dependency to v1.9.5-rc.0, which includes a change to the SNLookup to instead use the validator state in the `snow.Context`.