### PR TITLE
Fixes #464: adding missing import "encoding/json" (used in Stringer-method)

### DIFF
--- a/accounts/abi/bind/precompile_template.go
+++ b/accounts/abi/bind/precompile_template.go
@@ -45,9 +45,10 @@ Typically, custom codes are required in only those areas.
 package precompile
 
 import (
-	"math/big"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"math/big"
 	"strings"
 
 	"github.com/ava-labs/subnet-evm/accounts/abi"


### PR DESCRIPTION
This PR fixes #464 

- adding missing import-statement "encoding/json"
- re-ordering of imports

## Why this should be merged

it makes the precompile eventually compiling.

## How this works

it adds a missing import-statement

## How this was tested

- create a precompiled contract and compiles the whole repository with it