### PR TITLE
Check size before slice access

### DIFF
--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -369,5 +369,10 @@ func UnpackRevert(data []byte) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return unpacked[0].(string), nil
+
+	if len(unpacked) > 0 {
+		return unpacked[0].(string), nil
+	}
+
+	return "", nil
 }

--- a/accounts/abi/bind/base.go
+++ b/accounts/abi/bind/base.go
@@ -494,8 +494,10 @@ func (c *BoundContract) WatchLogs(opts *WatchOpts, name string, query ...[]inter
 
 // UnpackLog unpacks a retrieved log into the provided output structure.
 func (c *BoundContract) UnpackLog(out interface{}, event string, log types.Log) error {
-	if log.Topics[0] != c.abi.Events[event].ID {
-		return fmt.Errorf("event signature mismatch")
+	if len(log.Topics) > 0 {
+		if log.Topics[0] != c.abi.Events[event].ID {
+			return fmt.Errorf("event signature mismatch")
+		}
 	}
 	if len(log.Data) > 0 {
 		if err := c.abi.UnpackIntoInterface(out, event, log.Data); err != nil {
@@ -513,8 +515,10 @@ func (c *BoundContract) UnpackLog(out interface{}, event string, log types.Log) 
 
 // UnpackLogIntoMap unpacks a retrieved log into the provided map.
 func (c *BoundContract) UnpackLogIntoMap(out map[string]interface{}, event string, log types.Log) error {
-	if log.Topics[0] != c.abi.Events[event].ID {
-		return fmt.Errorf("event signature mismatch")
+	if len(log.Topics) > 0 {
+		if log.Topics[0] != c.abi.Events[event].ID {
+			return fmt.Errorf("event signature mismatch")
+		}
 	}
 	if len(log.Data) > 0 {
 		if err := c.abi.UnpackIntoMap(out, event, log.Data); err != nil {


### PR DESCRIPTION
**Areas in the code where we access a slice without checking slice length first.** 
### Simulated
https://github.com/ava-labs/subnet-evm/blob/master/accounts/abi/bind/backends/simulated.go#L179
https://github.com/ava-labs/subnet-evm/blob/master/accounts/abi/bind/backends/simulated.go#L724
https://github.com/ava-labs/subnet-evm/blob/master/accounts/abi/bind/backends/simulated.go#L839

Did not address these lines. Simulated Backend is only used for testing purposes. Worst case is that we get a panic on a poorly written test. 

### Base 
https://github.com/ava-labs/subnet-evm/blob/master/accounts/abi/bind/base.go#L497
https://github.com/ava-labs/subnet-evm/blob/master/accounts/abi/bind/base.go#L516

Modified to check slice length. Currently, `UnpackLogs` is only used on logs that have been filtered by `FilterLogs` and `WatchLogs`, which filter logs based on the event name. Technically, the event can be of type LOG0 (log with no topics)  log. 
`UnpackLogs,` in the future, could be used standalone without any filtered logs. It is a good precaution to take to check slice length. 

This code is in geth. 

### Bind
https://github.com/ava-labs/subnet-evm/blob/master/accounts/abi/bind/bind.go#L117
https://github.com/ava-labs/subnet-evm/blob/master/accounts/abi/bind/bind.go#L303

Did not address these. Bind is only used in the precompile gen and abi gen. These both take in arguments from a CLI command. Worst case scenario is a panic on a CLI command to generate a precompile/abi. User can simply adjust inputs to the command to fix. 


### ABI
https://github.com/ava-labs/subnet-evm/blob/master/accounts/abi/abi.go#L372

Modified to check slice length. 
The only way this could error is if a contract had a revert with an empty message, which is possible. 
Returns an empty slice here which would panic if we access -> https://github.com/ava-labs/subnet-evm/blob/0fb0afe8a38daf13880e8d3c0fc43b4edc74c80e/accounts/abi/argument.go#L95

This code is in geth. 