### PR TITLE
Implement gossiping to proposers

### DIFF
--- a/peer/client.go
+++ b/peer/client.go
@@ -7,7 +7,8 @@ import (
 	"errors"
 
 	"github.com/ava-labs/avalanchego/ids"
-
+	"github.com/ava-labs/avalanchego/utils/set"
+	
 	"github.com/ava-labs/avalanchego/version"
 )
 

--- a/peer/client.go
+++ b/peer/client.go
@@ -32,6 +32,8 @@ type NetworkClient interface {
 	// Gossip sends given gossip message to peers
 	Gossip(gossip []byte) error
 
+	GossipSpecific(gossip []byte, nodeIDs set.Set[ids.NodeID]) error
+
 	// TrackBandwidth should be called for each valid request with the bandwidth
 	// (length of response divided by request time), and with 0 if the response is invalid.
 	TrackBandwidth(nodeID ids.NodeID, bandwidth float64)
@@ -84,6 +86,10 @@ func (c *client) Request(nodeID ids.NodeID, request []byte) ([]byte, error) {
 
 func (c *client) Gossip(gossip []byte) error {
 	return c.network.Gossip(gossip)
+}
+
+func (c *client) GossipSpecific(gossip []byte, nodeIDs set.Set[ids.NodeID]) error {
+	return c.network.GossipSpecific(gossip, nodeIDs)
 }
 
 func (c *client) TrackBandwidth(nodeID ids.NodeID, bandwidth float64) {

--- a/peer/client.go
+++ b/peer/client.go
@@ -33,7 +33,8 @@ type NetworkClient interface {
 	// Gossip sends given gossip message to peers
 	Gossip(gossip []byte) error
 
-	GossipSpecific(gossip []byte, nodeIDs set.Set[ids.NodeID]) error
+	// GossipSpecific sends given gossip message to peers specified by [nodeIDs]
+	GossipSpecific(nodeIDs set.Set[ids.NodeID], gossip []byte) error
 
 	// TrackBandwidth should be called for each valid request with the bandwidth
 	// (length of response divided by request time), and with 0 if the response is invalid.
@@ -89,8 +90,8 @@ func (c *client) Gossip(gossip []byte) error {
 	return c.network.Gossip(gossip)
 }
 
-func (c *client) GossipSpecific(gossip []byte, nodeIDs set.Set[ids.NodeID]) error {
-	return c.network.GossipSpecific(gossip, nodeIDs)
+func (c *client) GossipSpecific(nodeIDs set.Set[ids.NodeID], gossip []byte) error {
+	return c.network.GossipSpecific(nodeIDs, gossip)
 }
 
 func (c *client) TrackBandwidth(nodeID ids.NodeID, bandwidth float64) {

--- a/peer/network.go
+++ b/peer/network.go
@@ -299,7 +299,7 @@ func (n *network) Gossip(gossip []byte) error {
 
 // Gossip sends given gossip message to peers specified by [nodeIDs]
 func (n *network) GossipSpecific(gossip []byte, nodeIDs set.Set[ids.NodeID]) error {
-	return n.appSender.SendAppGossipSpecific(nodeIDs, gossip)
+	return n.appSender.SendAppGossipSpecific(context.TODO(), nodeIDs, gossip)
 }
 
 // AppGossip is called by avalanchego -> VM when there is an incoming AppGossip from a peer

--- a/peer/network.go
+++ b/peer/network.go
@@ -51,6 +51,9 @@ type Network interface {
 	// Gossip sends given gossip message to peers
 	Gossip(gossip []byte) error
 
+	// Gossip sends given gossip message to peers specified by [nodeIDs]
+	GossipSpecific(gossip []byte, nodeIDs set.Set[ids.NodeID]) error
+
 	// Shutdown stops all peer channel listeners and marks the node to have stopped
 	// n.Start() can be called again but the peers will have to be reconnected
 	// by calling OnPeerConnected for each peer
@@ -292,6 +295,11 @@ func (n *network) getRequestHandler(requestID uint32) (message.ResponseHandler, 
 // Gossip sends given gossip message to peers
 func (n *network) Gossip(gossip []byte) error {
 	return n.appSender.SendAppGossip(context.TODO(), gossip)
+}
+
+// Gossip sends given gossip message to peers specified by [nodeIDs]
+func (n *network) GossipSpecific(gossip []byte, nodeIDs set.Set[ids.NodeID]) error {
+	return n.appSender.SendAppGossipSpecific(nodeIDs, gossip)
 }
 
 // AppGossip is called by avalanchego -> VM when there is an incoming AppGossip from a peer

--- a/peer/network.go
+++ b/peer/network.go
@@ -51,8 +51,8 @@ type Network interface {
 	// Gossip sends given gossip message to peers
 	Gossip(gossip []byte) error
 
-	// Gossip sends given gossip message to peers specified by [nodeIDs]
-	GossipSpecific(gossip []byte, nodeIDs set.Set[ids.NodeID]) error
+	// GossipSpecific sends given gossip message to peers specified by [nodeIDs]
+	GossipSpecific(nodeIDs set.Set[ids.NodeID], gossip []byte) error
 
 	// Shutdown stops all peer channel listeners and marks the node to have stopped
 	// n.Start() can be called again but the peers will have to be reconnected
@@ -297,8 +297,8 @@ func (n *network) Gossip(gossip []byte) error {
 	return n.appSender.SendAppGossip(context.TODO(), gossip)
 }
 
-// Gossip sends given gossip message to peers specified by [nodeIDs]
-func (n *network) GossipSpecific(gossip []byte, nodeIDs set.Set[ids.NodeID]) error {
+// GossipSpecific sends given gossip message to peers specified by [nodeIDs]
+func (n *network) GossipSpecific(nodeIDs set.Set[ids.NodeID], gossip []byte) error {
 	return n.appSender.SendAppGossipSpecific(context.TODO(), nodeIDs, gossip)
 }
 

--- a/plugin/evm/block_builder.go
+++ b/plugin/evm/block_builder.go
@@ -4,6 +4,7 @@
 package evm
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -171,7 +172,7 @@ func (b *blockBuilder) awaitSubmittedTxs() {
 					time.Sleep(waitBlockTime)
 
 					// Retrieve nodes to gossip to
-					proposers, err := b.ctx.ProposerRetriever.Proposers()
+					proposers, err := b.ctx.ProposerRetriever.GetCurrentProposers(context.TODO()) // UNSURE OF WHAT CONTEXT TO USE HERE
 					if err != nil {
 						log.Warn("failed to retrieve list of proposers", "err", err)
 					}

--- a/plugin/evm/block_builder.go
+++ b/plugin/evm/block_builder.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ava-labs/subnet-evm/params"
 
 	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/vms/proposervm/proposer"
 	commonEng "github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -178,7 +179,7 @@ func (b *blockBuilder) awaitSubmittedTxs() {
 					}
 
 					// [GossipTxsToNodes] will gossip txs directly to proposer nodes.
-					if err := b.gossiper.GossipTxsToNodes(ethTxsEvent.Txs, proposers); err != nil {
+					if err := b.gossiper.GossipTxsToNodes(proposers, ethTxsEvent.Txs); err != nil {
 						log.Warn(
 							"failed to gossip new eth transactions to proposers",
 							"err", err,

--- a/plugin/evm/block_builder.go
+++ b/plugin/evm/block_builder.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/ava-labs/avalanchego/utils/timer"
+	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/subnet-evm/core"
 	"github.com/ava-labs/subnet-evm/params"
 
@@ -183,6 +184,7 @@ func (b *blockBuilder) awaitSubmittedTxs() {
 						log.Warn(
 							"failed to gossip new eth transactions to proposers",
 							"err", err,
+							"numProposers", proposers.Len(),
 						)
 					}
 				}

--- a/plugin/evm/block_builder.go
+++ b/plugin/evm/block_builder.go
@@ -36,11 +36,15 @@ const (
 	minBlockBuildingRetryDelay = 500 * time.Millisecond
 )
 
+type blockBuilderConfig struct {
+	TargetedProposerGossipEnabled bool
+}
+
 type blockBuilder struct {
 	ctx         *snow.Context
 	chainConfig *params.ChainConfig
 
-	config Config
+	config 		*blockBuilderConfig
 
 	txPool   *core.TxPool
 	gossiper Gossiper
@@ -80,7 +84,9 @@ func (vm *VM) NewBlockBuilder(notifyBuildBlockChan chan<- commonEng.Message) *bl
 	)
 	b := &blockBuilder{
 		ctx:                  vm.ctx,
-		config: 			  vm.config,
+		config:  			  &blockBuilderConfig{
+			TargetedProposerGossipEnabled: vm.config.TargetedProposerGossipEnabled,
+		},
 		chainConfig:          vm.chainConfig,
 		blockChain: 		  vm.blockChain,
 		txPool:               vm.txPool,

--- a/plugin/evm/block_builder.go
+++ b/plugin/evm/block_builder.go
@@ -169,11 +169,17 @@ func (b *blockBuilder) awaitSubmittedTxs() {
 					// Give time for this node to build a block before attempting to
 					// gossip
 					time.Sleep(waitBlockTime)
-					// [GossipTxs] will block unless [gossiper.txsToGossipChan] (an
-					// unbuffered channel) is listened on
-					if err := b.gossiper.GossipTxs(ethTxsEvent.Txs); err != nil {
+
+					// Retrieve nodes to gossip to
+					proposers, err := b.ctx.ProposerRetriever.Proposers()
+					if err != nil {
+						log.Warn("failed to retrieve list of proposers", "err", err)
+					}
+
+					// [GossipTxsToNodes] will gossip txs directly to proposer nodes.
+					if err := b.gossiper.GossipTxsToNodes(ethTxsEvent.Txs, proposers); err != nil {
 						log.Warn(
-							"failed to gossip new eth transactions",
+							"failed to gossip new eth transactions to proposers",
 							"err", err,
 						)
 					}

--- a/plugin/evm/config.go
+++ b/plugin/evm/config.go
@@ -39,6 +39,7 @@ const (
 	defaultPriorityRegossipFrequency              = 1 * time.Second
 	defaultPriorityRegossipMaxTxs                 = 32
 	defaultPriorityRegossipTxsPerAddress          = 16
+	defaultTargetedProposerGossipEnabled          = true
 	defaultOfflinePruningBloomFilterSize   uint64 = 512 // Default size (MB) for the offline pruner to use
 	defaultLogLevel                               = "info"
 	defaultLogJSONFormat                          = false
@@ -157,6 +158,7 @@ type Config struct {
 	PriorityRegossipMaxTxs        int              `json:"priority-regossip-max-txs"`
 	PriorityRegossipTxsPerAddress int              `json:"priority-regossip-txs-per-address"`
 	PriorityRegossipAddresses     []common.Address `json:"priority-regossip-addresses"`
+	TargetedProposerGossipEnabled bool			   `json:"targeted-proposer-gossip-enabled"`
 
 	// Log
 	LogLevel      string `json:"log-level"`
@@ -242,6 +244,7 @@ func (c *Config) SetDefaults() {
 	c.PriorityRegossipFrequency.Duration = defaultPriorityRegossipFrequency
 	c.PriorityRegossipMaxTxs = defaultPriorityRegossipMaxTxs
 	c.PriorityRegossipTxsPerAddress = defaultPriorityRegossipTxsPerAddress
+	c.TargetedProposerGossipEnabled = defaultTargetedProposerGossipEnabled
 	c.OfflinePruningBloomFilterSize = defaultOfflinePruningBloomFilterSize
 	c.LogLevel = defaultLogLevel
 	c.LogJSONFormat = defaultLogJSONFormat

--- a/plugin/evm/gossiper.go
+++ b/plugin/evm/gossiper.go
@@ -405,7 +405,7 @@ func (n *pushGossiper) GossipTxs(txs []*types.Transaction) error {
 
 // GossipTxs immediately gossips the provided [txs] to [nodeIDs]. 
 func (n *pushGossiper) GossipTxsToNodes(nodeIDs set.Set[ids.NodeID], txs []*types.Transaction, ) error {
-	if len(txs) == 0 || set.Len(nodeIDs) == 0 {
+	if len(txs) == 0 || nodeIDs.Len() == 0 {
 		return nil
 	}
 

--- a/plugin/evm/gossiper.go
+++ b/plugin/evm/gossiper.go
@@ -42,7 +42,8 @@ type Gossiper interface {
 	// GossipTxs sends AppGossip message containing the given [txs]
 	GossipTxs(txs []*types.Transaction) error
 
-	GossipTxsToNodes(txs []*types.Transaction, nodeIDs set.Set[ids.NodeID]) error
+	// GossipTxsToNodes sends AppGossip message containing the given [txs] to nodes specified by [nodeIDs]
+	GossipTxsToNodes(nodeIDs set.Set[ids.NodeID], txs []*types.Transaction) error
 }
 
 // pushGossiper is used to gossip transactions to the network
@@ -403,7 +404,7 @@ func (n *pushGossiper) GossipTxs(txs []*types.Transaction) error {
 }
 
 // GossipTxs immediately gossips the provided [txs] to [nodeIDs]. 
-func (n *pushGossiper) GossipTxsToNodes(txs []*types.Transaction, nodeIDs set.Set[ids.NodeID]) error {
+func (n *pushGossiper) GossipTxsToNodes(nodeIDs set.Set[ids.NodeID], txs []*types.Transaction, ) error {
 	if len(txs) == 0 {
 		return nil
 	}
@@ -427,7 +428,7 @@ func (n *pushGossiper) GossipTxsToNodes(txs []*types.Transaction, nodeIDs set.Se
 		"node(ids)", nodeIDs,
 	)
 	n.stats.IncEthTxsGossipSent()
-	return n.client.GossipSpecific(msgBytes, nodeIDs)
+	return n.client.GossipSpecific(nodeIDs, msgBytes)
 }
 
 // GossipHandler handles incoming gossip messages
@@ -496,6 +497,6 @@ func (n *noopGossiper) GossipTxs([]*types.Transaction) error {
 	return nil
 }
 
-func (n *noopGossiper) GossipTxsToNodes([]*types.Transaction, set.Set[ids.NodeID]) error {
+func (n *noopGossiper) GossipTxsToNodes(set.Set[ids.NodeID], []*types.Transaction, ) error {
 	return nil
 }

--- a/plugin/evm/gossiper.go
+++ b/plugin/evm/gossiper.go
@@ -41,6 +41,8 @@ const (
 type Gossiper interface {
 	// GossipTxs sends AppGossip message containing the given [txs]
 	GossipTxs(txs []*types.Transaction) error
+
+	GossipTxsToNodes(txs []*types.Transaction, nodeIDs set.Set[ids.NodeID]) error
 }
 
 // pushGossiper is used to gossip transactions to the network
@@ -491,5 +493,9 @@ func (h *GossipHandler) HandleTxs(nodeID ids.NodeID, msg message.TxsGossip) erro
 type noopGossiper struct{}
 
 func (n *noopGossiper) GossipTxs([]*types.Transaction) error {
+	return nil
+}
+
+func (n *noopGossiper) GossipTxsToNodes([]*types.Transaction, set.Set[ids.NodeID]) error {
 	return nil
 }

--- a/plugin/evm/gossiper.go
+++ b/plugin/evm/gossiper.go
@@ -405,7 +405,7 @@ func (n *pushGossiper) GossipTxs(txs []*types.Transaction) error {
 
 // GossipTxs immediately gossips the provided [txs] to [nodeIDs]. 
 func (n *pushGossiper) GossipTxsToNodes(nodeIDs set.Set[ids.NodeID], txs []*types.Transaction, ) error {
-	if len(txs) == 0 {
+	if len(txs) == 0 || set.Len(nodeIDs) == 0 {
 		return nil
 	}
 

--- a/sync/client/mock_network.go
+++ b/sync/client/mock_network.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/subnet-evm/peer"
 
 	"github.com/ava-labs/avalanchego/version"
@@ -74,6 +75,10 @@ func (t *mockNetwork) processMock(request []byte) ([]byte, error) {
 }
 
 func (t *mockNetwork) Gossip([]byte) error {
+	panic("not implemented") // we don't care about this function for this test
+}
+
+func (t *mockNetwork) GossipSpecific(gossip []byte, nodeIDs set.Set[ids.NodeID]) error {
 	panic("not implemented") // we don't care about this function for this test
 }
 

--- a/sync/client/mock_network.go
+++ b/sync/client/mock_network.go
@@ -78,7 +78,7 @@ func (t *mockNetwork) Gossip([]byte) error {
 	panic("not implemented") // we don't care about this function for this test
 }
 
-func (t *mockNetwork) GossipSpecific(gossip []byte, nodeIDs set.Set[ids.NodeID]) error {
+func (t *mockNetwork) GossipSpecific(nodeIDs set.Set[ids.NodeID], gossip []byte) error {
 	panic("not implemented") // we don't care about this function for this test
 }
 


### PR DESCRIPTION
## Why this should be merged
- Currently, when transactions are submitted to the transaction pool, `subnet-evm` will
    - signal the consensus engine to call “BuildBlock” by sending a “PendingTxs” signal
    - gossip the new transactions submitted to the block
- Currently, snowman++ will select certain validators to act as proposers for a given window
    - thus, only a few validators(the proposers) will actually call “BuildBlock” when signaled
- Insight:
    - gossiping new transactions to validators that won’t be able to propose new blocks is wasted traffic / bandwidth
    - we should gossip new transactions only to the proposers at a given window

## How this works
- Exposes necessary interfaces to gossip to specific nodes
- Changes block builder to gossip transactions directly to proposers if `TargetedProposerGossipEnabled` is true

## How this was tested
- A version of this PR was tested on coreth by spinning up local avalanche-network and verifying that gossip was being sent to proposers via prints statements
