### PR TITLE
try to bump golangci-lint version

### DIFF
--- a/.github/workflows/lint-tests-release.yml
+++ b/.github/workflows/lint-tests-release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.47
+          version: v1.51
           working-directory: .
           args: --timeout 3m
 


### PR DESCRIPTION
## Why this should be merged

## How this works

## How this was tested
