### PR TITLE
rework on panics in precompiles

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -307,7 +307,10 @@ func (g *Genesis) ToBlock(db ethdb.Database) *types.Block {
 	}
 
 	// Configure any stateful precompiles that should be enabled in the genesis.
-	g.Config.CheckConfigurePrecompiles(nil, types.NewBlockWithHeader(head), statedb)
+	err = g.Config.ConfigurePrecompiles(nil, types.NewBlockWithHeader(head), statedb)
+	if err != nil {
+		panic(fmt.Sprintf("unable to configure precompiles in genesis block: %v", err))
+	}
 
 	// Do custom allocation after airdrop in case an address shows up in standard
 	// allocation

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -81,8 +81,7 @@ func (p *StateProcessor) Process(block *types.Block, parent *types.Header, state
 	// Configure any stateful precompiles that should go into effect during this block.
 	err := p.config.ConfigurePrecompiles(new(big.Int).SetUint64(parent.Time), block, statedb)
 	if err != nil {
-		werr := fmt.Errorf("could not configure precompiles: %w", err)
-		log.Error("failed to process the state changes", "err", werr)
+		log.Error("failed to process the state changes", "err", err)
 		return nil, nil, 0, err
 	}
 

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -37,6 +37,7 @@ import (
 	"github.com/ava-labs/subnet-evm/params"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 // StateProcessor is a basic Processor, which takes care of transitioning
@@ -79,9 +80,10 @@ func (p *StateProcessor) Process(block *types.Block, parent *types.Header, state
 
 	// Configure any stateful precompiles that should go into effect during this block.
 	err := p.config.ConfigurePrecompiles(new(big.Int).SetUint64(parent.Time), block, statedb)
-	// ASK: Should we panic instead?
 	if err != nil {
-		return nil, nil, 0, fmt.Errorf("could not configure precompiles: %w", err)
+		werr := fmt.Errorf("could not configure precompiles: %w", err)
+		log.Error("failed to process the state changes", "err", werr)
+		return nil, nil, 0, err
 	}
 
 	blockContext := NewEVMBlockContext(header, p.bc, nil)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -78,7 +78,11 @@ func (p *StateProcessor) Process(block *types.Block, parent *types.Header, state
 	)
 
 	// Configure any stateful precompiles that should go into effect during this block.
-	p.config.CheckConfigurePrecompiles(new(big.Int).SetUint64(parent.Time), block, statedb)
+	err := p.config.ConfigurePrecompiles(new(big.Int).SetUint64(parent.Time), block, statedb)
+	// ASK: Should we panic instead?
+	if err != nil {
+		return nil, nil, 0, fmt.Errorf("could not configure precompiles: %w", err)
+	}
 
 	blockContext := NewEVMBlockContext(header, p.bc, nil)
 	vmenv := vm.NewEVM(blockContext, vm.TxContext{}, statedb, p.config, cfg)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -81,7 +81,7 @@ func (p *StateProcessor) Process(block *types.Block, parent *types.Header, state
 	// Configure any stateful precompiles that should go into effect during this block.
 	err := p.config.ConfigurePrecompiles(new(big.Int).SetUint64(parent.Time), block, statedb)
 	if err != nil {
-		log.Error("failed to process the state changes", "err", err)
+		log.Error("failed to configure precompiles processing block", "hash", block.Hash(), "number", block.NumberU64(), "timestamp", block.Time(), "err", err)
 		return nil, nil, 0, err
 	}
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -186,9 +186,8 @@ func (w *worker) commitNewWork() (*types.Block, error) {
 	// Configure any stateful precompiles that should go into effect during this block.
 	err = w.chainConfig.ConfigurePrecompiles(new(big.Int).SetUint64(parent.Time()), types.NewBlockWithHeader(header), env.state)
 	if err != nil {
-		werr := fmt.Errorf("failed to configure precompiles: %w", err)
-		log.Error("failed to commit new work", "err", werr)
-		return nil, werr
+		log.Error("failed to commit new work", "err", err)
+		return nil, err
 	}
 
 	// Fill the block with all available pending transactions.

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -186,7 +186,7 @@ func (w *worker) commitNewWork() (*types.Block, error) {
 	// Configure any stateful precompiles that should go into effect during this block.
 	err = w.chainConfig.ConfigurePrecompiles(new(big.Int).SetUint64(parent.Time()), types.NewBlockWithHeader(header), env.state)
 	if err != nil {
-		log.Error("failed to commit new work", "err", err)
+		log.Error("failed to configure precompiles mining new block", "parent", parent.Hash(), "number", header.Number, "timestamp", header.Time, "err", err)
 		return nil, err
 	}
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -186,7 +186,9 @@ func (w *worker) commitNewWork() (*types.Block, error) {
 	// Configure any stateful precompiles that should go into effect during this block.
 	err = w.chainConfig.ConfigurePrecompiles(new(big.Int).SetUint64(parent.Time()), types.NewBlockWithHeader(header), env.state)
 	if err != nil {
-		return nil, fmt.Errorf("failed to configure precompiles: %w", err)
+		werr := fmt.Errorf("failed to configure precompiles: %w", err)
+		log.Error("failed to commit new work", "err", werr)
+		return nil, werr
 	}
 
 	// Fill the block with all available pending transactions.

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -184,7 +184,10 @@ func (w *worker) commitNewWork() (*types.Block, error) {
 		return nil, fmt.Errorf("failed to create new current environment: %w", err)
 	}
 	// Configure any stateful precompiles that should go into effect during this block.
-	w.chainConfig.CheckConfigurePrecompiles(new(big.Int).SetUint64(parent.Time()), types.NewBlockWithHeader(header), env.state)
+	err = w.chainConfig.ConfigurePrecompiles(new(big.Int).SetUint64(parent.Time()), types.NewBlockWithHeader(header), env.state)
+	if err != nil {
+		return nil, fmt.Errorf("failed to configure precompiles: %w", err)
+	}
 
 	// Fill the block with all available pending transactions.
 	pending := w.eth.TxPool().Pending(true)

--- a/params/precompile_config.go
+++ b/params/precompile_config.go
@@ -286,7 +286,7 @@ func (c *ChainConfig) ConfigurePrecompiles(parentTimestamp *big.Int, blockContex
 			} else {
 				log.Info("Activating new precompile", "precompileAddress", address, "config", config)
 				if err := precompile.Configure(c, blockContext, config, statedb); err != nil {
-					return err
+					return fmt.Errorf("could not configure precompile, precompileAddress: %s, reason: %w", address, err)
 				}
 			}
 		}

--- a/params/precompile_config.go
+++ b/params/precompile_config.go
@@ -346,13 +346,13 @@ func (c *ChainConfig) EnabledStatefulPrecompiles(blockTimestamp *big.Int) []prec
 	return statefulPrecompileConfigs
 }
 
-// CheckConfigurePrecompiles checks if any of the precompiles specified by the chain config are enabled or disabled by the block
+// ConfigurePrecompiles checks if any of the precompiles specified by the chain config are enabled or disabled by the block
 // transition from [parentTimestamp] to the timestamp set in [blockContext]. If this is the case, it calls [Configure]
 // or [Deconfigure] to apply the necessary state transitions for the upgrade.
 // This function is called:
 // - within genesis setup to configure the starting state for precompiles enabled at genesis,
 // - during block processing to update the state before processing the given block.
-func (c *ChainConfig) CheckConfigurePrecompiles(parentTimestamp *big.Int, blockContext precompile.BlockContext, statedb precompile.StateDB) {
+func (c *ChainConfig) ConfigurePrecompiles(parentTimestamp *big.Int, blockContext precompile.BlockContext, statedb precompile.StateDB) error {
 	blockTimestamp := blockContext.Timestamp()
 	for _, key := range precompileKeys { // Note: configure precompiles in a deterministic order.
 		for _, config := range c.getActivatingPrecompileConfigs(parentTimestamp, blockTimestamp, key, c.PrecompileUpgrades) {
@@ -368,8 +368,11 @@ func (c *ChainConfig) CheckConfigurePrecompiles(parentTimestamp *big.Int, blockC
 				statedb.Finalise(true)
 			} else {
 				log.Info("Activating new precompile", "name", key, "config", config)
-				precompile.Configure(c, blockContext, config, statedb)
+				if err := precompile.Configure(c, blockContext, config, statedb); err != nil {
+					return err
+				}
 			}
 		}
 	}
+	return nil
 }

--- a/precompile/allow_list.go
+++ b/precompile/allow_list.go
@@ -221,7 +221,7 @@ func createAllowListPrecompile(precompileAddr common.Address) StatefulPrecompile
 	// Construct the contract with no fallback function.
 	allowListFuncs := createAllowListFunctions(precompileAddr)
 	contract, err := NewStatefulPrecompileContract(nil, allowListFuncs)
-	// Change this to be returned as an error after refactoring this precompile
+	// TODO Change this to be returned as an error after refactoring this precompile
 	// to use the new precompile template.
 	if err != nil {
 		panic(err)

--- a/precompile/allow_list.go
+++ b/precompile/allow_list.go
@@ -46,13 +46,14 @@ type AllowListConfig struct {
 
 // Configure initializes the address space of [precompileAddr] by initializing the role of each of
 // the addresses in [AllowListAdmins].
-func (c *AllowListConfig) Configure(state StateDB, precompileAddr common.Address) {
+func (c *AllowListConfig) Configure(state StateDB, precompileAddr common.Address) error {
 	for _, enabledAddr := range c.EnabledAddresses {
 		setAllowListRole(state, precompileAddr, enabledAddr, AllowListEnabled)
 	}
 	for _, adminAddr := range c.AllowListAdmins {
 		setAllowListRole(state, precompileAddr, adminAddr, AllowListAdmin)
 	}
+	return nil
 }
 
 // Equal returns true iff [other] has the same admins in the same order in its allow list.
@@ -219,7 +220,12 @@ func createReadAllowList(precompileAddr common.Address) RunStatefulPrecompileFun
 func createAllowListPrecompile(precompileAddr common.Address) StatefulPrecompiledContract {
 	// Construct the contract with no fallback function.
 	allowListFuncs := createAllowListFunctions(precompileAddr)
-	contract := newStatefulPrecompileWithFunctionSelectors(nil, allowListFuncs)
+	contract, err := NewStatefulPrecompileContract(nil, allowListFuncs)
+	// Change this to be returned as an error after refactoring this precompile
+	// to use the new precompile template.
+	if err != nil {
+		panic(err)
+	}
 	return contract
 }
 

--- a/precompile/contract.go
+++ b/precompile/contract.go
@@ -98,9 +98,9 @@ type statefulPrecompileWithFunctionSelectors struct {
 	functions map[string]*statefulPrecompileFunction
 }
 
-// newStatefulPrecompileWithFunctionSelectors generates new StatefulPrecompile using [functions] as the available functions and [fallback]
+// NewStatefulPrecompileContract generates new StatefulPrecompile using [functions] as the available functions and [fallback]
 // as an optional fallback if there is no input data. Note: the selector of [fallback] will be ignored, so it is required to be left empty.
-func newStatefulPrecompileWithFunctionSelectors(fallback RunStatefulPrecompileFunc, functions []*statefulPrecompileFunction) StatefulPrecompiledContract {
+func NewStatefulPrecompileContract(fallback RunStatefulPrecompileFunc, functions []*statefulPrecompileFunction) (StatefulPrecompiledContract, error) {
 	// Construct the contract and populate [functions].
 	contract := &statefulPrecompileWithFunctionSelectors{
 		fallback:  fallback,
@@ -109,12 +109,15 @@ func newStatefulPrecompileWithFunctionSelectors(fallback RunStatefulPrecompileFu
 	for _, function := range functions {
 		_, exists := contract.functions[string(function.selector)]
 		if exists {
-			panic(fmt.Errorf("cannot create stateful precompile with duplicated function selector: %q", function.selector))
+			return nil, fmt.Errorf("cannot create stateful precompile with duplicated function selector: %q", function.selector)
+		}
+		if function == nil {
+			return nil, fmt.Errorf("cannot create stateful precompile with nil function, selector: %q", function.selector)
 		}
 		contract.functions[string(function.selector)] = function
 	}
 
-	return contract
+	return contract, nil
 }
 
 // Run selects the function using the 4 byte function selector at the start of the input and executes the underlying function on the

--- a/precompile/contract.go
+++ b/precompile/contract.go
@@ -111,9 +111,6 @@ func NewStatefulPrecompileContract(fallback RunStatefulPrecompileFunc, functions
 		if exists {
 			return nil, fmt.Errorf("cannot create stateful precompile with duplicated function selector: %q", function.selector)
 		}
-		if function == nil {
-			return nil, fmt.Errorf("cannot create stateful precompile with nil function, selector: %q", function.selector)
-		}
 		contract.functions[string(function.selector)] = function
 	}
 

--- a/precompile/contract_deployer_allow_list.go
+++ b/precompile/contract_deployer_allow_list.go
@@ -52,8 +52,8 @@ func (c *ContractDeployerAllowListConfig) Address() common.Address {
 }
 
 // Configure configures [state] with the desired admins based on [c].
-func (c *ContractDeployerAllowListConfig) Configure(_ ChainConfig, state StateDB, _ BlockContext) {
-	c.AllowListConfig.Configure(state, ContractDeployerAllowListAddress)
+func (c *ContractDeployerAllowListConfig) Configure(_ ChainConfig, state StateDB, _ BlockContext) error {
+	return c.AllowListConfig.Configure(state, ContractDeployerAllowListAddress)
 }
 
 // Contract returns the singleton stateful precompiled contract to be used for the allow list.

--- a/precompile/fee_config_manager.go
+++ b/precompile/fee_config_manager.go
@@ -114,12 +114,12 @@ func (c *FeeConfigManagerConfig) Configure(chainConfig ChainConfig, state StateD
 	if c.InitialFeeConfig != nil {
 		if err := StoreFeeConfig(state, *c.InitialFeeConfig, blockContext); err != nil {
 			// This should not happen since we already checked this config with Verify()
-			return fmt.Errorf("invalid feeConfig provided: %w", err)
+			return fmt.Errorf("cannot configure given initial fee config: %w", err)
 		}
 	} else {
 		if err := StoreFeeConfig(state, chainConfig.GetFeeConfig(), blockContext); err != nil {
 			// This should not happen since we already checked the chain config in the genesis creation.
-			return fmt.Errorf("invalid feeConfig provided in chainConfig: %w", err)
+			return fmt.Errorf("cannot configure fee config in chain config: %w", err)
 		}
 	}
 	return c.AllowListConfig.Configure(state, FeeConfigManagerAddress)
@@ -277,7 +277,7 @@ func GetFeeConfigLastChangedAt(stateDB StateDB) *big.Int {
 // A validation on [feeConfig] is done before storing.
 func StoreFeeConfig(stateDB StateDB, feeConfig commontype.FeeConfig, blockContext BlockContext) error {
 	if err := feeConfig.Verify(); err != nil {
-		return err
+		return fmt.Errorf("cannot verify fee config: %w", err)
 	}
 
 	for i := minFeeConfigFieldKey; i <= numFeeConfigField; i++ {

--- a/precompile/fee_config_manager.go
+++ b/precompile/fee_config_manager.go
@@ -390,7 +390,7 @@ func createFeeConfigManagerPrecompile(precompileAddr common.Address) StatefulPre
 	feeConfigManagerFunctions = append(feeConfigManagerFunctions, setFeeConfigFunc, getFeeConfigFunc, getFeeConfigLastChangedAtFunc)
 	// Construct the contract with no fallback function.
 	contract, err := NewStatefulPrecompileContract(nil, feeConfigManagerFunctions)
-	// Change this to be returned as an error after refactoring this precompile
+	// TODO Change this to be returned as an error after refactoring this precompile
 	// to use the new precompile template.
 	if err != nil {
 		panic(err)

--- a/precompile/fee_config_manager.go
+++ b/precompile/fee_config_manager.go
@@ -231,7 +231,7 @@ func UnpackFeeConfigInput(input []byte) (commontype.FeeConfig, error) {
 		case blockGasCostStepKey:
 			feeConfig.BlockGasCostStep = new(big.Int).SetBytes(packedElement)
 		default:
-			// this should not ever happen. keep this as panic.
+			// This should never encounter an unknown fee config key
 			panic(fmt.Sprintf("unknown fee config key: %d", i))
 		}
 	}

--- a/precompile/fee_config_manager.go
+++ b/precompile/fee_config_manager.go
@@ -261,7 +261,7 @@ func GetStoredFeeConfig(stateDB StateDB) commontype.FeeConfig {
 		case blockGasCostStepKey:
 			feeConfig.BlockGasCostStep = new(big.Int).Set(val.Big())
 		default:
-			// this should not ever happen. keep this as panic.
+			// This should never encounter an unknown fee config key
 			panic(fmt.Sprintf("unknown fee config key: %d", i))
 		}
 	}
@@ -300,7 +300,7 @@ func StoreFeeConfig(stateDB StateDB, feeConfig commontype.FeeConfig, blockContex
 		case blockGasCostStepKey:
 			input = common.BigToHash(feeConfig.BlockGasCostStep)
 		default:
-			// this should not ever happen. keep this as panic.
+			// this should not ever happen.
 			panic(fmt.Sprintf("unknown fee config key: %d", i))
 		}
 		stateDB.SetState(FeeConfigManagerAddress, common.Hash{byte(i)}, input)

--- a/precompile/fee_config_manager.go
+++ b/precompile/fee_config_manager.go
@@ -300,7 +300,7 @@ func StoreFeeConfig(stateDB StateDB, feeConfig commontype.FeeConfig, blockContex
 		case blockGasCostStepKey:
 			input = common.BigToHash(feeConfig.BlockGasCostStep)
 		default:
-			// this should not ever happen.
+			// This should never encounter an unknown fee config key
 			panic(fmt.Sprintf("unknown fee config key: %d", i))
 		}
 		stateDB.SetState(FeeConfigManagerAddress, common.Hash{byte(i)}, input)

--- a/precompile/stateful_precompile_config.go
+++ b/precompile/stateful_precompile_config.go
@@ -32,7 +32,7 @@ type StatefulPrecompileConfig interface {
 	// Configure is called on the first block where the stateful precompile should be enabled. This
 	// provides the config the ability to set its initial state and should only modify the state within
 	// its own address space.
-	Configure(ChainConfig, StateDB, BlockContext)
+	Configure(ChainConfig, StateDB, BlockContext) error
 	// Contract returns a thread-safe singleton that can be used as the StatefulPrecompiledContract when
 	// this config is enabled.
 	Contract() StatefulPrecompiledContract
@@ -45,7 +45,7 @@ type StatefulPrecompileConfig interface {
 // Configure sets the nonce and code to non-empty values then calls Configure on [precompileConfig] to make the necessary
 // state update to enable the StatefulPrecompile.
 // Assumes that [precompileConfig] is non-nil.
-func Configure(chainConfig ChainConfig, blockContext BlockContext, precompileConfig StatefulPrecompileConfig, state StateDB) {
+func Configure(chainConfig ChainConfig, blockContext BlockContext, precompileConfig StatefulPrecompileConfig, state StateDB) error {
 	// Set the nonce of the precompile's address (as is done when a contract is created) to ensure
 	// that it is marked as non-empty and will not be cleaned up when the statedb is finalized.
 	state.SetNonce(precompileConfig.Address(), 1)
@@ -53,5 +53,5 @@ func Configure(chainConfig ChainConfig, blockContext BlockContext, precompileCon
 	// can be called from within Solidity contracts. Solidity adds a check before invoking a contract to ensure
 	// that it does not attempt to invoke a non-existent contract.
 	state.SetCode(precompileConfig.Address(), []byte{0x1})
-	precompileConfig.Configure(chainConfig, state, blockContext)
+	return precompileConfig.Configure(chainConfig, state, blockContext)
 }

--- a/precompile/tx_allow_list.go
+++ b/precompile/tx_allow_list.go
@@ -55,8 +55,8 @@ func (c *TxAllowListConfig) Address() common.Address {
 }
 
 // Configure configures [state] with the desired admins based on [c].
-func (c *TxAllowListConfig) Configure(_ ChainConfig, state StateDB, _ BlockContext) {
-	c.AllowListConfig.Configure(state, TxAllowListAddress)
+func (c *TxAllowListConfig) Configure(_ ChainConfig, state StateDB, _ BlockContext) error {
+	return c.AllowListConfig.Configure(state, TxAllowListAddress)
 }
 
 // Contract returns the singleton stateful precompiled contract to be used for the allow list.

--- a/precompile/utils.go
+++ b/precompile/utils.go
@@ -17,7 +17,6 @@ var functionSignatureRegex = regexp.MustCompile(`[\w]+\(((([\w]+)?)|((([\w]+),)+
 // CalculateFunctionSelector returns the 4 byte function selector that results from [functionSignature]
 // Ex. the function setBalance(addr address, balance uint256) should be passed in as the string:
 // "setBalance(address,uint256)"
-// TODO: remove this after moving to ABI based function selectors.
 func CalculateFunctionSelector(functionSignature string) []byte {
 	if !functionSignatureRegex.MatchString(functionSignature) {
 		panic(fmt.Errorf("invalid function signature: %q", functionSignature))


### PR DESCRIPTION
## Why this should be merged

Removes panics in precompile functions and returns errors instead. Also refactors precompile create functions to make it more compact.

## How this works

Changes `Configure` and `CheckConfigurePrecompiles` functions to return an error instead of panicking. 

Also refactors `create{Name}Precompile` functions to be more compact and clean-looking.

## How this was tested

Locally generated reward manager precompile with tool and compared. 

