### PR TITLE
Bump avalanchego dep to v1.9.7 and start v0.4.9 release cycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ The Subnet EVM runs in a separate process from the main AvalancheGo process and 
 [v0.4.2] AvalancheGo@v1.9.1 (Protocol Version: 18)
 [v0.4.3] AvalancheGo@v1.9.2-v1.9.3 (Protocol Version: 19)
 [v0.4.4] AvalancheGo@v1.9.2-v1.9.3 (Protocol Version: 19)
+[v0.4.5] AvalancheGo@v1.9.4 (Protocol Version: 20)
+[v0.4.6] AvalancheGo@v1.9.4 (Protocol Version: 20)
+[v0.4.7] AvalancheGo@v1.9.5 (Protocol Version: 21)
+[v0.4.8] AvalancheGo@v1.9.6-v1.9.7 (Protocol Version: 22)
 ```
 
 ## API

--- a/cmd/simulator/go.mod
+++ b/cmd/simulator/go.mod
@@ -15,7 +15,7 @@ replace github.com/ava-labs/subnet-evm => ../..
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.10.0 // indirect
-	github.com/ava-labs/avalanchego v1.9.6 // indirect
+	github.com/ava-labs/avalanchego v1.9.7 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.3.2 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.3 // indirect

--- a/cmd/simulator/go.sum
+++ b/cmd/simulator/go.sum
@@ -45,8 +45,8 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk5
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah4HI848JfFxHt+iPb26b4zyfspmqY0/8=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/ava-labs/avalanchego v1.9.6 h1:xDLo7iVf73ohgR3alhRJcEalM7B8Pi5HkgCesl8lkf8=
-github.com/ava-labs/avalanchego v1.9.6/go.mod h1:ckdSQHeoRN6PmQ3TLgWAe6Kh9tFpU4Lu6MgDW4GrU/Q=
+github.com/ava-labs/avalanchego v1.9.7 h1:f2vS8jUBZmrqPcfU5NEa7dSHXbKfTB0EyjcCyvqxqPw=
+github.com/ava-labs/avalanchego v1.9.7/go.mod h1:ckdSQHeoRN6PmQ3TLgWAe6Kh9tFpU4Lu6MgDW4GrU/Q=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=

--- a/compatibility.json
+++ b/compatibility.json
@@ -1,5 +1,6 @@
 {
   "rpcChainVMProtocolVersion": {
+    "v0.4.9": 22,
     "v0.4.8": 22,
     "v0.4.7": 21,
     "v0.4.6": 20,

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/VictoriaMetrics/fastcache v1.10.0
 	github.com/ava-labs/avalanche-network-runner-sdk v0.3.0
-	github.com/ava-labs/avalanchego v1.9.6
+	github.com/ava-labs/avalanchego v1.9.7
 	github.com/cespare/cp v0.1.0
 	github.com/creack/pty v1.1.18
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/ava-labs/avalanche-network-runner-sdk v0.3.0 h1:TVi9JEdKNU/RevYZ9PyW4pULbEdS+KQDA9Ki2DUvuAs=
 github.com/ava-labs/avalanche-network-runner-sdk v0.3.0/go.mod h1:SgKJvtqvgo/Bl/c8fxEHCLaSxEbzimYfBopcfrajxQk=
-github.com/ava-labs/avalanchego v1.9.6 h1:xDLo7iVf73ohgR3alhRJcEalM7B8Pi5HkgCesl8lkf8=
-github.com/ava-labs/avalanchego v1.9.6/go.mod h1:ckdSQHeoRN6PmQ3TLgWAe6Kh9tFpU4Lu6MgDW4GrU/Q=
+github.com/ava-labs/avalanchego v1.9.7 h1:f2vS8jUBZmrqPcfU5NEa7dSHXbKfTB0EyjcCyvqxqPw=
+github.com/ava-labs/avalanchego v1.9.7/go.mod h1:ckdSQHeoRN6PmQ3TLgWAe6Kh9tFpU4Lu6MgDW4GrU/Q=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=

--- a/plugin/evm/version.go
+++ b/plugin/evm/version.go
@@ -11,7 +11,7 @@ var (
 	// GitCommit is set by the build script
 	GitCommit string
 	// Version is the version of Subnet EVM
-	Version string = "v0.4.8"
+	Version string = "v0.4.9"
 )
 
 func init() {

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 # Set up the versions to be used
-subnet_evm_version=${SUBNET_EVM_VERSION:-'v0.4.8'}
+subnet_evm_version=${SUBNET_EVM_VERSION:-'v0.4.9'}
 # Don't export them as they're used in the context of other calls
-avalanche_version=${AVALANCHE_VERSION:-'v1.9.6'}
+avalanche_version=${AVALANCHE_VERSION:-'v1.9.7'}
 network_runner_version=${NETWORK_RUNNER_VERSION:-'v1.3.5'}
 ginkgo_version=${GINKGO_VERSION:-'v2.2.0'}
 


### PR DESCRIPTION
This PR bumps the AvalancheGo dependency to v1.9.7 and starts the v0.4.9 release cycle.