### PR TITLE
Improve version output

### DIFF
--- a/plugin/main.go
+++ b/plugin/main.go
@@ -9,19 +9,20 @@ import (
 
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/ulimit"
+	"github.com/ava-labs/avalanchego/version"
 	"github.com/ava-labs/avalanchego/vms/rpcchainvm"
 
 	"github.com/ava-labs/subnet-evm/plugin/evm"
 )
 
 func main() {
-	version, err := PrintVersion()
+	printVersion, err := PrintVersion()
 	if err != nil {
 		fmt.Printf("couldn't get config: %s", err)
 		os.Exit(1)
 	}
-	if version {
-		fmt.Println(evm.Version)
+	if printVersion {
+		fmt.Printf("Subnet-EVM/%s [AvalancheGo=%s, rpcchainvm=%d]\n", evm.Version, version.Current, version.RPCChainVMProtocol)
 		os.Exit(0)
 	}
 	if err := ulimit.Set(ulimit.DefaultFDLimit, logging.NoLog{}); err != nil {


### PR DESCRIPTION
## Why this should be merged

This PR improves the output of the version command to display the version of AvalancheGo and RPCChainVMProtocol version that Subnet-EVM was built with.

## How this works

This prints two additional constants in the version command imported from AvalancheGo.

## How this was tested

```bash
aaronbuchwald@dhcp-vl2052-1520 subnet-evm % ../avalanchego/build/plugins/srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy --version
Subnet-EVM/v0.4.9@a584fcad593885b6c095f42adaff6b53d51aedb8 [AvalancheGo=v1.9.7, rpcchainvm=22]
```
