### PR TITLE
rename fee manager config struct

### DIFF
--- a/commontype/fee_config.go
+++ b/commontype/fee_config.go
@@ -16,7 +16,7 @@ import (
 //
 // The dynamic fee algorithm simply increases fees when the network is operating at a utilization level above the target and decreases fees
 // when the network is operating at a utilization level below the target.
-// This struct is used by params.Config and precompile.FeeConfigManager
+// This struct is used by params.Config and precompile.FeeManager
 // any modification of this struct has direct affect on the precompiled contract
 // and changes should be carefully handled in the precompiled contract code.
 type FeeConfig struct {

--- a/contract-examples/README.md
+++ b/contract-examples/README.md
@@ -44,7 +44,7 @@ $ yarn
 
 `ExampleDeployerList` shows how `ContractDeployerAllowList` precompile can be used in a smart contract. It uses `IAllowList` to interact with `ContractDeployerAllowList` precompile. When the precompile is activated only those allowed can deploy contracts.
 
-`ExampleFeeManager` shows how a contract can change fee configuration with the `FeeConfigManager` precompile.
+`ExampleFeeManager` shows how a contract can change fee configuration with the `FeeManager` precompile.
 
 All of these `NativeMinter`, `FeeManager` and `AllowList` contracts should be enabled by a chain config in genesis or as an upgrade. See the example genesis under [Tests](#tests) section.
 

--- a/contract-examples/contracts/ExampleFeeManager.sol
+++ b/contract-examples/contracts/ExampleFeeManager.sol
@@ -6,7 +6,7 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 import "./AllowList.sol";
 import "./IFeeManager.sol";
 
-// ExampleFeeManager shows how FeeConfigManager precompile can be used in a smart contract
+// ExampleFeeManager shows how FeeManager precompile can be used in a smart contract
 // All methods of [allowList] can be directly called. There are example calls as tasks in hardhat.config.ts file.
 contract ExampleFeeManager is AllowList {
   // Precompiled Fee Manager Contract Address

--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -344,13 +344,13 @@ func (bc *BlockChain) SubscribeAcceptedTransactionEvent(ch chan<- NewTxsEvent) e
 }
 
 // GetFeeConfigAt returns the fee configuration and the last changed block number at [parent].
-// If FeeConfigManager is activated at [parent], returns the fee config in the precompile contract state.
+// If FeeManager is activated at [parent], returns the fee config in the precompile contract state.
 // Otherwise returns the fee config in the chain config.
 // Assumes that a valid configuration is stored when the precompile is activated.
 func (bc *BlockChain) GetFeeConfigAt(parent *types.Header) (commontype.FeeConfig, *big.Int, error) {
 	config := bc.Config()
 	bigTime := new(big.Int).SetUint64(parent.Time)
-	if !config.IsPrecompileEnabled(precompile.FeeConfigManagerAddress, bigTime) {
+	if !config.IsPrecompileEnabled(precompile.FeeManagerAddress, bigTime) {
 		return config.FeeConfig, common.Big0, nil
 	}
 

--- a/core/stateful_precompile_test.go
+++ b/core/stateful_precompile_test.go
@@ -711,7 +711,7 @@ func TestContractNativeMinterRun(t *testing.T) {
 	}
 }
 
-func TestFeeConfigManagerRun(t *testing.T) {
+func TestFeeManagerRun(t *testing.T) {
 	type test struct {
 		caller       common.Address
 		preCondition func(t *testing.T, state *state.StateDB)
@@ -923,7 +923,7 @@ func TestFeeConfigManagerRun(t *testing.T) {
 			readOnly:    false,
 			expectedRes: []byte{},
 			assertState: func(t *testing.T, state *state.StateDB) {
-				res := feemanager.GetFeeConfigManagerStatus(state, noRoleAddr)
+				res := feemanager.GetFeeManagerStatus(state, noRoleAddr)
 				require.Equal(t, allowlist.AllowListEnabled, res)
 			},
 		},
@@ -946,9 +946,9 @@ func TestFeeConfigManagerRun(t *testing.T) {
 			require.NoError(t, err)
 
 			// Set up the state so that each address has the expected permissions at the start.
-			feemanager.SetFeeConfigManagerStatus(state, adminAddr, allowlist.AllowListAdmin)
-			feemanager.SetFeeConfigManagerStatus(state, enabledAddr, allowlist.AllowListEnabled)
-			feemanager.SetFeeConfigManagerStatus(state, noRoleAddr, allowlist.AllowListNoRole)
+			feemanager.SetFeeManagerStatus(state, adminAddr, allowlist.AllowListAdmin)
+			feemanager.SetFeeManagerStatus(state, enabledAddr, allowlist.AllowListEnabled)
+			feemanager.SetFeeManagerStatus(state, noRoleAddr, allowlist.AllowListNoRole)
 
 			if test.preCondition != nil {
 				test.preCondition(t, state)
@@ -958,7 +958,7 @@ func TestFeeConfigManagerRun(t *testing.T) {
 			if test.config != nil {
 				test.config.Configure(params.TestChainConfig, state, blockContext)
 			}
-			ret, remainingGas, err := feemanager.FeeConfigManagerPrecompile.Run(&mockAccessibleState{state: state, blockContext: blockContext, snowContext: snow.DefaultContextTest()}, test.caller, precompile.FeeConfigManagerAddress, test.input(), test.suppliedGas, test.readOnly)
+			ret, remainingGas, err := feemanager.FeeManagerPrecompile.Run(&mockAccessibleState{state: state, blockContext: blockContext, snowContext: snow.DefaultContextTest()}, test.caller, precompile.FeeManagerAddress, test.input(), test.suppliedGas, test.readOnly)
 			if len(test.expectedErr) != 0 {
 				require.ErrorContains(t, err, test.expectedErr)
 			} else {

--- a/core/stateful_precompile_test.go
+++ b/core/stateful_precompile_test.go
@@ -718,7 +718,7 @@ func TestFeeConfigManagerRun(t *testing.T) {
 		input        func() []byte
 		suppliedGas  uint64
 		readOnly     bool
-		config       *feemanager.FeeConfigManagerConfig
+		config       *feemanager.FeeManagerConfig
 
 		expectedRes []byte
 		expectedErr string
@@ -772,7 +772,7 @@ func TestFeeConfigManagerRun(t *testing.T) {
 			suppliedGas: feemanager.SetFeeConfigGasCost,
 			readOnly:    false,
 			expectedRes: nil,
-			config: &feemanager.FeeConfigManagerConfig{
+			config: &feemanager.FeeManagerConfig{
 				InitialFeeConfig: &testFeeConfig,
 			},
 			expectedErr: "cannot be greater than maxBlockGasCost",
@@ -828,7 +828,7 @@ func TestFeeConfigManagerRun(t *testing.T) {
 				return feemanager.PackGetFeeConfigInput()
 			},
 			suppliedGas: feemanager.GetFeeConfigGasCost,
-			config: &feemanager.FeeConfigManagerConfig{
+			config: &feemanager.FeeManagerConfig{
 				InitialFeeConfig: &testFeeConfig,
 			},
 			readOnly: true,

--- a/core/test_blockchain.go
+++ b/core/test_blockchain.go
@@ -1643,7 +1643,7 @@ func TestStatefulPrecompiles(t *testing.T, create func(db ethdb.Database, chainC
 				tx := types.NewTx(&types.DynamicFeeTx{
 					ChainID:   params.TestChainConfig.ChainID,
 					Nonce:     gen.TxNonce(addr1),
-					To:        &precompile.FeeConfigManagerAddress,
+					To:        &precompile.FeeManagerAddress,
 					Gas:       3_000_000,
 					Value:     common.Big0,
 					GasFeeCap: feeCap,
@@ -1658,7 +1658,7 @@ func TestStatefulPrecompiles(t *testing.T, create func(db ethdb.Database, chainC
 				gen.AddTx(signedTx)
 			},
 			verifyState: func(sdb *state.StateDB) error {
-				res := feemanager.GetFeeConfigManagerStatus(sdb, addr1)
+				res := feemanager.GetFeeManagerStatus(sdb, addr1)
 				assert.Equal(allowlist.AllowListAdmin, res)
 
 				storedConfig := feemanager.GetStoredFeeConfig(sdb)
@@ -1670,7 +1670,7 @@ func TestStatefulPrecompiles(t *testing.T, create func(db ethdb.Database, chainC
 				return nil
 			},
 			verifyGenesis: func(sdb *state.StateDB) {
-				res := feemanager.GetFeeConfigManagerStatus(sdb, addr1)
+				res := feemanager.GetFeeManagerStatus(sdb, addr1)
 				assert.Equal(allowlist.AllowListAdmin, res)
 
 				feeConfig, _, err := blockchain.GetFeeConfigAt(blockchain.Genesis().Header())

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1443,10 +1443,10 @@ func (pool *TxPool) reset(oldHead, newHead *types.Header) {
 	// when we reset txPool we should explicitly check if fee struct for min base fee has changed
 	// so that we can correctly drop txs with < minBaseFee from tx pool.
 	// TODO: this should be checking IsSubnetEVM since we also support minimumFee for SubnetEVM
-	// without requiring FeeConfigManager is enabled.
+	// without requiring FeeManager is enabled.
 	// This is already being set by SetMinFee when gas price updater starts.
 	// However tests are currently failing if we change this check to IsSubnetEVM.
-	if pool.chainconfig.IsPrecompileEnabled(precompile.FeeConfigManagerAddress, new(big.Int).SetUint64(newHead.Time)) {
+	if pool.chainconfig.IsPrecompileEnabled(precompile.FeeManagerAddress, new(big.Int).SetUint64(newHead.Time)) {
 		feeConfig, _, err := pool.chain.GetFeeConfigAt(newHead)
 		if err != nil {
 			log.Error("Failed to get fee config state", "err", err, "root", newHead.Root)

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -318,7 +318,7 @@ func (oracle *Oracle) suggestDynamicFees(ctx context.Context) (*big.Int, *big.In
 		feeLastChangedAt *big.Int
 		feeConfig        commontype.FeeConfig
 	)
-	if oracle.backend.ChainConfig().IsPrecompileEnabled(precompile.FeeConfigManagerAddress, new(big.Int).SetUint64(head.Time)) {
+	if oracle.backend.ChainConfig().IsPrecompileEnabled(precompile.FeeManagerAddress, new(big.Int).SetUint64(head.Time)) {
 		feeConfig, feeLastChangedAt, err = oracle.backend.GetFeeConfigAt(head)
 		if err != nil {
 			return nil, nil, err

--- a/eth/gasprice/gasprice_test.go
+++ b/eth/gasprice/gasprice_test.go
@@ -463,7 +463,7 @@ func TestSuggestGasPriceAfterFeeConfigUpdate(t *testing.T) {
 		tx := types.NewTx(&types.DynamicFeeTx{
 			ChainID:   chainConfig.ChainID,
 			Nonce:     b.TxNonce(addr),
-			To:        &precompile.FeeConfigManagerAddress,
+			To:        &precompile.FeeManagerAddress,
 			Gas:       chainConfig.FeeConfig.GasLimit.Uint64(),
 			Value:     common.Big0,
 			GasFeeCap: chainConfig.FeeConfig.MinBaseFee, // give low fee, it should work since we still haven't applied high fees

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -128,7 +128,7 @@ func (w *worker) commitNewWork() (*types.Block, error) {
 
 	bigTimestamp := new(big.Int).SetUint64(timestamp)
 	var gasLimit uint64
-	// The fee config manager relies on the state of the parent block to set the fee config
+	// The fee manager relies on the state of the parent block to set the fee config
 	// because the fee config may be changed by the current block.
 	feeConfig, _, err := w.chain.GetFeeConfigAt(parent.Header())
 	if err != nil {

--- a/params/precompile_config.go
+++ b/params/precompile_config.go
@@ -40,7 +40,7 @@ func (p *PrecompileUpgrade) getByAddress(address common.Address) (precompile.Sta
 		return p.ContractNativeMinterConfig, p.ContractNativeMinterConfig != nil
 	case precompile.TxAllowListAddress:
 		return p.TxAllowListConfig, p.TxAllowListConfig != nil
-	case precompile.FeeConfigManagerAddress:
+	case precompile.FeeManagerAddress:
 		return p.FeeManagerConfig, p.FeeManagerConfig != nil
 	case precompile.RewardManagerAddress:
 		return p.RewardManagerConfig, p.RewardManagerConfig != nil
@@ -184,7 +184,7 @@ func (c *ChainConfig) GetActivePrecompileUpgrade(blockTimestamp *big.Int) Precom
 	if config := c.GetPrecompileConfig(precompile.TxAllowListAddress, blockTimestamp); config != nil && !config.IsDisabled() {
 		pu.TxAllowListConfig = config.(*txallowlist.TxAllowListConfig)
 	}
-	if config := c.GetPrecompileConfig(precompile.FeeConfigManagerAddress, blockTimestamp); config != nil && !config.IsDisabled() {
+	if config := c.GetPrecompileConfig(precompile.FeeManagerAddress, blockTimestamp); config != nil && !config.IsDisabled() {
 		pu.FeeManagerConfig = config.(*feemanager.FeeManagerConfig)
 	}
 	if config := c.GetPrecompileConfig(precompile.RewardManagerAddress, blockTimestamp); config != nil && !config.IsDisabled() {

--- a/params/precompile_config.go
+++ b/params/precompile_config.go
@@ -25,7 +25,7 @@ type PrecompileUpgrade struct {
 	ContractDeployerAllowListConfig *deployerallowlist.ContractDeployerAllowListConfig `json:"contractDeployerAllowListConfig,omitempty"` // Config for the contract deployer allow list precompile
 	ContractNativeMinterConfig      *nativeminter.ContractNativeMinterConfig           `json:"contractNativeMinterConfig,omitempty"`      // Config for the native minter precompile
 	TxAllowListConfig               *txallowlist.TxAllowListConfig                     `json:"txAllowListConfig,omitempty"`               // Config for the tx allow list precompile
-	FeeManagerConfig                *feemanager.FeeConfigManagerConfig                 `json:"feeManagerConfig,omitempty"`                // Config for the fee manager precompile
+	FeeManagerConfig                *feemanager.FeeManagerConfig                       `json:"feeManagerConfig,omitempty"`                // Config for the fee manager precompile
 	RewardManagerConfig             *rewardmanager.RewardManagerConfig                 `json:"rewardManagerConfig,omitempty"`             // Config for the reward manager precompile
 	// ADD YOUR PRECOMPILE HERE
 	// {YourPrecompile}Config  *precompile.{YourPrecompile}Config `json:"{yourPrecompile}Config,omitempty"`
@@ -185,7 +185,7 @@ func (c *ChainConfig) GetActivePrecompileUpgrade(blockTimestamp *big.Int) Precom
 		pu.TxAllowListConfig = config.(*txallowlist.TxAllowListConfig)
 	}
 	if config := c.GetPrecompileConfig(precompile.FeeConfigManagerAddress, blockTimestamp); config != nil && !config.IsDisabled() {
-		pu.FeeManagerConfig = config.(*feemanager.FeeConfigManagerConfig)
+		pu.FeeManagerConfig = config.(*feemanager.FeeManagerConfig)
 	}
 	if config := c.GetPrecompileConfig(precompile.RewardManagerAddress, blockTimestamp); config != nil && !config.IsDisabled() {
 		pu.RewardManagerConfig = config.(*rewardmanager.RewardManagerConfig)

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -2411,13 +2411,13 @@ func TestFeeManagerChangeFee(t *testing.T) {
 	}
 
 	// Check that address 0 is whitelisted and address 1 is not
-	role := feemanager.GetFeeConfigManagerStatus(genesisState, testEthAddrs[0])
+	role := feemanager.GetFeeManagerStatus(genesisState, testEthAddrs[0])
 	if role != allowlist.AllowListAdmin {
-		t.Fatalf("Expected fee manager list status to be set to admin: %s, but found: %s", precompile.FeeConfigManagerAddress, role)
+		t.Fatalf("Expected fee manager list status to be set to admin: %s, but found: %s", precompile.FeeManagerAddress, role)
 	}
-	role = feemanager.GetFeeConfigManagerStatus(genesisState, testEthAddrs[1])
+	role = feemanager.GetFeeManagerStatus(genesisState, testEthAddrs[1])
 	if role != allowlist.AllowListNoRole {
-		t.Fatalf("Expected fee manager list status to be set to no role: %s, but found: %s", precompile.FeeConfigManagerAddress, role)
+		t.Fatalf("Expected fee manager list status to be set to no role: %s, but found: %s", precompile.FeeManagerAddress, role)
 	}
 	// Contract is initialized but no preconfig is given, reader should return genesis fee config
 	feeConfig, lastChangedAt, err := vm.blockChain.GetFeeConfigAt(vm.blockChain.Genesis().Header())
@@ -2435,7 +2435,7 @@ func TestFeeManagerChangeFee(t *testing.T) {
 	tx := types.NewTx(&types.DynamicFeeTx{
 		ChainID:   genesis.Config.ChainID,
 		Nonce:     uint64(0),
-		To:        &precompile.FeeConfigManagerAddress,
+		To:        &precompile.FeeManagerAddress,
 		Gas:       testLowFeeConfig.GasLimit.Uint64(),
 		Value:     common.Big0,
 		GasFeeCap: testLowFeeConfig.MinBaseFee, // give low fee, it should work since we still haven't applied high fees
@@ -2471,7 +2471,7 @@ func TestFeeManagerChangeFee(t *testing.T) {
 	tx2 := types.NewTx(&types.DynamicFeeTx{
 		ChainID:   genesis.Config.ChainID,
 		Nonce:     uint64(1),
-		To:        &precompile.FeeConfigManagerAddress,
+		To:        &precompile.FeeManagerAddress,
 		Gas:       genesis.Config.FeeConfig.GasLimit.Uint64(),
 		Value:     common.Big0,
 		GasFeeCap: testLowFeeConfig.MinBaseFee, // this is too low for applied config, should fail

--- a/precompile/feemanager/config.go
+++ b/precompile/feemanager/config.go
@@ -15,7 +15,7 @@ import (
 )
 
 // FeeManagerConfig wraps [AllowListConfig] and uses it to implement the StatefulPrecompileConfig
-// interface while adding in the FeeConfigManager specific precompile address.
+// interface while adding in the FeeManager specific precompile address.
 type FeeManagerConfig struct {
 	allowlist.AllowListConfig // Config for the fee config manager allow list
 	precompile.UpgradeableConfig
@@ -23,7 +23,7 @@ type FeeManagerConfig struct {
 }
 
 // NewFeeManagerConfig returns a config for a network upgrade at [blockTimestamp] that enables
-// FeeConfigManager with the given [admins] and [enableds] as members of the allowlist with [initialConfig] as initial fee config if specified.
+// FeeManager with the given [admins] and [enableds] as members of the allowlist with [initialConfig] as initial fee config if specified.
 func NewFeeManagerConfig(blockTimestamp *big.Int, admins []common.Address, enableds []common.Address, initialConfig *commontype.FeeConfig) *FeeManagerConfig {
 	return &FeeManagerConfig{
 		AllowListConfig: allowlist.AllowListConfig{
@@ -36,7 +36,7 @@ func NewFeeManagerConfig(blockTimestamp *big.Int, admins []common.Address, enabl
 }
 
 // NewDisableFeeManagerConfig returns config for a network upgrade at [blockTimestamp]
-// that disables FeeConfigManager.
+// that disables FeeManager.
 func NewDisableFeeManagerConfig(blockTimestamp *big.Int) *FeeManagerConfig {
 	return &FeeManagerConfig{
 		UpgradeableConfig: precompile.UpgradeableConfig{
@@ -48,7 +48,7 @@ func NewDisableFeeManagerConfig(blockTimestamp *big.Int) *FeeManagerConfig {
 
 // Address returns the address of the fee config manager contract.
 func (c *FeeManagerConfig) Address() common.Address {
-	return precompile.FeeConfigManagerAddress
+	return precompile.FeeManagerAddress
 }
 
 // Equal returns true if [s] is a [*FeeManagerConfig] and it has been configured identical to [c].
@@ -84,12 +84,12 @@ func (c *FeeManagerConfig) Configure(chainConfig precompile.ChainConfig, state p
 			return fmt.Errorf("cannot configure fee config in chain config: %w", err)
 		}
 	}
-	return c.AllowListConfig.Configure(state, precompile.FeeConfigManagerAddress)
+	return c.AllowListConfig.Configure(state, precompile.FeeManagerAddress)
 }
 
 // Contract returns the singleton stateful precompiled contract to be used for the fee manager.
 func (c *FeeManagerConfig) Contract() precompile.StatefulPrecompiledContract {
-	return FeeConfigManagerPrecompile
+	return FeeManagerPrecompile
 }
 
 func (c *FeeManagerConfig) Verify() error {

--- a/precompile/feemanager/config.go
+++ b/precompile/feemanager/config.go
@@ -17,7 +17,7 @@ import (
 // FeeManagerConfig wraps [AllowListConfig] and uses it to implement the StatefulPrecompileConfig
 // interface while adding in the FeeManager specific precompile address.
 type FeeManagerConfig struct {
-	allowlist.AllowListConfig // Config for the fee config manager allow list
+	allowlist.AllowListConfig
 	precompile.UpgradeableConfig
 	InitialFeeConfig *commontype.FeeConfig `json:"initialFeeConfig,omitempty"` // initial fee config to be immediately activated
 }
@@ -46,7 +46,7 @@ func NewDisableFeeManagerConfig(blockTimestamp *big.Int) *FeeManagerConfig {
 	}
 }
 
-// Address returns the address of the fee config manager contract.
+// Address returns the address of the FeeManager contract.
 func (c *FeeManagerConfig) Address() common.Address {
 	return precompile.FeeManagerAddress
 }
@@ -72,7 +72,7 @@ func (c *FeeManagerConfig) Equal(s precompile.StatefulPrecompileConfig) bool {
 
 // Configure configures [state] with the desired admins based on [c].
 func (c *FeeManagerConfig) Configure(chainConfig precompile.ChainConfig, state precompile.StateDB, blockContext precompile.BlockContext) error {
-	// Store the initial fee config into the state when the fee config manager activates.
+	// Store the initial fee config into the state when the fee manager activates.
 	if c.InitialFeeConfig != nil {
 		if err := StoreFeeConfig(state, *c.InitialFeeConfig, blockContext); err != nil {
 			// This should not happen since we already checked this config with Verify()

--- a/precompile/feemanager/config.go
+++ b/precompile/feemanager/config.go
@@ -14,9 +14,9 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-// FeeConfigManagerConfig wraps [AllowListConfig] and uses it to implement the StatefulPrecompileConfig
+// FeeManagerConfig wraps [AllowListConfig] and uses it to implement the StatefulPrecompileConfig
 // interface while adding in the FeeConfigManager specific precompile address.
-type FeeConfigManagerConfig struct {
+type FeeManagerConfig struct {
 	allowlist.AllowListConfig // Config for the fee config manager allow list
 	precompile.UpgradeableConfig
 	InitialFeeConfig *commontype.FeeConfig `json:"initialFeeConfig,omitempty"` // initial fee config to be immediately activated
@@ -24,8 +24,8 @@ type FeeConfigManagerConfig struct {
 
 // NewFeeManagerConfig returns a config for a network upgrade at [blockTimestamp] that enables
 // FeeConfigManager with the given [admins] and [enableds] as members of the allowlist with [initialConfig] as initial fee config if specified.
-func NewFeeManagerConfig(blockTimestamp *big.Int, admins []common.Address, enableds []common.Address, initialConfig *commontype.FeeConfig) *FeeConfigManagerConfig {
-	return &FeeConfigManagerConfig{
+func NewFeeManagerConfig(blockTimestamp *big.Int, admins []common.Address, enableds []common.Address, initialConfig *commontype.FeeConfig) *FeeManagerConfig {
+	return &FeeManagerConfig{
 		AllowListConfig: allowlist.AllowListConfig{
 			AllowListAdmins:  admins,
 			EnabledAddresses: enableds,
@@ -37,8 +37,8 @@ func NewFeeManagerConfig(blockTimestamp *big.Int, admins []common.Address, enabl
 
 // NewDisableFeeManagerConfig returns config for a network upgrade at [blockTimestamp]
 // that disables FeeConfigManager.
-func NewDisableFeeManagerConfig(blockTimestamp *big.Int) *FeeConfigManagerConfig {
-	return &FeeConfigManagerConfig{
+func NewDisableFeeManagerConfig(blockTimestamp *big.Int) *FeeManagerConfig {
+	return &FeeManagerConfig{
 		UpgradeableConfig: precompile.UpgradeableConfig{
 			BlockTimestamp: blockTimestamp,
 			Disable:        true,
@@ -47,14 +47,14 @@ func NewDisableFeeManagerConfig(blockTimestamp *big.Int) *FeeConfigManagerConfig
 }
 
 // Address returns the address of the fee config manager contract.
-func (c *FeeConfigManagerConfig) Address() common.Address {
+func (c *FeeManagerConfig) Address() common.Address {
 	return precompile.FeeConfigManagerAddress
 }
 
-// Equal returns true if [s] is a [*FeeConfigManagerConfig] and it has been configured identical to [c].
-func (c *FeeConfigManagerConfig) Equal(s precompile.StatefulPrecompileConfig) bool {
+// Equal returns true if [s] is a [*FeeManagerConfig] and it has been configured identical to [c].
+func (c *FeeManagerConfig) Equal(s precompile.StatefulPrecompileConfig) bool {
 	// typecast before comparison
-	other, ok := (s).(*FeeConfigManagerConfig)
+	other, ok := (s).(*FeeManagerConfig)
 	if !ok {
 		return false
 	}
@@ -71,7 +71,7 @@ func (c *FeeConfigManagerConfig) Equal(s precompile.StatefulPrecompileConfig) bo
 }
 
 // Configure configures [state] with the desired admins based on [c].
-func (c *FeeConfigManagerConfig) Configure(chainConfig precompile.ChainConfig, state precompile.StateDB, blockContext precompile.BlockContext) error {
+func (c *FeeManagerConfig) Configure(chainConfig precompile.ChainConfig, state precompile.StateDB, blockContext precompile.BlockContext) error {
 	// Store the initial fee config into the state when the fee config manager activates.
 	if c.InitialFeeConfig != nil {
 		if err := StoreFeeConfig(state, *c.InitialFeeConfig, blockContext); err != nil {
@@ -88,11 +88,11 @@ func (c *FeeConfigManagerConfig) Configure(chainConfig precompile.ChainConfig, s
 }
 
 // Contract returns the singleton stateful precompiled contract to be used for the fee manager.
-func (c *FeeConfigManagerConfig) Contract() precompile.StatefulPrecompiledContract {
+func (c *FeeManagerConfig) Contract() precompile.StatefulPrecompiledContract {
 	return FeeConfigManagerPrecompile
 }
 
-func (c *FeeConfigManagerConfig) Verify() error {
+func (c *FeeManagerConfig) Verify() error {
 	if err := c.AllowListConfig.Verify(); err != nil {
 		return err
 	}
@@ -103,8 +103,8 @@ func (c *FeeConfigManagerConfig) Verify() error {
 	return c.InitialFeeConfig.Verify()
 }
 
-// String returns a string representation of the FeeConfigManagerConfig.
-func (c *FeeConfigManagerConfig) String() string {
+// String returns a string representation of the FeeManagerConfig.
+func (c *FeeManagerConfig) String() string {
 	bytes, _ := json.Marshal(c)
 	return string(bytes)
 }

--- a/precompile/feemanager/config_test.go
+++ b/precompile/feemanager/config_test.go
@@ -61,7 +61,7 @@ func TestVerifyFeeManagerConfig(t *testing.T) {
 	}
 }
 
-func TestEqualFeeConfigManagerConfig(t *testing.T) {
+func TestEqualFeeManagerConfig(t *testing.T) {
 	admins := []common.Address{{1}}
 	enableds := []common.Address{{2}}
 	tests := []struct {

--- a/precompile/feemanager/contract.go
+++ b/precompile/feemanager/contract.go
@@ -42,7 +42,7 @@ var (
 	_ precompile.StatefulPrecompileConfig = &FeeManagerConfig{}
 
 	// Singleton StatefulPrecompiledContract for setting fee configs by permissioned callers.
-	FeeConfigManagerPrecompile precompile.StatefulPrecompiledContract = createFeeConfigManagerPrecompile(precompile.FeeConfigManagerAddress)
+	FeeManagerPrecompile precompile.StatefulPrecompiledContract = createFeeManagerPrecompile(precompile.FeeManagerAddress)
 
 	setFeeConfigSignature              = precompile.CalculateFunctionSelector("setFeeConfig(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256)")
 	getFeeConfigSignature              = precompile.CalculateFunctionSelector("getFeeConfig()")
@@ -53,15 +53,15 @@ var (
 	ErrCannotChangeFee = errors.New("non-enabled cannot change fee config")
 )
 
-// GetFeeConfigManagerStatus returns the role of [address] for the fee config manager list.
-func GetFeeConfigManagerStatus(stateDB precompile.StateDB, address common.Address) allowlist.AllowListRole {
-	return allowlist.GetAllowListStatus(stateDB, precompile.FeeConfigManagerAddress, address)
+// GetFeeManagerStatus returns the role of [address] for the fee config manager list.
+func GetFeeManagerStatus(stateDB precompile.StateDB, address common.Address) allowlist.AllowListRole {
+	return allowlist.GetAllowListStatus(stateDB, precompile.FeeManagerAddress, address)
 }
 
-// SetFeeConfigManagerStatus sets the permissions of [address] to [role] for the
+// SetFeeManagerStatus sets the permissions of [address] to [role] for the
 // fee config manager list. assumes [role] has already been verified as valid.
-func SetFeeConfigManagerStatus(stateDB precompile.StateDB, address common.Address, role allowlist.AllowListRole) {
-	allowlist.SetAllowListRole(stateDB, precompile.FeeConfigManagerAddress, address, role)
+func SetFeeManagerStatus(stateDB precompile.StateDB, address common.Address, role allowlist.AllowListRole) {
+	allowlist.SetAllowListRole(stateDB, precompile.FeeManagerAddress, address, role)
 }
 
 // PackGetFeeConfigInput packs the getFeeConfig signature
@@ -148,7 +148,7 @@ func UnpackFeeConfigInput(input []byte) (commontype.FeeConfig, error) {
 func GetStoredFeeConfig(stateDB precompile.StateDB) commontype.FeeConfig {
 	feeConfig := commontype.FeeConfig{}
 	for i := minFeeConfigFieldKey; i <= numFeeConfigField; i++ {
-		val := stateDB.GetState(precompile.FeeConfigManagerAddress, common.Hash{byte(i)})
+		val := stateDB.GetState(precompile.FeeManagerAddress, common.Hash{byte(i)})
 		switch i {
 		case gasLimitKey:
 			feeConfig.GasLimit = new(big.Int).Set(val.Big())
@@ -175,7 +175,7 @@ func GetStoredFeeConfig(stateDB precompile.StateDB) commontype.FeeConfig {
 }
 
 func GetFeeConfigLastChangedAt(stateDB precompile.StateDB) *big.Int {
-	val := stateDB.GetState(precompile.FeeConfigManagerAddress, feeConfigLastChangedAtKey)
+	val := stateDB.GetState(precompile.FeeManagerAddress, feeConfigLastChangedAtKey)
 	return val.Big()
 }
 
@@ -209,14 +209,14 @@ func StoreFeeConfig(stateDB precompile.StateDB, feeConfig commontype.FeeConfig, 
 			// This should never encounter an unknown fee config key
 			panic(fmt.Sprintf("unknown fee config key: %d", i))
 		}
-		stateDB.SetState(precompile.FeeConfigManagerAddress, common.Hash{byte(i)}, input)
+		stateDB.SetState(precompile.FeeManagerAddress, common.Hash{byte(i)}, input)
 	}
 
 	blockNumber := blockContext.Number()
 	if blockNumber == nil {
 		return fmt.Errorf("blockNumber cannot be nil")
 	}
-	stateDB.SetState(precompile.FeeConfigManagerAddress, feeConfigLastChangedAtKey, common.BigToHash(blockNumber))
+	stateDB.SetState(precompile.FeeManagerAddress, feeConfigLastChangedAtKey, common.BigToHash(blockNumber))
 
 	return nil
 }
@@ -239,7 +239,7 @@ func setFeeConfig(accessibleState precompile.PrecompileAccessibleState, caller c
 
 	stateDB := accessibleState.GetStateDB()
 	// Verify that the caller is in the allow list and therefore has the right to modify it
-	callerStatus := allowlist.GetAllowListStatus(stateDB, precompile.FeeConfigManagerAddress, caller)
+	callerStatus := allowlist.GetAllowListStatus(stateDB, precompile.FeeManagerAddress, caller)
 	if !callerStatus.IsEnabled() {
 		return nil, remainingGas, fmt.Errorf("%w: %s", ErrCannotChangeFee, caller)
 	}
@@ -283,19 +283,19 @@ func getFeeConfigLastChangedAt(accessibleState precompile.PrecompileAccessibleSt
 	return common.BigToHash(lastChangedAt).Bytes(), remainingGas, err
 }
 
-// createFeeConfigManagerPrecompile returns a StatefulPrecompiledContract
+// createFeeManagerPrecompile returns a StatefulPrecompiledContract
 // with getters and setters for the chain's fee config. Access to the getters/setters
 // is controlled by an allow list for [precompileAddr].
-func createFeeConfigManagerPrecompile(precompileAddr common.Address) precompile.StatefulPrecompiledContract {
-	feeConfigManagerFunctions := allowlist.CreateAllowListFunctions(precompileAddr)
+func createFeeManagerPrecompile(precompileAddr common.Address) precompile.StatefulPrecompiledContract {
+	FeeManagerFunctions := allowlist.CreateAllowListFunctions(precompileAddr)
 
 	setFeeConfigFunc := precompile.NewStatefulPrecompileFunction(setFeeConfigSignature, setFeeConfig)
 	getFeeConfigFunc := precompile.NewStatefulPrecompileFunction(getFeeConfigSignature, getFeeConfig)
 	getFeeConfigLastChangedAtFunc := precompile.NewStatefulPrecompileFunction(getFeeConfigLastChangedAtSignature, getFeeConfigLastChangedAt)
 
-	feeConfigManagerFunctions = append(feeConfigManagerFunctions, setFeeConfigFunc, getFeeConfigFunc, getFeeConfigLastChangedAtFunc)
+	FeeManagerFunctions = append(FeeManagerFunctions, setFeeConfigFunc, getFeeConfigFunc, getFeeConfigLastChangedAtFunc)
 	// Construct the contract with no fallback function.
-	contract, err := precompile.NewStatefulPrecompileContract(nil, feeConfigManagerFunctions)
+	contract, err := precompile.NewStatefulPrecompileContract(nil, FeeManagerFunctions)
 	// TODO Change this to be returned as an error after refactoring this precompile
 	// to use the new precompile template.
 	if err != nil {

--- a/precompile/feemanager/contract.go
+++ b/precompile/feemanager/contract.go
@@ -39,7 +39,7 @@ const (
 )
 
 var (
-	_ precompile.StatefulPrecompileConfig = &FeeConfigManagerConfig{}
+	_ precompile.StatefulPrecompileConfig = &FeeManagerConfig{}
 
 	// Singleton StatefulPrecompiledContract for setting fee configs by permissioned callers.
 	FeeConfigManagerPrecompile precompile.StatefulPrecompiledContract = createFeeConfigManagerPrecompile(precompile.FeeConfigManagerAddress)

--- a/precompile/feemanager/contract.go
+++ b/precompile/feemanager/contract.go
@@ -53,13 +53,13 @@ var (
 	ErrCannotChangeFee = errors.New("non-enabled cannot change fee config")
 )
 
-// GetFeeManagerStatus returns the role of [address] for the fee config manager list.
+// GetFeeManagerStatus returns the role of [address] for the FeeManager allowlist.
 func GetFeeManagerStatus(stateDB precompile.StateDB, address common.Address) allowlist.AllowListRole {
 	return allowlist.GetAllowListStatus(stateDB, precompile.FeeManagerAddress, address)
 }
 
 // SetFeeManagerStatus sets the permissions of [address] to [role] for the
-// fee config manager list. assumes [role] has already been verified as valid.
+// FeeManager allowlist.
 func SetFeeManagerStatus(stateDB precompile.StateDB, address common.Address, role allowlist.AllowListRole) {
 	allowlist.SetAllowListRole(stateDB, precompile.FeeManagerAddress, address, role)
 }

--- a/precompile/params.go
+++ b/precompile/params.go
@@ -31,7 +31,7 @@ var (
 	ContractDeployerAllowListAddress = common.HexToAddress("0x0200000000000000000000000000000000000000")
 	ContractNativeMinterAddress      = common.HexToAddress("0x0200000000000000000000000000000000000001")
 	TxAllowListAddress               = common.HexToAddress("0x0200000000000000000000000000000000000002")
-	FeeConfigManagerAddress          = common.HexToAddress("0x0200000000000000000000000000000000000003")
+	FeeManagerAddress                = common.HexToAddress("0x0200000000000000000000000000000000000003")
 	RewardManagerAddress             = common.HexToAddress("0x0200000000000000000000000000000000000004")
 	// ADD YOUR PRECOMPILE HERE
 	// {YourPrecompile}Address       = common.HexToAddress("0x03000000000000000000000000000000000000??")
@@ -40,7 +40,7 @@ var (
 		ContractDeployerAllowListAddress,
 		ContractNativeMinterAddress,
 		TxAllowListAddress,
-		FeeConfigManagerAddress,
+		FeeManagerAddress,
 		RewardManagerAddress,
 		// ADD YOUR PRECOMPILE HERE
 		// YourPrecompileAddress


### PR DESCRIPTION
## Why this should be merged

Cleans up extra "config" word in the name

## How this works

Renames struct

## How this was tested

Existing UTs should cover this

Replaces #422 