### PR TITLE
Add release checklist template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/release_checklist.md
@@ -1,5 +1,5 @@
 ---
-name: Release Checlist
+name: Release Checklist
 about: Create a ticket to track a release
 title: ''
 labels: release

--- a/.github/ISSUE_TEMPLATE/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/release_checklist.md
@@ -1,0 +1,25 @@
+---
+name: Release Checlist
+about: Create a ticket to track a release
+title: ''
+labels: release
+assignees: ''
+
+---
+
+**Release**
+The release version and a description of the planned changes to be included in the release.
+
+**Issues**
+Link the major issues planned to be included in the release.
+
+**Documentation**
+Link the relevant documentation PRs for this release.
+
+**Checklist**
+- [ ] Update version in scripts/versions.sh and plugin/evm/version.go
+- [ ] Bump AvalancheGo dependency for RPCChainVM Compatibility
+- [ ] Add new entry in compatibility.json for RPCChainVM Compatibility
+- [ ] Update AvalancheGo compatibility in README
+- [ ] Bump cmd/simulator go mod (if needed)
+- [ ] Confirm release binaries are generated correctly

--- a/.github/ISSUE_TEMPLATE/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/release_checklist.md
@@ -22,4 +22,4 @@ Link the relevant documentation PRs for this release.
 - [ ] Add new entry in compatibility.json for RPCChainVM Compatibility
 - [ ] Update AvalancheGo compatibility in README
 - [ ] Bump cmd/simulator go mod (if needed)
-- [ ] Confirm release binaries are generated correctly
+- [ ] Confirm goreleaser job has successfully generated binaries by checking the releases page


### PR DESCRIPTION
This PR adds a release checklist template to help track all of the items that go into a Subnet-EVM release.