### PR TITLE
introduce precompiles as registrable modules

### DIFF
--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -39,7 +39,6 @@ import (
 	"github.com/ava-labs/subnet-evm/core/types"
 	"github.com/ava-labs/subnet-evm/core/vm"
 	"github.com/ava-labs/subnet-evm/params"
-	"github.com/ava-labs/subnet-evm/precompile"
 	"github.com/ava-labs/subnet-evm/precompile/feemanager"
 	"github.com/ava-labs/subnet-evm/precompile/rewardmanager"
 	"github.com/ethereum/go-ethereum/common"
@@ -350,7 +349,7 @@ func (bc *BlockChain) SubscribeAcceptedTransactionEvent(ch chan<- NewTxsEvent) e
 func (bc *BlockChain) GetFeeConfigAt(parent *types.Header) (commontype.FeeConfig, *big.Int, error) {
 	config := bc.Config()
 	bigTime := new(big.Int).SetUint64(parent.Time)
-	if !config.IsPrecompileEnabled(precompile.FeeConfigManagerAddress, bigTime) {
+	if !config.IsPrecompileEnabled(feemanager.Address, bigTime) {
 		return config.FeeConfig, common.Big0, nil
 	}
 
@@ -394,7 +393,7 @@ func (bc *BlockChain) GetCoinbaseAt(parent *types.Header) (common.Address, bool,
 		return constants.BlackholeAddr, false, nil
 	}
 
-	if !config.IsPrecompileEnabled(precompile.RewardManagerAddress, bigTime) {
+	if !config.IsPrecompileEnabled(rewardmanager.Address, bigTime) {
 		if bc.chainConfig.AllowFeeRecipients {
 			return common.Address{}, true, nil
 		} else {

--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -196,7 +196,7 @@ func TestStatefulPrecompilesConfigure(t *testing.T) {
 			},
 			assertState: func(t *testing.T, sdb *state.StateDB) {
 				assert.Equal(t, precompile.AllowListAdmin, deployerallowlist.GetContractDeployerAllowListStatus(sdb, addr), "unexpected allow list status for modified address")
-				assert.Equal(t, uint64(1), sdb.GetNonce(precompile.ContractDeployerAllowListAddress))
+				assert.Equal(t, uint64(1), sdb.GetNonce(deployerallowlist.Address))
 			},
 		},
 	} {

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -36,7 +36,6 @@ import (
 	"github.com/ava-labs/subnet-evm/core/types"
 	"github.com/ava-labs/subnet-evm/core/vm"
 	"github.com/ava-labs/subnet-evm/params"
-	"github.com/ava-labs/subnet-evm/precompile"
 	"github.com/ava-labs/subnet-evm/precompile/txallowlist"
 	"github.com/ava-labs/subnet-evm/vmerrs"
 	"github.com/ethereum/go-ethereum/common"
@@ -250,7 +249,7 @@ func (st *StateTransition) preCheck() error {
 		}
 
 		// Check that the sender is on the tx allow list if enabled
-		if st.evm.ChainConfig().IsPrecompileEnabled(precompile.TxAllowListAddress, st.evm.Context.Time) {
+		if st.evm.ChainConfig().IsPrecompileEnabled(txallowlist.Address, st.evm.Context.Time) {
 			txAllowListRole := txallowlist.GetTxAllowListStatus(st.state, st.msg.From())
 			if !txAllowListRole.IsEnabled() {
 				return fmt.Errorf("%w: %s", txallowlist.ErrSenderAddressNotAllowListed, st.msg.From())

--- a/core/stateful_precompile_test.go
+++ b/core/stateful_precompile_test.go
@@ -250,7 +250,7 @@ func TestContractDeployerAllowListRun(t *testing.T) {
 			require.Equal(t, precompile.AllowListNoRole, deployerallowlist.GetContractDeployerAllowListStatus(state, noRoleAddr))
 
 			blockContext := &mockBlockContext{blockNumber: common.Big0}
-			ret, remainingGas, err := deployerallowlist.ContractDeployerAllowListPrecompile.Run(&mockAccessibleState{state: state, blockContext: blockContext, snowContext: snow.DefaultContextTest()}, test.caller, precompile.ContractDeployerAllowListAddress, test.input(), test.suppliedGas, test.readOnly)
+			ret, remainingGas, err := deployerallowlist.ContractDeployerAllowListPrecompile.Run(&mockAccessibleState{state: state, blockContext: blockContext, snowContext: snow.DefaultContextTest()}, test.caller, deployerallowlist.Address, test.input(), test.suppliedGas, test.readOnly)
 			if len(test.expectedErr) != 0 {
 				require.ErrorContains(t, err, test.expectedErr)
 			} else {
@@ -371,7 +371,7 @@ func TestTxAllowListRun(t *testing.T) {
 		},
 		"set no role with readOnly enabled": {
 			caller:         adminAddr,
-			precompileAddr: precompile.TxAllowListAddress,
+			precompileAddr: txallowlist.Address,
 			input: func() []byte {
 				input, err := precompile.PackModifyAllowList(adminAddr, precompile.AllowListNoRole)
 				require.NoError(t, err)
@@ -444,7 +444,7 @@ func TestTxAllowListRun(t *testing.T) {
 			require.Equal(t, precompile.AllowListAdmin, txallowlist.GetTxAllowListStatus(state, adminAddr))
 
 			blockContext := &mockBlockContext{blockNumber: common.Big0}
-			ret, remainingGas, err := txallowlist.TxAllowListPrecompile.Run(&mockAccessibleState{state: state, blockContext: blockContext, snowContext: snow.DefaultContextTest()}, test.caller, precompile.TxAllowListAddress, test.input(), test.suppliedGas, test.readOnly)
+			ret, remainingGas, err := txallowlist.TxAllowListPrecompile.Run(&mockAccessibleState{state: state, blockContext: blockContext, snowContext: snow.DefaultContextTest()}, test.caller, txallowlist.Address, test.input(), test.suppliedGas, test.readOnly)
 			if len(test.expectedErr) != 0 {
 				require.ErrorContains(t, err, test.expectedErr)
 			} else {
@@ -693,7 +693,7 @@ func TestContractNativeMinterRun(t *testing.T) {
 			if test.config != nil {
 				test.config.Configure(params.TestChainConfig, state, blockContext)
 			}
-			ret, remainingGas, err := nativeminter.ContractNativeMinterPrecompile.Run(&mockAccessibleState{state: state, blockContext: blockContext, snowContext: snow.DefaultContextTest()}, test.caller, precompile.ContractNativeMinterAddress, test.input(), test.suppliedGas, test.readOnly)
+			ret, remainingGas, err := nativeminter.ContractNativeMinterPrecompile.Run(&mockAccessibleState{state: state, blockContext: blockContext, snowContext: snow.DefaultContextTest()}, test.caller, nativeminter.Address, test.input(), test.suppliedGas, test.readOnly)
 			if len(test.expectedErr) != 0 {
 				require.ErrorContains(t, err, test.expectedErr)
 			} else {
@@ -957,7 +957,7 @@ func TestFeeConfigManagerRun(t *testing.T) {
 			if test.config != nil {
 				test.config.Configure(params.TestChainConfig, state, blockContext)
 			}
-			ret, remainingGas, err := feemanager.FeeConfigManagerPrecompile.Run(&mockAccessibleState{state: state, blockContext: blockContext, snowContext: snow.DefaultContextTest()}, test.caller, precompile.FeeConfigManagerAddress, test.input(), test.suppliedGas, test.readOnly)
+			ret, remainingGas, err := feemanager.FeeConfigManagerPrecompile.Run(&mockAccessibleState{state: state, blockContext: blockContext, snowContext: snow.DefaultContextTest()}, test.caller, feemanager.Address, test.input(), test.suppliedGas, test.readOnly)
 			if len(test.expectedErr) != 0 {
 				require.ErrorContains(t, err, test.expectedErr)
 			} else {
@@ -1277,7 +1277,7 @@ func TestRewardManagerRun(t *testing.T) {
 			if test.config != nil {
 				test.config.Configure(params.TestChainConfig, state, blockContext)
 			}
-			ret, remainingGas, err := rewardmanager.RewardManagerPrecompile.Run(&mockAccessibleState{state: state, blockContext: blockContext, snowContext: snow.DefaultContextTest()}, test.caller, precompile.RewardManagerAddress, test.input(), test.suppliedGas, test.readOnly)
+			ret, remainingGas, err := rewardmanager.RewardManagerPrecompile.Run(&mockAccessibleState{state: state, blockContext: blockContext, snowContext: snow.DefaultContextTest()}, test.caller, rewardmanager.Address, test.input(), test.suppliedGas, test.readOnly)
 			if len(test.expectedErr) != 0 {
 				require.ErrorContains(t, err, test.expectedErr)
 			} else {

--- a/core/test_blockchain.go
+++ b/core/test_blockchain.go
@@ -1596,7 +1596,7 @@ func TestStatefulPrecompiles(t *testing.T, create func(db ethdb.Database, chainC
 				tx := types.NewTx(&types.DynamicFeeTx{
 					ChainID:   params.TestChainConfig.ChainID,
 					Nonce:     gen.TxNonce(addr1),
-					To:        &precompile.ContractDeployerAllowListAddress,
+					To:        &deployerallowlist.Address,
 					Gas:       3_000_000,
 					Value:     common.Big0,
 					GasFeeCap: feeCap,
@@ -1642,7 +1642,7 @@ func TestStatefulPrecompiles(t *testing.T, create func(db ethdb.Database, chainC
 				tx := types.NewTx(&types.DynamicFeeTx{
 					ChainID:   params.TestChainConfig.ChainID,
 					Nonce:     gen.TxNonce(addr1),
-					To:        &precompile.FeeConfigManagerAddress,
+					To:        &feemanager.Address,
 					Gas:       3_000_000,
 					Value:     common.Big0,
 					GasFeeCap: feeCap,

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -42,7 +42,7 @@ import (
 	"github.com/ava-labs/subnet-evm/core/types"
 	"github.com/ava-labs/subnet-evm/metrics"
 	"github.com/ava-labs/subnet-evm/params"
-	"github.com/ava-labs/subnet-evm/precompile"
+	"github.com/ava-labs/subnet-evm/precompile/feemanager"
 	"github.com/ava-labs/subnet-evm/precompile/txallowlist"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/prque"
@@ -694,7 +694,7 @@ func (pool *TxPool) checkTxState(from common.Address, tx *types.Transaction) err
 
 	// If the tx allow list is enabled, return an error if the from address is not allow listed.
 	headTimestamp := big.NewInt(int64(pool.currentHead.Time))
-	if pool.chainconfig.IsPrecompileEnabled(precompile.TxAllowListAddress, headTimestamp) {
+	if pool.chainconfig.IsPrecompileEnabled(txallowlist.Address, headTimestamp) {
 		txAllowListRole := txallowlist.GetTxAllowListStatus(pool.currentState, from)
 		if !txAllowListRole.IsEnabled() {
 			return fmt.Errorf("%w: %s", txallowlist.ErrSenderAddressNotAllowListed, from)
@@ -1446,7 +1446,7 @@ func (pool *TxPool) reset(oldHead, newHead *types.Header) {
 	// without requiring FeeConfigManager is enabled.
 	// This is already being set by SetMinFee when gas price updater starts.
 	// However tests are currently failing if we change this check to IsSubnetEVM.
-	if pool.chainconfig.IsPrecompileEnabled(precompile.FeeConfigManagerAddress, new(big.Int).SetUint64(newHead.Time)) {
+	if pool.chainconfig.IsPrecompileEnabled(feemanager.Address, new(big.Int).SetUint64(newHead.Time)) {
 		feeConfig, _, err := pool.chain.GetFeeConfigAt(newHead)
 		if err != nil {
 			log.Error("Failed to get fee config state", "err", err, "root", newHead.Root)

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -158,12 +158,13 @@ func init() {
 
 	// Ensure that this package will panic during init if there is a conflict present with the declared
 	// precompile addresses.
-	for _, k := range precompile.UsedAddresses {
-		if _, ok := PrecompileAllNativeAddresses[k]; ok {
-			panic(fmt.Errorf("precompile address collides with existing native address: %s", k))
+	for _, module := range precompile.RegisteredModules {
+		address := module.Address()
+		if _, ok := PrecompileAllNativeAddresses[address]; ok {
+			panic(fmt.Errorf("precompile address collides with existing native address: %s", address))
 		}
-		if k == constants.BlackholeAddr {
-			panic(fmt.Errorf("cannot use address %s for stateful precompile - overlaps with blackhole address", k))
+		if address == constants.BlackholeAddr {
+			panic(fmt.Errorf("cannot use address %s for stateful precompile - overlaps with blackhole address", address))
 		}
 	}
 }

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -508,7 +508,7 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 		return nil, common.Address{}, 0, vmerrs.ErrContractAddressCollision
 	}
 	// If the allow list is enabled, check that [evm.TxContext.Origin] has permission to deploy a contract.
-	if evm.chainRules.IsPrecompileEnabled(precompile.ContractDeployerAllowListAddress) {
+	if evm.chainRules.IsPrecompileEnabled(deployerallowlist.Address) {
 		allowListRole := deployerallowlist.GetContractDeployerAllowListStatus(evm.StateDB, evm.TxContext.Origin)
 		if !allowListRole.IsEnabled() {
 			return nil, common.Address{}, 0, fmt.Errorf("tx.origin %s is not authorized to deploy a contract", evm.TxContext.Origin)

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -39,7 +39,7 @@ import (
 	"github.com/ava-labs/subnet-evm/core"
 	"github.com/ava-labs/subnet-evm/core/types"
 	"github.com/ava-labs/subnet-evm/params"
-	"github.com/ava-labs/subnet-evm/precompile"
+	"github.com/ava-labs/subnet-evm/precompile/feemanager"
 	"github.com/ava-labs/subnet-evm/rpc"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
@@ -318,7 +318,7 @@ func (oracle *Oracle) suggestDynamicFees(ctx context.Context) (*big.Int, *big.In
 		feeLastChangedAt *big.Int
 		feeConfig        commontype.FeeConfig
 	)
-	if oracle.backend.ChainConfig().IsPrecompileEnabled(precompile.FeeConfigManagerAddress, new(big.Int).SetUint64(head.Time)) {
+	if oracle.backend.ChainConfig().IsPrecompileEnabled(feemanager.Address, new(big.Int).SetUint64(head.Time)) {
 		feeConfig, feeLastChangedAt, err = oracle.backend.GetFeeConfigAt(head)
 		if err != nil {
 			return nil, nil, err

--- a/eth/gasprice/gasprice_test.go
+++ b/eth/gasprice/gasprice_test.go
@@ -40,7 +40,6 @@ import (
 	"github.com/ava-labs/subnet-evm/core/vm"
 	"github.com/ava-labs/subnet-evm/ethdb"
 	"github.com/ava-labs/subnet-evm/params"
-	"github.com/ava-labs/subnet-evm/precompile"
 	"github.com/ava-labs/subnet-evm/precompile/feemanager"
 	"github.com/ava-labs/subnet-evm/rpc"
 	"github.com/ethereum/go-ethereum/common"
@@ -463,7 +462,7 @@ func TestSuggestGasPriceAfterFeeConfigUpdate(t *testing.T) {
 		tx := types.NewTx(&types.DynamicFeeTx{
 			ChainID:   chainConfig.ChainID,
 			Nonce:     b.TxNonce(addr),
-			To:        &precompile.FeeConfigManagerAddress,
+			To:        &feemanager.Address,
 			Gas:       chainConfig.FeeConfig.GasLimit.Uint64(),
 			Value:     common.Big0,
 			GasFeeCap: chainConfig.FeeConfig.MinBaseFee, // give low fee, it should work since we still haven't applied high fees

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -44,6 +44,7 @@ import (
 	"github.com/ava-labs/subnet-evm/core/vm"
 	"github.com/ava-labs/subnet-evm/eth/tracers/logger"
 	"github.com/ava-labs/subnet-evm/params"
+	"github.com/ava-labs/subnet-evm/precompile"
 	"github.com/ava-labs/subnet-evm/rpc"
 	"github.com/ava-labs/subnet-evm/vmerrs"
 	"github.com/davecgh/go-spew/spew"
@@ -626,12 +627,20 @@ func (api *BlockChainAPI) ChainId() *hexutil.Big {
 }
 
 // GetActivePrecompilesAt returns the active precompile configs at the given block timestamp.
-func (s *BlockChainAPI) GetActivePrecompilesAt(ctx context.Context, blockTimestamp *big.Int) params.PrecompileUpgrade {
+func (s *BlockChainAPI) GetActivePrecompilesAt(ctx context.Context, blockTimestamp *big.Int) map[string]precompile.StatefulPrecompileConfig {
 	if blockTimestamp == nil {
 		blockTimestampInt := s.b.CurrentHeader().Time
 		blockTimestamp = new(big.Int).SetUint64(blockTimestampInt)
 	}
-	return s.b.ChainConfig().GetActivePrecompileUpgrade(blockTimestamp)
+	res := make(map[string]precompile.StatefulPrecompileConfig)
+	for _, module := range precompile.RegisteredModules {
+		address := module.Address()
+		if config := s.b.ChainConfig().GetPrecompileConfig(address, blockTimestamp); config != nil && !config.IsDisabled() {
+			res[config.Name()] = config
+		}
+	}
+
+	return res
 }
 
 type FeeConfigResult struct {

--- a/params/precompile_config_test.go
+++ b/params/precompile_config_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/ava-labs/subnet-evm/commontype"
-	"github.com/ava-labs/subnet-evm/precompile"
 	"github.com/ava-labs/subnet-evm/precompile/deployerallowlist"
 	"github.com/ava-labs/subnet-evm/precompile/feemanager"
 	"github.com/ava-labs/subnet-evm/precompile/txallowlist"
@@ -206,15 +205,15 @@ func TestGetPrecompileConfig(t *testing.T) {
 		ContractDeployerAllowListConfig: deployerallowlist.NewContractDeployerAllowListConfig(big.NewInt(10), nil, nil),
 	}
 
-	deployerConfig := config.GetPrecompileConfig(precompile.ContractDeployerAllowListAddress, big.NewInt(0))
+	deployerConfig := config.GetPrecompileConfig(deployerallowlist.Address, big.NewInt(0))
 	assert.Nil(deployerConfig)
 
-	deployerConfig = config.GetPrecompileConfig(precompile.ContractDeployerAllowListAddress, big.NewInt(10))
+	deployerConfig = config.GetPrecompileConfig(deployerallowlist.Address, big.NewInt(10))
 	assert.NotNil(deployerConfig)
 
-	deployerConfig = config.GetPrecompileConfig(precompile.ContractDeployerAllowListAddress, big.NewInt(11))
+	deployerConfig = config.GetPrecompileConfig(deployerallowlist.Address, big.NewInt(11))
 	assert.NotNil(deployerConfig)
 
-	txAllowListConfig := config.GetPrecompileConfig(precompile.TxAllowListAddress, big.NewInt(0))
+	txAllowListConfig := config.GetPrecompileConfig(txallowlist.Address, big.NewInt(0))
 	assert.Nil(txAllowListConfig)
 }

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -2413,11 +2413,11 @@ func TestFeeManagerChangeFee(t *testing.T) {
 	// Check that address 0 is whitelisted and address 1 is not
 	role := feemanager.GetFeeConfigManagerStatus(genesisState, testEthAddrs[0])
 	if role != precompile.AllowListAdmin {
-		t.Fatalf("Expected fee manager list status to be set to admin: %s, but found: %s", precompile.FeeConfigManagerAddress, role)
+		t.Fatalf("Expected fee manager list status to be set to admin: %s, but found: %s", feemanager.Address, role)
 	}
 	role = feemanager.GetFeeConfigManagerStatus(genesisState, testEthAddrs[1])
 	if role != precompile.AllowListNoRole {
-		t.Fatalf("Expected fee manager list status to be set to no role: %s, but found: %s", precompile.FeeConfigManagerAddress, role)
+		t.Fatalf("Expected fee manager list status to be set to no role: %s, but found: %s", feemanager.Address, role)
 	}
 	// Contract is initialized but no preconfig is given, reader should return genesis fee config
 	feeConfig, lastChangedAt, err := vm.blockChain.GetFeeConfigAt(vm.blockChain.Genesis().Header())
@@ -2435,7 +2435,7 @@ func TestFeeManagerChangeFee(t *testing.T) {
 	tx := types.NewTx(&types.DynamicFeeTx{
 		ChainID:   genesis.Config.ChainID,
 		Nonce:     uint64(0),
-		To:        &precompile.FeeConfigManagerAddress,
+		To:        &feemanager.Address,
 		Gas:       testLowFeeConfig.GasLimit.Uint64(),
 		Value:     common.Big0,
 		GasFeeCap: testLowFeeConfig.MinBaseFee, // give low fee, it should work since we still haven't applied high fees
@@ -2471,7 +2471,7 @@ func TestFeeManagerChangeFee(t *testing.T) {
 	tx2 := types.NewTx(&types.DynamicFeeTx{
 		ChainID:   genesis.Config.ChainID,
 		Nonce:     uint64(1),
-		To:        &precompile.FeeConfigManagerAddress,
+		To:        &feemanager.Address,
 		Gas:       genesis.Config.FeeConfig.GasLimit.Uint64(),
 		Value:     common.Big0,
 		GasFeeCap: testLowFeeConfig.MinBaseFee, // this is too low for applied config, should fail
@@ -2659,7 +2659,7 @@ func TestRewardManagerPrecompileSetRewardAddress(t *testing.T) {
 
 	gas := 21000 + 240 + rewardmanager.SetRewardAddressGasCost // 21000 for tx, 240 for tx data
 
-	tx := types.NewTransaction(uint64(0), precompile.RewardManagerAddress, big.NewInt(1), gas, big.NewInt(testMinGasPrice), data)
+	tx := types.NewTransaction(uint64(0), rewardmanager.Address, big.NewInt(1), gas, big.NewInt(testMinGasPrice), data)
 
 	signedTx, err := types.SignTx(tx, types.NewEIP155Signer(vm.chainConfig.ChainID), testKeys[0])
 	require.NoError(t, err)
@@ -2795,7 +2795,7 @@ func TestRewardManagerPrecompileAllowFeeRecipients(t *testing.T) {
 
 	gas := 21000 + 240 + rewardmanager.AllowFeeRecipientsGasCost // 21000 for tx, 240 for tx data
 
-	tx := types.NewTransaction(uint64(0), precompile.RewardManagerAddress, big.NewInt(1), gas, big.NewInt(testMinGasPrice), data)
+	tx := types.NewTransaction(uint64(0), rewardmanager.Address, big.NewInt(1), gas, big.NewInt(testMinGasPrice), data)
 
 	signedTx, err := types.SignTx(tx, types.NewEIP155Signer(vm.chainConfig.ChainID), testKeys[0])
 	require.NoError(t, err)

--- a/precompile/deployerallowlist/config.go
+++ b/precompile/deployerallowlist/config.go
@@ -11,7 +11,11 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-var _ precompile.StatefulPrecompileConfig = &ContractDeployerAllowListConfig{}
+var (
+	_ precompile.StatefulPrecompileConfig = &ContractDeployerAllowListConfig{}
+
+	Address = common.HexToAddress("0x0200000000000000000000000000000000000000")
+)
 
 // ContractDeployerAllowListConfig wraps [AllowListConfig] and uses it to implement the StatefulPrecompileConfig
 // interface while adding in the contract deployer specific precompile address.
@@ -45,12 +49,12 @@ func NewDisableContractDeployerAllowListConfig(blockTimestamp *big.Int) *Contrac
 
 // Address returns the address of the contract deployer allow list.
 func (c *ContractDeployerAllowListConfig) Address() common.Address {
-	return precompile.ContractDeployerAllowListAddress
+	return Address
 }
 
 // Configure configures [state] with the desired admins based on [c].
 func (c *ContractDeployerAllowListConfig) Configure(_ precompile.ChainConfig, state precompile.StateDB, _ precompile.BlockContext) error {
-	return c.AllowListConfig.Configure(state, precompile.ContractDeployerAllowListAddress)
+	return c.AllowListConfig.Configure(state, Address)
 }
 
 // Contract returns the singleton stateful precompiled contract to be used for the allow list.
@@ -72,4 +76,8 @@ func (c *ContractDeployerAllowListConfig) Equal(s precompile.StatefulPrecompileC
 func (c *ContractDeployerAllowListConfig) String() string {
 	bytes, _ := json.Marshal(c)
 	return string(bytes)
+}
+
+func (c ContractDeployerAllowListConfig) Name() string {
+	return "contractDeployerAllowListConfig"
 }

--- a/precompile/deployerallowlist/contract.go
+++ b/precompile/deployerallowlist/contract.go
@@ -10,18 +10,18 @@ import (
 
 var (
 	// Singleton StatefulPrecompiledContract for W/R access to the contract deployer allow list.
-	ContractDeployerAllowListPrecompile precompile.StatefulPrecompiledContract = precompile.CreateAllowListPrecompile(precompile.ContractDeployerAllowListAddress)
+	ContractDeployerAllowListPrecompile precompile.StatefulPrecompiledContract = precompile.CreateAllowListPrecompile(Address)
 )
 
 // GetContractDeployerAllowListStatus returns the role of [address] for the contract deployer
 // allow list.
 func GetContractDeployerAllowListStatus(stateDB precompile.StateDB, address common.Address) precompile.AllowListRole {
-	return precompile.GetAllowListStatus(stateDB, precompile.ContractDeployerAllowListAddress, address)
+	return precompile.GetAllowListStatus(stateDB, Address, address)
 }
 
 // SetContractDeployerAllowListStatus sets the permissions of [address] to [role] for the
 // contract deployer allow list.
 // assumes [role] has already been verified as valid.
 func SetContractDeployerAllowListStatus(stateDB precompile.StateDB, address common.Address, role precompile.AllowListRole) {
-	precompile.SetAllowListRole(stateDB, precompile.ContractDeployerAllowListAddress, address, role)
+	precompile.SetAllowListRole(stateDB, Address, address, role)
 }

--- a/precompile/feemanager/config.go
+++ b/precompile/feemanager/config.go
@@ -13,12 +13,22 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
+var (
+	_ precompile.StatefulPrecompileConfig = &FeeConfigManagerConfig{}
+
+	Address = common.HexToAddress("0x0200000000000000000000000000000000000003")
+)
+
 // FeeConfigManagerConfig wraps [AllowListConfig] and uses it to implement the StatefulPrecompileConfig
 // interface while adding in the FeeConfigManager specific precompile address.
 type FeeConfigManagerConfig struct {
 	precompile.AllowListConfig // Config for the fee config manager allow list
 	precompile.UpgradeableConfig
 	InitialFeeConfig *commontype.FeeConfig `json:"initialFeeConfig,omitempty"` // initial fee config to be immediately activated
+}
+
+func init() {
+	precompile.RegisterPrecompile(FeeConfigManagerConfig{})
 }
 
 // NewFeeManagerConfig returns a config for a network upgrade at [blockTimestamp] that enables
@@ -46,8 +56,8 @@ func NewDisableFeeManagerConfig(blockTimestamp *big.Int) *FeeConfigManagerConfig
 }
 
 // Address returns the address of the fee config manager contract.
-func (c *FeeConfigManagerConfig) Address() common.Address {
-	return precompile.FeeConfigManagerAddress
+func (c FeeConfigManagerConfig) Address() common.Address {
+	return Address
 }
 
 // Equal returns true if [s] is a [*FeeConfigManagerConfig] and it has been configured identical to [c].
@@ -83,11 +93,11 @@ func (c *FeeConfigManagerConfig) Configure(chainConfig precompile.ChainConfig, s
 			return fmt.Errorf("cannot configure fee config in chain config: %w", err)
 		}
 	}
-	return c.AllowListConfig.Configure(state, precompile.FeeConfigManagerAddress)
+	return c.AllowListConfig.Configure(state, Address)
 }
 
 // Contract returns the singleton stateful precompiled contract to be used for the fee manager.
-func (c *FeeConfigManagerConfig) Contract() precompile.StatefulPrecompiledContract {
+func (c FeeConfigManagerConfig) Contract() precompile.StatefulPrecompiledContract {
 	return FeeConfigManagerPrecompile
 }
 
@@ -106,4 +116,8 @@ func (c *FeeConfigManagerConfig) Verify() error {
 func (c *FeeConfigManagerConfig) String() string {
 	bytes, _ := json.Marshal(c)
 	return string(bytes)
+}
+
+func (c FeeConfigManagerConfig) Name() string {
+	return "feeManagerConfig"
 }

--- a/precompile/feemanager/contract.go
+++ b/precompile/feemanager/contract.go
@@ -41,7 +41,7 @@ var (
 	_ precompile.StatefulPrecompileConfig = &FeeConfigManagerConfig{}
 
 	// Singleton StatefulPrecompiledContract for setting fee configs by permissioned callers.
-	FeeConfigManagerPrecompile precompile.StatefulPrecompiledContract = createFeeConfigManagerPrecompile(precompile.FeeConfigManagerAddress)
+	FeeConfigManagerPrecompile precompile.StatefulPrecompiledContract = createFeeConfigManagerPrecompile(Address)
 
 	setFeeConfigSignature              = precompile.CalculateFunctionSelector("setFeeConfig(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256)")
 	getFeeConfigSignature              = precompile.CalculateFunctionSelector("getFeeConfig()")
@@ -54,13 +54,13 @@ var (
 
 // GetFeeConfigManagerStatus returns the role of [address] for the fee config manager list.
 func GetFeeConfigManagerStatus(stateDB precompile.StateDB, address common.Address) precompile.AllowListRole {
-	return precompile.GetAllowListStatus(stateDB, precompile.FeeConfigManagerAddress, address)
+	return precompile.GetAllowListStatus(stateDB, Address, address)
 }
 
 // SetFeeConfigManagerStatus sets the permissions of [address] to [role] for the
 // fee config manager list. assumes [role] has already been verified as valid.
 func SetFeeConfigManagerStatus(stateDB precompile.StateDB, address common.Address, role precompile.AllowListRole) {
-	precompile.SetAllowListRole(stateDB, precompile.FeeConfigManagerAddress, address, role)
+	precompile.SetAllowListRole(stateDB, Address, address, role)
 }
 
 // PackGetFeeConfigInput packs the getFeeConfig signature
@@ -147,7 +147,7 @@ func UnpackFeeConfigInput(input []byte) (commontype.FeeConfig, error) {
 func GetStoredFeeConfig(stateDB precompile.StateDB) commontype.FeeConfig {
 	feeConfig := commontype.FeeConfig{}
 	for i := minFeeConfigFieldKey; i <= numFeeConfigField; i++ {
-		val := stateDB.GetState(precompile.FeeConfigManagerAddress, common.Hash{byte(i)})
+		val := stateDB.GetState(Address, common.Hash{byte(i)})
 		switch i {
 		case gasLimitKey:
 			feeConfig.GasLimit = new(big.Int).Set(val.Big())
@@ -174,7 +174,7 @@ func GetStoredFeeConfig(stateDB precompile.StateDB) commontype.FeeConfig {
 }
 
 func GetFeeConfigLastChangedAt(stateDB precompile.StateDB) *big.Int {
-	val := stateDB.GetState(precompile.FeeConfigManagerAddress, feeConfigLastChangedAtKey)
+	val := stateDB.GetState(Address, feeConfigLastChangedAtKey)
 	return val.Big()
 }
 
@@ -208,14 +208,14 @@ func StoreFeeConfig(stateDB precompile.StateDB, feeConfig commontype.FeeConfig, 
 			// This should never encounter an unknown fee config key
 			panic(fmt.Sprintf("unknown fee config key: %d", i))
 		}
-		stateDB.SetState(precompile.FeeConfigManagerAddress, common.Hash{byte(i)}, input)
+		stateDB.SetState(Address, common.Hash{byte(i)}, input)
 	}
 
 	blockNumber := blockContext.Number()
 	if blockNumber == nil {
 		return fmt.Errorf("blockNumber cannot be nil")
 	}
-	stateDB.SetState(precompile.FeeConfigManagerAddress, feeConfigLastChangedAtKey, common.BigToHash(blockNumber))
+	stateDB.SetState(Address, feeConfigLastChangedAtKey, common.BigToHash(blockNumber))
 
 	return nil
 }
@@ -238,7 +238,7 @@ func setFeeConfig(accessibleState precompile.PrecompileAccessibleState, caller c
 
 	stateDB := accessibleState.GetStateDB()
 	// Verify that the caller is in the allow list and therefore has the right to modify it
-	callerStatus := precompile.GetAllowListStatus(stateDB, precompile.FeeConfigManagerAddress, caller)
+	callerStatus := precompile.GetAllowListStatus(stateDB, Address, caller)
 	if !callerStatus.IsEnabled() {
 		return nil, remainingGas, fmt.Errorf("%w: %s", ErrCannotChangeFee, caller)
 	}

--- a/precompile/mock_interface.go
+++ b/precompile/mock_interface.go
@@ -113,3 +113,7 @@ func (n *noopStatefulPrecompileConfig) Contract() StatefulPrecompiledContract {
 func (n *noopStatefulPrecompileConfig) String() string {
 	return ""
 }
+
+func (n *noopStatefulPrecompileConfig) Name() string {
+	return ""
+}

--- a/precompile/nativeminter/config.go
+++ b/precompile/nativeminter/config.go
@@ -14,7 +14,11 @@ import (
 	"github.com/ethereum/go-ethereum/common/math"
 )
 
-var _ precompile.StatefulPrecompileConfig = &ContractNativeMinterConfig{}
+var (
+	_ precompile.StatefulPrecompileConfig = &ContractNativeMinterConfig{}
+
+	Address = common.HexToAddress("0x0200000000000000000000000000000000000001")
+)
 
 // ContractNativeMinterConfig wraps [AllowListConfig] and uses it to implement the StatefulPrecompileConfig
 // interface while adding in the ContractNativeMinter specific precompile address.
@@ -22,6 +26,10 @@ type ContractNativeMinterConfig struct {
 	precompile.AllowListConfig
 	precompile.UpgradeableConfig
 	InitialMint map[common.Address]*math.HexOrDecimal256 `json:"initialMint,omitempty"` // initial mint config to be immediately minted
+}
+
+func init() {
+	precompile.RegisterPrecompile(ContractNativeMinterConfig{})
 }
 
 // NewContractNativeMinterConfig returns a config for a network upgrade at [blockTimestamp] that enables
@@ -49,8 +57,8 @@ func NewDisableContractNativeMinterConfig(blockTimestamp *big.Int) *ContractNati
 }
 
 // Address returns the address of the native minter contract.
-func (c *ContractNativeMinterConfig) Address() common.Address {
-	return precompile.ContractNativeMinterAddress
+func (c ContractNativeMinterConfig) Address() common.Address {
+	return Address
 }
 
 // Configure configures [state] with the desired admins based on [c].
@@ -62,11 +70,11 @@ func (c *ContractNativeMinterConfig) Configure(_ precompile.ChainConfig, state p
 		}
 	}
 
-	return c.AllowListConfig.Configure(state, precompile.ContractNativeMinterAddress)
+	return c.AllowListConfig.Configure(state, Address)
 }
 
 // Contract returns the singleton stateful precompiled contract to be used for the native minter.
-func (c *ContractNativeMinterConfig) Contract() precompile.StatefulPrecompiledContract {
+func (c ContractNativeMinterConfig) Contract() precompile.StatefulPrecompiledContract {
 	return ContractNativeMinterPrecompile
 }
 
@@ -122,4 +130,8 @@ func (c *ContractNativeMinterConfig) Equal(s precompile.StatefulPrecompileConfig
 func (c *ContractNativeMinterConfig) String() string {
 	bytes, _ := json.Marshal(c)
 	return string(bytes)
+}
+
+func (c ContractNativeMinterConfig) Name() string {
+	return "contractNativeMinterConfig"
 }

--- a/precompile/nativeminter/contract_native_minter.go
+++ b/precompile/nativeminter/contract_native_minter.go
@@ -24,7 +24,7 @@ const (
 
 var (
 	// Singleton StatefulPrecompiledContract for minting native assets by permissioned callers.
-	ContractNativeMinterPrecompile precompile.StatefulPrecompiledContract = createNativeMinterPrecompile(precompile.ContractNativeMinterAddress)
+	ContractNativeMinterPrecompile precompile.StatefulPrecompiledContract = createNativeMinterPrecompile(Address)
 
 	mintSignature = precompile.CalculateFunctionSelector("mintNativeCoin(address,uint256)") // address, amount
 	ErrCannotMint = errors.New("non-enabled cannot mint")
@@ -32,13 +32,13 @@ var (
 
 // GetContractNativeMinterStatus returns the role of [address] for the minter list.
 func GetContractNativeMinterStatus(stateDB precompile.StateDB, address common.Address) precompile.AllowListRole {
-	return precompile.GetAllowListStatus(stateDB, precompile.ContractNativeMinterAddress, address)
+	return precompile.GetAllowListStatus(stateDB, Address, address)
 }
 
 // SetContractNativeMinterStatus sets the permissions of [address] to [role] for the
 // minter list. assumes [role] has already been verified as valid.
 func SetContractNativeMinterStatus(stateDB precompile.StateDB, address common.Address, role precompile.AllowListRole) {
-	precompile.SetAllowListRole(stateDB, precompile.ContractNativeMinterAddress, address, role)
+	precompile.SetAllowListRole(stateDB, Address, address, role)
 }
 
 // PackMintInput packs [address] and [amount] into the appropriate arguments for minting operation.
@@ -83,7 +83,7 @@ func mintNativeCoin(accessibleState precompile.PrecompileAccessibleState, caller
 
 	stateDB := accessibleState.GetStateDB()
 	// Verify that the caller is in the allow list and therefore has the right to modify it
-	callerStatus := precompile.GetAllowListStatus(stateDB, precompile.ContractNativeMinterAddress, caller)
+	callerStatus := precompile.GetAllowListStatus(stateDB, Address, caller)
 	if !callerStatus.IsEnabled() {
 		return nil, remainingGas, fmt.Errorf("%w: %s", ErrCannotMint, caller)
 	}

--- a/precompile/rewardmanager/config.go
+++ b/precompile/rewardmanager/config.go
@@ -14,7 +14,15 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-var _ precompile.StatefulPrecompileConfig = &RewardManagerConfig{}
+var (
+	_ precompile.StatefulPrecompileConfig = &RewardManagerConfig{}
+
+	Address = common.HexToAddress("0x0200000000000000000000000000000000000004")
+)
+
+func init() {
+	precompile.RegisterPrecompile(RewardManagerConfig{})
+}
 
 type InitialRewardConfig struct {
 	AllowFeeRecipients bool           `json:"allowFeeRecipients"`
@@ -108,13 +116,13 @@ func (c *RewardManagerConfig) Equal(s precompile.StatefulPrecompileConfig) bool 
 
 // Address returns the address of the RewardManager. Addresses reside under the precompile/params.go
 // Select a non-conflicting address and set it in the params.go.
-func (c *RewardManagerConfig) Address() common.Address {
-	return precompile.RewardManagerAddress
+func (c RewardManagerConfig) Address() common.Address {
+	return Address
 }
 
 // Configure configures [state] with the initial configuration.
 func (c *RewardManagerConfig) Configure(chainConfig precompile.ChainConfig, state precompile.StateDB, _ precompile.BlockContext) error {
-	c.AllowListConfig.Configure(state, precompile.RewardManagerAddress)
+	c.AllowListConfig.Configure(state, Address)
 	// configure the RewardManager with the given initial configuration
 	if c.InitialRewardConfig != nil {
 		return c.InitialRewardConfig.Configure(state)
@@ -131,7 +139,7 @@ func (c *RewardManagerConfig) Configure(chainConfig precompile.ChainConfig, stat
 }
 
 // Contract returns the singleton stateful precompiled contract to be used for RewardManager.
-func (c *RewardManagerConfig) Contract() precompile.StatefulPrecompiledContract {
+func (c RewardManagerConfig) Contract() precompile.StatefulPrecompiledContract {
 	return RewardManagerPrecompile
 }
 
@@ -149,4 +157,8 @@ func (c *RewardManagerConfig) Verify() error {
 func (c *RewardManagerConfig) String() string {
 	bytes, _ := json.Marshal(c)
 	return string(bytes)
+}
+
+func (c RewardManagerConfig) Name() string {
+	return "rewardManagerConfig"
 }

--- a/precompile/rewardmanager/contract.go
+++ b/precompile/rewardmanager/contract.go
@@ -57,7 +57,7 @@ func init() {
 		panic(err)
 	}
 	RewardManagerABI = parsed
-	RewardManagerPrecompile, err = createRewardManagerPrecompile(precompile.RewardManagerAddress)
+	RewardManagerPrecompile, err = createRewardManagerPrecompile(Address)
 	if err != nil {
 		panic(err)
 	}
@@ -65,13 +65,13 @@ func init() {
 
 // GetRewardManagerAllowListStatus returns the role of [address] for the RewardManager list.
 func GetRewardManagerAllowListStatus(stateDB precompile.StateDB, address common.Address) precompile.AllowListRole {
-	return precompile.GetAllowListStatus(stateDB, precompile.RewardManagerAddress, address)
+	return precompile.GetAllowListStatus(stateDB, Address, address)
 }
 
 // SetRewardManagerAllowListStatus sets the permissions of [address] to [role] for the
 // RewardManager list. Assumes [role] has already been verified as valid.
 func SetRewardManagerAllowListStatus(stateDB precompile.StateDB, address common.Address, role precompile.AllowListRole) {
-	precompile.SetAllowListRole(stateDB, precompile.RewardManagerAddress, address, role)
+	precompile.SetAllowListRole(stateDB, Address, address, role)
 }
 
 // PackAllowFeeRecipients packs the function selector (first 4 func signature bytes).
@@ -82,12 +82,12 @@ func PackAllowFeeRecipients() ([]byte, error) {
 
 // EnableAllowFeeRecipients enables fee recipients.
 func EnableAllowFeeRecipients(stateDB precompile.StateDB) {
-	stateDB.SetState(precompile.RewardManagerAddress, rewardAddressStorageKey, allowFeeRecipientsAddressValue)
+	stateDB.SetState(Address, rewardAddressStorageKey, allowFeeRecipientsAddressValue)
 }
 
 // DisableRewardAddress disables rewards and burns them by sending to Blackhole Address.
 func DisableFeeRewards(stateDB precompile.StateDB) {
-	stateDB.SetState(precompile.RewardManagerAddress, rewardAddressStorageKey, constants.BlackholeAddr.Hash())
+	stateDB.SetState(Address, rewardAddressStorageKey, constants.BlackholeAddr.Hash())
 }
 
 func allowFeeRecipients(accessibleState precompile.PrecompileAccessibleState, caller common.Address, addr common.Address, input []byte, suppliedGas uint64, readOnly bool) (ret []byte, remainingGas uint64, err error) {
@@ -104,7 +104,7 @@ func allowFeeRecipients(accessibleState precompile.PrecompileAccessibleState, ca
 	// You can modify/delete this code if you don't want this function to be restricted by the allow list.
 	stateDB := accessibleState.GetStateDB()
 	// Verify that the caller is in the allow list and therefore has the right to modify it
-	callerStatus := precompile.GetAllowListStatus(stateDB, precompile.RewardManagerAddress, caller)
+	callerStatus := precompile.GetAllowListStatus(stateDB, Address, caller)
 	if !callerStatus.IsEnabled() {
 		return nil, remainingGas, fmt.Errorf("%w: %s", ErrCannotAllowFeeRecipients, caller)
 	}
@@ -164,7 +164,7 @@ func PackCurrentRewardAddressOutput(rewardAddress common.Address) ([]byte, error
 // GetStoredRewardAddress returns the current value of the address stored under rewardAddressStorageKey.
 // Returns an empty address and true if allow fee recipients is enabled, otherwise returns current reward address and false.
 func GetStoredRewardAddress(stateDB precompile.StateDB) (common.Address, bool) {
-	val := stateDB.GetState(precompile.RewardManagerAddress, rewardAddressStorageKey)
+	val := stateDB.GetState(Address, rewardAddressStorageKey)
 	return common.BytesToAddress(val.Bytes()), val == allowFeeRecipientsAddressValue
 }
 
@@ -174,7 +174,7 @@ func StoreRewardAddress(stateDB precompile.StateDB, val common.Address) error {
 	if val == (common.Address{}) {
 		return ErrEmptyRewardAddress
 	}
-	stateDB.SetState(precompile.RewardManagerAddress, rewardAddressStorageKey, val.Hash())
+	stateDB.SetState(Address, rewardAddressStorageKey, val.Hash())
 	return nil
 }
 
@@ -216,7 +216,7 @@ func setRewardAddress(accessibleState precompile.PrecompileAccessibleState, call
 	// You can modify/delete this code if you don't want this function to be restricted by the allow list.
 	stateDB := accessibleState.GetStateDB()
 	// Verify that the caller is in the allow list and therefore has the right to modify it
-	callerStatus := precompile.GetAllowListStatus(stateDB, precompile.RewardManagerAddress, caller)
+	callerStatus := precompile.GetAllowListStatus(stateDB, Address, caller)
 	if !callerStatus.IsEnabled() {
 		return nil, remainingGas, fmt.Errorf("%w: %s", ErrCannotSetRewardAddress, caller)
 	}
@@ -269,7 +269,7 @@ func disableRewards(accessibleState precompile.PrecompileAccessibleState, caller
 	// You can modify/delete this code if you don't want this function to be restricted by the allow list.
 	stateDB := accessibleState.GetStateDB()
 	// Verify that the caller is in the allow list and therefore has the right to modify it
-	callerStatus := precompile.GetAllowListStatus(stateDB, precompile.RewardManagerAddress, caller)
+	callerStatus := precompile.GetAllowListStatus(stateDB, Address, caller)
 	if !callerStatus.IsEnabled() {
 		return nil, remainingGas, fmt.Errorf("%w: %s", ErrCannotDisableRewards, caller)
 	}

--- a/precompile/stateful_precompile_config.go
+++ b/precompile/stateful_precompile_config.go
@@ -10,10 +10,19 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-// StatefulPrecompileConfig defines the interface for a stateful precompile to
-type StatefulPrecompileConfig interface {
+type StatefulPrecompileModule interface {
 	// Address returns the address where the stateful precompile is accessible.
 	Address() common.Address
+	// Contract returns a thread-safe singleton that can be used as the StatefulPrecompiledContract when
+	// this config is enabled.
+	Contract() StatefulPrecompiledContract
+	// Name returns the name of the stateful precompile.
+	Name() string
+}
+
+// StatefulPrecompileConfig defines the interface for a stateful precompile to
+type StatefulPrecompileConfig interface {
+	StatefulPrecompileModule
 	// Timestamp returns the timestamp at which this stateful precompile should be enabled.
 	// 1) 0 indicates that the precompile should be enabled from genesis.
 	// 2) n indicates that the precompile should be enabled in the first block with timestamp >= [n].
@@ -35,9 +44,6 @@ type StatefulPrecompileConfig interface {
 	// provides the config the ability to set its initial state and should only modify the state within
 	// its own address space.
 	Configure(ChainConfig, StateDB, BlockContext) error
-	// Contract returns a thread-safe singleton that can be used as the StatefulPrecompiledContract when
-	// this config is enabled.
-	Contract() StatefulPrecompiledContract
 
 	fmt.Stringer
 }

--- a/precompile/txallowlist/config.go
+++ b/precompile/txallowlist/config.go
@@ -13,6 +13,8 @@ import (
 
 var (
 	_ precompile.StatefulPrecompileConfig = &TxAllowListConfig{}
+
+	Address = common.HexToAddress("0x0200000000000000000000000000000000000002")
 )
 
 // TxAllowListConfig wraps [AllowListConfig] and uses it to implement the StatefulPrecompileConfig
@@ -20,6 +22,10 @@ var (
 type TxAllowListConfig struct {
 	precompile.AllowListConfig
 	precompile.UpgradeableConfig
+}
+
+func init() {
+	precompile.RegisterPrecompile(TxAllowListConfig{})
 }
 
 // NewTxAllowListConfig returns a config for a network upgrade at [blockTimestamp] that enables
@@ -46,17 +52,17 @@ func NewDisableTxAllowListConfig(blockTimestamp *big.Int) *TxAllowListConfig {
 }
 
 // Address returns the address of the contract deployer allow list.
-func (c *TxAllowListConfig) Address() common.Address {
-	return precompile.TxAllowListAddress
+func (c TxAllowListConfig) Address() common.Address {
+	return Address
 }
 
 // Configure configures [state] with the desired admins based on [c].
 func (c *TxAllowListConfig) Configure(_ precompile.ChainConfig, state precompile.StateDB, _ precompile.BlockContext) error {
-	return c.AllowListConfig.Configure(state, precompile.TxAllowListAddress)
+	return c.AllowListConfig.Configure(state, Address)
 }
 
 // Contract returns the singleton stateful precompiled contract to be used for the allow list.
-func (c *TxAllowListConfig) Contract() precompile.StatefulPrecompiledContract {
+func (c TxAllowListConfig) Contract() precompile.StatefulPrecompiledContract {
 	return TxAllowListPrecompile
 }
 
@@ -74,4 +80,8 @@ func (c *TxAllowListConfig) Equal(s precompile.StatefulPrecompileConfig) bool {
 func (c *TxAllowListConfig) String() string {
 	bytes, _ := json.Marshal(c)
 	return string(bytes)
+}
+
+func (c TxAllowListConfig) Name() string {
+	return "txAllowList"
 }

--- a/precompile/txallowlist/contract.go
+++ b/precompile/txallowlist/contract.go
@@ -13,7 +13,7 @@ import (
 var (
 	_ precompile.StatefulPrecompileConfig = &TxAllowListConfig{}
 	// Singleton StatefulPrecompiledContract for W/R access to the contract deployer allow list.
-	TxAllowListPrecompile precompile.StatefulPrecompiledContract = precompile.CreateAllowListPrecompile(precompile.TxAllowListAddress)
+	TxAllowListPrecompile precompile.StatefulPrecompiledContract = precompile.CreateAllowListPrecompile(Address)
 
 	ErrSenderAddressNotAllowListed = errors.New("cannot issue transaction from non-allow listed address")
 )
@@ -21,12 +21,12 @@ var (
 // GetTxAllowListStatus returns the role of [address] for the contract deployer
 // allow list.
 func GetTxAllowListStatus(stateDB precompile.StateDB, address common.Address) precompile.AllowListRole {
-	return precompile.GetAllowListStatus(stateDB, precompile.TxAllowListAddress, address)
+	return precompile.GetAllowListStatus(stateDB, Address, address)
 }
 
 // SetTxAllowListStatus sets the permissions of [address] to [role] for the
 // tx allow list.
 // assumes [role] has already been verified as valid.
 func SetTxAllowListStatus(stateDB precompile.StateDB, address common.Address, role precompile.AllowListRole) {
-	precompile.SetAllowListRole(stateDB, precompile.TxAllowListAddress, address, role)
+	precompile.SetAllowListRole(stateDB, Address, address, role)
 }


### PR DESCRIPTION
## Why this should be merged

Moves address definitions to sub-precompile packages. 

## How this works

Introduces PrecompileModule struct in precompile package with a way to register a new precompile module in init.

## How this was tested

Locally tested running with a older version of Subnet-EVM along with this PR.

Also UTs should cover this.
