### PR TITLE
Add create precompile script to set CGO flag before running precompilegen script

### DIFF
--- a/scripts/generate_precompile.sh
+++ b/scripts/generate_precompile.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -e
+
+# This script generates a Stateful Precompile stub based off of a Solidity ABI file.
+# It first sets the necessary CGO_FLAGs for the BLST library used in AvalancheGo and
+# then runs PrecompileGen.
+if ! [[ "$0" =~ scripts/generate_precompile.sh ]]; then
+  echo "must be run from repository root, but got $0"
+  exit 255
+fi
+
+# Load the versions
+SUBNET_EVM_PATH=$(
+  cd "$(dirname "${BASH_SOURCE[0]}")"
+  cd .. && pwd
+)
+
+# Load the constants
+source "$SUBNET_EVM_PATH"/scripts/constants.sh
+
+go run ./cmd/precompilegen/main.go $@


### PR DESCRIPTION
## Why this should be merged

This PR should be merged in order to ensure that the CGO flags required by the blst library imported in AvalancheGo are set as required.

This PR addresses: https://github.com/ava-labs/subnet-evm/issues/483

## How this works

This PR creates a new script `./scripts/create_precompile.sh` which sets the required constants and then runs the same command that `go run ...` command that was previously required to generate a precompile stub.

## How this was tested

This was tested by completing step 0 of the PrecompileGen tutorial with one modification included in this PR: https://github.com/ava-labs/avalanche-docs/pull/1196

## How is this documented

Change to PrecompileGen tutorial is documented here: https://github.com/ava-labs/avalanche-docs/pull/1196