### PR TITLE
State upgrades

### DIFF
--- a/contract-examples/contracts/ExampleCodeUpgradeAfter.sol
+++ b/contract-examples/contracts/ExampleCodeUpgradeAfter.sol
@@ -1,0 +1,19 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+// ExampleContractAfter shows how the CodeUpgrader precompile can be used to upgrade the code of a smart contract.
+contract ExampleCodeUpgraderAfter {
+    // Make a 6 gap variable.
+    uint256[7] private ______gap;
+
+    // Cap is now at slot 0x7.
+    uint256 public cap = 125000000 ether; // We initialize the cap to 125 million ether.
+
+    event CapUpdated(uint256 newCap);
+
+    // Add a method to update the cap.
+    function updateCap(uint256 _cap) public {
+        cap = _cap;
+        emit CapUpdated(_cap);
+    }
+}

--- a/contract-examples/contracts/ExampleCodeUpgradeBefore.sol
+++ b/contract-examples/contracts/ExampleCodeUpgradeBefore.sol
@@ -1,0 +1,11 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+// ExampleContractBefore shows how the CodeUpgrader precompile can be used to upgrade the code of a smart contract.
+contract ExampleCodeUpgraderBefore {
+    // Make a 6 gap variable.
+    uint256[7] private ______gap;
+
+    // Cap is now at slot 0x7.
+    uint256 public cap = 125000000 ether; // We initialize the cap to 125 million ether.
+}

--- a/contract-examples/contracts/ExampleStateSlotUpgrade.sol
+++ b/contract-examples/contracts/ExampleStateSlotUpgrade.sol
@@ -1,0 +1,11 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+// ExampleStateSlotUpgrade shows how the Slot state upgrader can be used.
+contract ExampleStateSlotUpgrade {
+    // Make a 6 gap variable.
+    uint256[6] private ______gap;
+
+    // Cap is now at slot 7.
+    uint256 public cap = 125000000 ether; // We initialize the cap to 125 million ether.
+}

--- a/contract-examples/hardhat.config.ts
+++ b/contract-examples/hardhat.config.ts
@@ -3,7 +3,7 @@ import "./tasks.ts"
 
 // HardHat users must populate these environment variables in order to connect to their subnet-evm instance
 // Since the blockchainID is not known in advance, there's no good default to use and we use the C-Chain here.
-var local_rpc_uri = process.env.RPC_URI || "http://127.0.0.1:9650/ext/bc/C/rpc"
+var local_rpc_uri = process.env.RPC_URI || "http://127.0.0.1:9656/ext/bc/2JnjbcpDB5J53syUJPyjPDdv6uQmtYC6AZazbmETkrB1ggbd73/rpc"
 var local_chain_id = process.env.CHAIN_ID || 99999
 
 export default {

--- a/contract-examples/hardhat.config.ts
+++ b/contract-examples/hardhat.config.ts
@@ -3,7 +3,7 @@ import "./tasks.ts"
 
 // HardHat users must populate these environment variables in order to connect to their subnet-evm instance
 // Since the blockchainID is not known in advance, there's no good default to use and we use the C-Chain here.
-var local_rpc_uri = process.env.RPC_URI || "http://127.0.0.1:9656/ext/bc/2JnjbcpDB5J53syUJPyjPDdv6uQmtYC6AZazbmETkrB1ggbd73/rpc"
+var local_rpc_uri = process.env.RPC_URI || "http://127.0.0.1:9650/ext/bc/C/rpc"
 var local_chain_id = process.env.CHAIN_ID || 99999
 
 export default {

--- a/contract-examples/test/ExampleCodeUpgrader.ts
+++ b/contract-examples/test/ExampleCodeUpgrader.ts
@@ -1,0 +1,49 @@
+// (c) 2019-2022, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+import { expect } from "chai"
+import { ethers } from "hardhat"
+import { Contract, ContractFactory } from "ethers"
+
+describe("ExampleCodeUpgrader", function () {
+    let beforeContract: Contract
+    let afterContract: Contract
+    let ExampleCodeUpgraderBeforeFactory: ContractFactory
+    let ExampleCodeUpgraderAfterFactory: ContractFactory
+
+    before(async function () {
+        // Deploy the two contracts, before and after.
+        ExampleCodeUpgraderBeforeFactory = await ethers.getContractFactory(
+            "ExampleCodeUpgraderBefore"
+        )
+        beforeContract = await ExampleCodeUpgraderBeforeFactory.deploy()
+        await beforeContract.deployTransaction.wait(1)
+        console.log(`Before contract deployed to: ${beforeContract.address}`)
+
+        ExampleCodeUpgraderAfterFactory = await ethers.getContractFactory(
+            "ExampleCodeUpgraderAfter"
+        )
+        afterContract = await ExampleCodeUpgraderAfterFactory.deploy()
+        await afterContract.deployTransaction.wait(1)
+        console.log(`After contract deployed to: ${afterContract.address}`)
+    })
+
+    it("update cap method fails on before contract, but not after", async function () {
+        // expect(await beforeContract.updateCap()).to.be.equal(
+        //     ethers.BigNumber.from(ethers.utils.parseEther("250000000"))
+        // )
+
+        expect(await afterContract.updateCap("250000000")).to.emit(
+            afterContract, "CapUpdated"
+        )
+    })
+
+    it("after network upgrade, before contract now has after contract's code", async function () {
+        console.log("Using hardcoded before contract addresses: 0x52C84043CD9c865236f11d9Fc9F56aa003c1f922")
+        const newBeforeContract = ExampleCodeUpgraderAfterFactory.attach("0x52C84043CD9c865236f11d9Fc9F56aa003c1f922")
+
+        expect(await newBeforeContract.updateCap(ethers.BigNumber.from("250000000"))).to.emit(
+            newBeforeContract, "CapUpdated"
+        )
+    })
+})

--- a/contract-examples/test/state_slot_upgrader.ts
+++ b/contract-examples/test/state_slot_upgrader.ts
@@ -1,0 +1,30 @@
+// (c) 2019-2022, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+import { expect } from "chai"
+import { ethers } from "hardhat"
+import { Contract, ContractFactory } from "ethers"
+
+describe("ExampleStateSlotUpgrade", function () {
+    let capIncreaserContract: Contract
+
+    before(async function () {
+        // Deploy ExampleStateSlotUpgrade Contract
+        const ContractF: ContractFactory = await ethers.getContractFactory(
+            "ExampleStateSlotUpgrade"
+        )
+
+        capIncreaserContract = await ContractF.deploy()
+        await capIncreaserContract.deployTransaction.wait(1)
+        console.log(`Contract deployed to: ${capIncreaserContract.address}`)
+
+        console.log("Using hardcoded contract address: 0x52C84043CD9c865236f11d9Fc9F56aa003c1f922")
+        capIncreaserContract = ContractF.attach("0x52C84043CD9c865236f11d9Fc9F56aa003c1f922")
+    })
+
+    it("cap was updated to 250 million", async function () {
+        expect(await capIncreaserContract.cap()).to.be.equal(
+            ethers.BigNumber.from(ethers.utils.parseEther("250000000"))
+        )
+    })
+})

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -307,7 +307,7 @@ func (g *Genesis) ToBlock(db ethdb.Database) *types.Block {
 	}
 
 	// Configure any stateful precompiles that should be enabled in the genesis.
-	g.Config.CheckConfigurePrecompiles(nil, types.NewBlockWithHeader(head), statedb)
+	g.Config.ApplyStateUpgrades(nil, types.NewBlockWithHeader(head), statedb)
 
 	// Do custom allocation after airdrop in case an address shows up in standard
 	// allocation

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -78,7 +78,7 @@ func (p *StateProcessor) Process(block *types.Block, parent *types.Header, state
 	)
 
 	// Configure any stateful precompiles that should go into effect during this block.
-	p.config.CheckConfigurePrecompiles(new(big.Int).SetUint64(parent.Time), block, statedb)
+	p.config.ApplyStateUpgrades(new(big.Int).SetUint64(parent.Time), block, statedb)
 
 	blockContext := NewEVMBlockContext(header, p.bc, nil)
 	vmenv := vm.NewEVM(blockContext, vm.TxContext{}, statedb, p.config, cfg)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -186,7 +186,7 @@ func (w *worker) commitNewWork() (*types.Block, error) {
 		return nil, fmt.Errorf("failed to create new current environment: %w", err)
 	}
 	// Configure any stateful precompiles that should go into effect during this block.
-	w.chainConfig.CheckConfigurePrecompiles(new(big.Int).SetUint64(parent.Time()), types.NewBlockWithHeader(header), env.state)
+	w.chainConfig.ApplyStateUpgrades(new(big.Int).SetUint64(parent.Time()), types.NewBlockWithHeader(header), env.state)
 
 	// Fill the block with all available pending transactions.
 	pending := w.eth.TxPool().Pending(true)

--- a/params/config.go
+++ b/params/config.go
@@ -171,6 +171,9 @@ type UpgradeConfig struct {
 	// forks must be present or upgradeBytes will be rejected.
 	NetworkUpgrades *NetworkUpgrades `json:"networkUpgrades,omitempty"`
 
+	// Config for enabling state upgrades from genesis.
+	StateUpgrades []StateUpgrade `json:"stateUpgrades,omitempty"`
+
 	// Config for enabling and disabling precompiles as network upgrades.
 	PrecompileUpgrades []PrecompileUpgrade `json:"precompileUpgrades,omitempty"`
 }
@@ -342,6 +345,11 @@ func (c *ChainConfig) Verify() error {
 		return err
 	}
 
+	// Verify the state upgrades are internally consistent given the existing chainConfig.
+	if err := c.verifyStateUpgrades(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -473,6 +481,11 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, lastHeight *big.Int, 
 
 	// Check that the precompiles on the new config are compatible with the existing precompile config.
 	if err := c.CheckPrecompilesCompatible(newcfg.PrecompileUpgrades, lastTimestamp); err != nil {
+		return err
+	}
+
+	// Check that the state upgrades on the new config are compatible with the existing state upgrade config.
+	if err := c.CheckStateUpgradesCompatible(newcfg.StateUpgrades, lastTimestamp); err != nil {
 		return err
 	}
 

--- a/params/precompile_config.go
+++ b/params/precompile_config.go
@@ -5,6 +5,7 @@ package params
 
 import (
 	"fmt"
+	"github.com/ava-labs/subnet-evm/stateupgrade"
 	"math/big"
 
 	"github.com/ava-labs/subnet-evm/precompile"
@@ -389,9 +390,8 @@ func (c *ChainConfig) ApplyStateUpgrades(parentTimestamp *big.Int, blockContext 
 				// since Suicide will be committed after the reconfiguration.
 				statedb.Finalise(true)
 			} else {
-				log.Info("Activating new precompile", "name", key, "config", config)
-				// TODO The statedb might need to be type cast
-				//stateupgrade.RunUpgrade(c, blockContext, config, statedb)
+				log.Info("Activating new state upgrade", "name", key, "config", config)
+				stateupgrade.RunUpgrade(c, blockContext, config, statedb)
 			}
 		}
 	}

--- a/params/stateupgrade_config.go
+++ b/params/stateupgrade_config.go
@@ -19,10 +19,10 @@ type stateUpgradeKey int
 const (
 	stateUpgradeCodeKey stateUpgradeKey = iota + 1
 	stateUpgradeStateKey
-	stateUpgradeBalanceKey
-	stateUpgradeDeployKey
+	//stateUpgradeBalanceKey
+	//stateUpgradeDeployKey
 )
-var stateUpgradeKeys = []stateUpgradeKey{stateUpgradeCodeKey, stateUpgradeStateKey, stateUpgradeBalanceKey, stateUpgradeDeployKey}
+var stateUpgradeKeys = []stateUpgradeKey{stateUpgradeCodeKey, stateUpgradeStateKey/*, stateUpgradeBalanceKey, stateUpgradeDeployKey*/}
 
 // StateUpgrade is a helper struct embedded in UpgradeConfig, representing
 // each of the possible stateful state upgrade types that can be activated
@@ -38,6 +38,12 @@ func (p *StateUpgrade) getByKey(key stateUpgradeKey) (stateupgrade.StateUpgradeC
 	switch key {
 	case stateUpgradeCodeKey:
 		return p.StateUpgradeCodeConfig, p.StateUpgradeCodeConfig != nil
+	case stateUpgradeStateKey:
+		return p.StateUpgradeStateConfig, p.StateUpgradeStateConfig != nil
+	//case stateUpgradeBalanceKey:
+	//	return p.StateUpgradeBalanceConfig, p.StateUpgradeBalanceConfig != nil
+	//case stateUpgradeDeployKey:
+	//	return p.StateUpgradeDeployConfig, p.StateUpgradeDeployConfig != nil
 	default:
 		panic(fmt.Sprintf("unknown state upgrade key: %v", key))
 	}

--- a/params/stateupgrade_config.go
+++ b/params/stateupgrade_config.go
@@ -1,0 +1,226 @@
+// (c) 2022 Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package params
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ava-labs/subnet-evm/stateupgrade"
+	"github.com/ava-labs/subnet-evm/utils"
+)
+
+// stateUpgradeKey is a helper type used to reference each of the
+// possible state upgrade types that can be activated
+// as a network upgrade.
+type stateUpgradeKey int
+
+const (
+	stateUpgradeCodeKey stateUpgradeKey = iota + 1
+	stateUpgradeStateKey
+	stateUpgradeBalanceKey
+	stateUpgradeDeployKey
+)
+var stateUpgradeKeys = []stateUpgradeKey{stateUpgradeCodeKey, stateUpgradeStateKey, stateUpgradeBalanceKey, stateUpgradeDeployKey}
+
+// StateUpgrade is a helper struct embedded in UpgradeConfig, representing
+// each of the possible stateful state upgrade types that can be activated
+// as a network upgrade.
+type StateUpgrade struct {
+	StateUpgradeCodeConfig 			*stateupgrade.StateUpgradeCodeConfig		`json:"stateUpgradeCodeConfig,omitempty"` 		   // Config for the state upgrade code upgrader
+	StateUpgradeStateConfig 		*stateupgrade.StateUpgradeStateConfig		`json:"stateUpgradeStateConfig,omitempty"` 		   // Config for the state upgrade state upgrader
+	//StateUpgradeBalanceConfig 		*stateupgrade.StateUpgradeBalanceConfig		`json:"stateUpgradeBalanceConfig,omitempty"` 	   // Config for the state upgrade balance upgrader
+	//StateUpgradeDeployConfig 		*stateupgrade.StateUpgradeDeployConfig		`json:"stateUpgradeDeployConfig,omitempty"` 	   // Config for the state upgrade deploy upgrader
+}
+
+func (p *StateUpgrade) getByKey(key stateUpgradeKey) (stateupgrade.StateUpgradeConfig, bool) {
+	switch key {
+	case stateUpgradeCodeKey:
+		return p.StateUpgradeCodeConfig, p.StateUpgradeCodeConfig != nil
+	default:
+		panic(fmt.Sprintf("unknown state upgrade key: %v", key))
+	}
+}
+
+// verifyStateUpgrades checks [c.StateUpgrades] is well formed:
+// - [upgrades] must specify exactly one key per StateUpgrade
+// - the specified blockTimestamps must monotonically increase
+// - the specified blockTimestamps must be compatible with those
+//   specified in the chainConfig by genesis.
+// - check a state upgrade is disabled before it is re-enabled
+func (c *ChainConfig) verifyStateUpgrades() error {
+	var lastBlockTimestamp *big.Int
+	for i, upgrade := range c.StateUpgrades {
+		hasKey := false // used to verify if there is only one key per Upgrade
+
+		for _, key := range stateUpgradeKeys {
+			config, ok := upgrade.getByKey(key)
+			if !ok {
+				continue
+			}
+			if hasKey {
+				return fmt.Errorf("StateUpgrades[%d] has more than one key set", i)
+			}
+			configTimestamp := config.Timestamp()
+			if configTimestamp == nil {
+				return fmt.Errorf("StateUpgrades[%d] cannot have a nil timestamp", i)
+			}
+			// Verify specified timestamps are monotonically increasing across all state upgrade keys.
+			// Note: It is OK for multiple configs of different keys to specify the same timestamp.
+			if lastBlockTimestamp != nil && configTimestamp.Cmp(lastBlockTimestamp) < 0 {
+				return fmt.Errorf("StateUpgrades[%d] config timestamp (%v) < previous timestamp (%v)", i, configTimestamp, lastBlockTimestamp)
+			}
+			lastBlockTimestamp = configTimestamp
+			hasKey = true
+		}
+		if !hasKey {
+			return fmt.Errorf("empty state upgrade at index %d", i)
+		}
+	}
+
+	for _, key := range stateUpgradeKeys {
+		var (
+			lastUpgraded *big.Int
+			disabled     bool
+		)
+		disabled = true
+		// next range over upgrades to verify correct use of disabled and blockTimestamps.
+		for i, upgrade := range c.StateUpgrades {
+			config, ok := upgrade.getByKey(key)
+			// Skip the upgrade if it's not relevant to [key].
+			if !ok {
+				continue
+			}
+
+			if disabled == config.IsDisabled() {
+				return fmt.Errorf("StateUpgrades[%d] disable should be [%v]", i, !disabled)
+			}
+			if lastUpgraded != nil && (config.Timestamp().Cmp(lastUpgraded) <= 0) {
+				return fmt.Errorf("StateUpgrades[%d] config timestamp (%v) <= previous timestamp (%v)", i, config.Timestamp(), lastUpgraded)
+			}
+
+			if err := config.Verify(); err != nil {
+				return err
+			}
+
+			disabled = config.IsDisabled()
+			lastUpgraded = config.Timestamp()
+		}
+	}
+
+	return nil
+}
+
+func (c *ChainConfig) GetActiveStateUpgrades(blockTimestamp *big.Int) StateUpgrade {
+	u := StateUpgrade{}
+	if config := c.GetStateUpgradeCodeConfig(blockTimestamp); config != nil && !config.Disable {
+		u.StateUpgradeCodeConfig = config
+	}
+
+	return u
+}
+
+// getActiveStateUpgradeConfig returns the most recent state upgrade config corresponding to [key].
+// If none have occurred, returns nil.
+func (c *ChainConfig) getActiveStateUpgradeConfig(blockTimestamp *big.Int, key stateUpgradeKey, upgrades []StateUpgrade) stateupgrade.StateUpgradeConfig {
+	configs := c.getActivatingStateUpgradeConfigs(nil, blockTimestamp, key, upgrades)
+	if len(configs) == 0 {
+		return nil
+	}
+	return configs[len(configs)-1] // return the most recent config
+}
+
+// getActivatingStateUpgradeConfigs returns all forks configured to activate during the state transition from a block with timestamp [from]
+// to a block with timestamp [to].
+func (c *ChainConfig) getActivatingStateUpgradeConfigs(from *big.Int, to *big.Int, key stateUpgradeKey, upgrades []StateUpgrade) []stateupgrade.StateUpgradeConfig {
+	configs := make([]stateupgrade.StateUpgradeConfig, 0)
+	// Loop over all upgrades checking for the requested state upgrade config.
+	for _, upgrade := range upgrades {
+		if config, ok := upgrade.getByKey(key); ok {
+			// Check if the state upgrade activates in the specified range.
+			if utils.IsForkTransition(config.Timestamp(), from, to) {
+				configs = append(configs, config)
+			}
+		}
+	}
+	return configs
+}
+
+// GetStateUpgradeCodeConfig returns the latest forked StateUpgradeCodeConfig
+// specified by [c] or nil if it was never enabled.
+func (c *ChainConfig) GetStateUpgradeCodeConfig(blockTimestamp *big.Int) *stateupgrade.StateUpgradeCodeConfig {
+	if val := c.getActiveStateUpgradeConfig(blockTimestamp, stateUpgradeCodeKey, c.StateUpgrades); val != nil {
+		return val.(*stateupgrade.StateUpgradeCodeConfig)
+	}
+	return nil
+}
+
+// CheckStateUpgradesCompatible checks if [StateUpgrades] are compatible with [c] at [headTimestamp].
+// Returns a ConfigCompatError if upgrades already forked at [headTimestamp] are missing from
+// [stateUpgrades]. Upgrades not already forked may be modified or absent from [stateUpgrades].
+// Returns nil if [stateUpgrades] is compatible with [c].
+// Assumes given timestamp is the last accepted block timestamp.
+// This ensures that as long as the node has not accepted a block with a different rule set it will allow a new upgrade to be applied as long as it activates after the last accepted block.
+func (c *ChainConfig) CheckStateUpgradesCompatible(stateUpgrades []StateUpgrade, lastTimestamp *big.Int) *ConfigCompatError {
+	for _, key := range stateUpgradeKeys {
+		if err := c.checkStateUpgradeCompatible(key, stateUpgrades, lastTimestamp); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// checkStateUpgradeCompatible verifies that the state upgrade specified by [key] is compatible between [c] and [stateUpgrades] at [headTimestamp].
+// Returns an error if upgrades already forked at [headTimestamp] are missing from [stateUpgrades].
+// Upgrades that have already gone into effect cannot be modified or absent from [stateUpgrades].
+func (c *ChainConfig) checkStateUpgradeCompatible(key stateUpgradeKey, stateUpgrades []StateUpgrade, lastTimestamp *big.Int) *ConfigCompatError {
+	// all active upgrades must match
+	activeUpgrades := c.getActivatingStateUpgradeConfigs(nil, lastTimestamp, key, c.StateUpgrades)
+	newUpgrades := c.getActivatingStateUpgradeConfigs(nil, lastTimestamp, key, stateUpgrades)
+
+	// first, check existing upgrades are there
+	for i, upgrade := range activeUpgrades {
+		if len(newUpgrades) <= i {
+			// missing upgrade
+			return newCompatError(
+				fmt.Sprintf("missing StateUpgrade[%d]", i),
+				upgrade.Timestamp(),
+				nil,
+			)
+		}
+		// All upgrades that have forked must be identical.
+		if !upgrade.Equal(newUpgrades[i]) {
+			return newCompatError(
+				fmt.Sprintf("StateUpgrade[%d]", i),
+				upgrade.Timestamp(),
+				newUpgrades[i].Timestamp(),
+			)
+		}
+	}
+	// then, make sure newUpgrades does not have additional upgrades
+	// that are already activated. (cannot perform retroactive upgrade)
+	if len(newUpgrades) > len(activeUpgrades) {
+		return newCompatError(
+			fmt.Sprintf("cannot retroactively enable StateUpgrade[%d]", len(activeUpgrades)),
+			nil,
+			newUpgrades[len(activeUpgrades)].Timestamp(), // this indexes to the first element in newUpgrades after the end of activeUpgrades
+		)
+	}
+
+	return nil
+}
+
+// EnabledStateUpgrades returns a slice of stateful state upgrade configs that
+// have been activated through an upgrade.
+func (c *ChainConfig) EnabledStateUpgrades(blockTimestamp *big.Int) []stateupgrade.StateUpgradeConfig {
+	stateUpgradeConfigs := make([]stateupgrade.StateUpgradeConfig, 0)
+	for _, key := range stateUpgradeKeys {
+		if config := c.getActiveStateUpgradeConfig(blockTimestamp, key, c.StateUpgrades); config != nil {
+			stateUpgradeConfigs = append(stateUpgradeConfigs, config)
+		}
+	}
+
+	return stateUpgradeConfigs
+}

--- a/precompile/contract.go
+++ b/precompile/contract.go
@@ -50,6 +50,7 @@ type StateDB interface {
 	SetState(common.Address, common.Hash, common.Hash)
 
 	SetCode(common.Address, []byte)
+	GetCode(common.Address) []byte
 
 	SetNonce(common.Address, uint64)
 	GetNonce(common.Address) uint64

--- a/stateupgrade/code.go
+++ b/stateupgrade/code.go
@@ -19,7 +19,7 @@ type StateUpgradeCodeConfigStruct struct {
 // StateUpgradeCodeConfig implements the StateUpgradeConfig interface.
 type StateUpgradeCodeConfig struct {
 	UpgradeableConfig
-	InitialStateUpgradeCodeConfig *StateUpgradeCodeConfigStruct `json:"initialStateUpgradeCodeConfig,omitempty"`
+	InitialStateUpgradeCodeConfig *StateUpgradeCodeConfigStruct `json:"config,omitempty"`
 }
 
 func init() {

--- a/stateupgrade/code.go
+++ b/stateupgrade/code.go
@@ -1,0 +1,89 @@
+package stateupgrade
+
+import (
+	"encoding/json"
+	"github.com/ethereum/go-ethereum/log"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type StateUpgradeCodeConfigStruct struct {
+	// The source contract address.
+	Source common.Address `json:"source,omitempty"`
+
+	// The address of the contract that will be upgraded.
+	Target common.Address `json:"target,omitempty"`
+}
+
+// StateUpgradeCodeConfig implements the StateUpgradeConfig interface.
+type StateUpgradeCodeConfig struct {
+	UpgradeableConfig
+	InitialStateUpgradeCodeConfig *StateUpgradeCodeConfigStruct `json:"initialStateUpgradeCodeConfig,omitempty"`
+}
+
+func init() {
+	// Nothing to do here
+}
+
+// NewStateUpgradeCodeConfig returns a config for a network upgrade at [blockTimestamp] that enables
+// StateUpgradeCode .
+func NewStateUpgradeCodeConfig(blockTimestamp *big.Int) *StateUpgradeCodeConfig {
+	return &StateUpgradeCodeConfig{
+		UpgradeableConfig: UpgradeableConfig{BlockTimestamp: blockTimestamp},
+	}
+}
+
+// NewDisableStateUpgradeCodeConfig returns config for a network upgrade at [blockTimestamp]
+// that disables StateUpgradeCode.
+func NewDisableStateUpgradeCodeConfig(blockTimestamp *big.Int) *StateUpgradeCodeConfig {
+	return &StateUpgradeCodeConfig{
+		UpgradeableConfig: UpgradeableConfig{
+			BlockTimestamp: blockTimestamp,
+			Disable:        true,
+		},
+	}
+}
+
+// Equal returns true if [s] is a [*StateUpgradeCodeConfig] and it has been configured identical to [c].
+func (c *StateUpgradeCodeConfig) Equal(s StateUpgradeConfig) bool {
+	// typecast before comparison
+	other, ok := (s).(*StateUpgradeCodeConfig)
+	if !ok {
+		return false
+	}
+	// modify this boolean accordingly with your custom StateUpgradeCodeConfig, to check if [other] and the current [c] are equal
+	// if StateUpgradeCodeConfig contains only UpgradeableConfig  you can skip modifying it.
+	equals := c.UpgradeableConfig.Equal(&other.UpgradeableConfig)
+	return equals
+}
+
+// String returns a string representation of the StateUpgradeCodeConfig.
+func (c *StateUpgradeCodeConfig) String() string {
+	bytes, _ := json.Marshal(c)
+	return string(bytes)
+}
+
+// Configure configures [state] with the initial configuration.
+func (c *StateUpgradeCodeConfig) RunUpgrade(_ ChainConfig, state StateDB, _ BlockContext) {
+	// This will be called in the first block where it is enabled.
+	// 1) If BlockTimestamp is nil, this will not be called
+	// 2) If BlockTimestamp is 0, this will be called while setting up the genesis block
+	// 3) If BlockTimestamp is 1000, this will be called while processing the first block
+	// whose timestamp is >= 1000
+
+	// Set the code.
+	log.Info("Running StateUpgradeCode Config", "config", c)
+	if c.InitialStateUpgradeCodeConfig != nil {
+		// Load the account of the source contract.
+		log.Info("Setting the code", "source", c.InitialStateUpgradeCodeConfig.Source, "target", c.InitialStateUpgradeCodeConfig.Target, "code", state.GetCode(c.InitialStateUpgradeCodeConfig.Source))
+		state.SetCode(c.InitialStateUpgradeCodeConfig.Target, state.GetCode(c.InitialStateUpgradeCodeConfig.Source))
+	} else {
+		log.Error("Code Upgrader Config is not set")
+	}
+}
+
+// Verify tries to verify StateUpgradeCodeConfig and returns an error accordingly.
+func (c *StateUpgradeCodeConfig) Verify() error {
+	return nil
+}

--- a/stateupgrade/contract.go
+++ b/stateupgrade/contract.go
@@ -1,0 +1,49 @@
+// (c) 2019-2020, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package stateupgrade
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// BlockContext defines an interface that provides information to a stateful stateupgrade
+// about the block that activates the upgrade. The stateupgrade can access this information
+// to initialize its state.
+type BlockContext interface {
+	Number() *big.Int
+	Timestamp() *big.Int
+}
+
+// ChainConfig defines an interface that provides information to a stateful stateupgrade
+// about the chain configuration. The stateupgrade can access this information to initialize
+// its state.
+type ChainConfig interface {
+
+}
+
+// StateDB is the interface for accessing EVM state
+type StateDB interface {
+	GetState(common.Address, common.Hash) common.Hash
+	SetState(common.Address, common.Hash, common.Hash)
+
+	SetCode(common.Address, []byte)
+	GetCode(common.Address) []byte
+
+	SetNonce(common.Address, uint64)
+	GetNonce(common.Address) uint64
+
+	GetBalance(common.Address) *big.Int
+	AddBalance(common.Address, *big.Int)
+	SubBalance(common.Address, *big.Int)
+
+	CreateAccount(common.Address)
+	Exist(common.Address) bool
+
+	AddLog(addr common.Address, topics []common.Hash, data []byte, blockNumber uint64)
+
+	Suicide(common.Address) bool
+	Finalise(deleteEmptyObjects bool)
+}

--- a/stateupgrade/state.go
+++ b/stateupgrade/state.go
@@ -1,0 +1,89 @@
+package stateupgrade
+
+import (
+	"encoding/json"
+	"github.com/ethereum/go-ethereum/log"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type StateUpgradeStateConfigStruct struct {
+	// The source contract address.
+	Source common.Address `json:"source,omitempty"`
+
+	// The address of the contract that will be upgraded.
+	Target common.Address `json:"target,omitempty"`
+}
+
+// StateUpgradeStateConfig implements the StateUpgradeConfig interface.
+type StateUpgradeStateConfig struct {
+	UpgradeableConfig
+	InitialStateUpgradeStateConfig *StateUpgradeStateConfigStruct `json:"initialStateUpgradeStateConfig,omitempty"`
+}
+
+func init() {
+	// Nothing to do here
+}
+
+// NewStateUpgradeStateConfig returns a config for a network upgrade at [blockTimestamp] that enables
+// StateUpgradeState .
+func NewStateUpgradeStateConfig(blockTimestamp *big.Int) *StateUpgradeStateConfig {
+	return &StateUpgradeStateConfig{
+		UpgradeableConfig: UpgradeableConfig{BlockTimestamp: blockTimestamp},
+	}
+}
+
+// NewDisableStateUpgradeStateConfig returns config for a network upgrade at [blockTimestamp]
+// that disables StateUpgradeState.
+func NewDisableStateUpgradeStateConfig(blockTimestamp *big.Int) *StateUpgradeStateConfig {
+	return &StateUpgradeStateConfig{
+		UpgradeableConfig: UpgradeableConfig{
+			BlockTimestamp: blockTimestamp,
+			Disable:        true,
+		},
+	}
+}
+
+// Equal returns true if [s] is a [*StateUpgradeStateConfig] and it has been configured identical to [c].
+func (c *StateUpgradeStateConfig) Equal(s StateUpgradeConfig) bool {
+	// typecast before comparison
+	other, ok := (s).(*StateUpgradeStateConfig)
+	if !ok {
+		return false
+	}
+	// modify this boolean accordingly with your custom StateUpgradeStateConfig, to check if [other] and the current [c] are equal
+	// if StateUpgradeStateConfig contains only UpgradeableConfig  you can skip modifying it.
+	equals := c.UpgradeableConfig.Equal(&other.UpgradeableConfig)
+	return equals
+}
+
+// String returns a string representation of the StateUpgradeStateConfig.
+func (c *StateUpgradeStateConfig) String() string {
+	bytes, _ := json.Marshal(c)
+	return string(bytes)
+}
+
+// Configure configures [state] with the initial configuration.
+func (c *StateUpgradeStateConfig) RunUpgrade(_ ChainConfig, state StateDB, _ BlockContext) {
+	// This will be called in the first block where it is enabled.
+	// 1) If BlockTimestamp is nil, this will not be called
+	// 2) If BlockTimestamp is 0, this will be called while setting up the genesis block
+	// 3) If BlockTimestamp is 1000, this will be called while processing the first block
+	// whose timestamp is >= 1000
+
+	// Set the code.
+	log.Info("Running StateUpgradeState Config", "config", c)
+	if c.InitialStateUpgradeStateConfig != nil {
+		// Load the account of the source contract.
+		log.Info("Setting the code", "source", c.InitialStateUpgradeStateConfig.Source, "target", c.InitialStateUpgradeStateConfig.Target, "code", state.GetCode(c.InitialStateUpgradeStateConfig.Source))
+		state.SetCode(c.InitialStateUpgradeStateConfig.Target, state.GetCode(c.InitialStateUpgradeStateConfig.Source))
+	} else {
+		log.Error("Code Upgrader Config is not set")
+	}
+}
+
+// Verify tries to verify StateUpgradeStateConfig and returns an error accordingly.
+func (c *StateUpgradeStateConfig) Verify() error {
+	return nil
+}

--- a/stateupgrade/state.go
+++ b/stateupgrade/state.go
@@ -9,17 +9,20 @@ import (
 )
 
 type StateUpgradeStateConfigStruct struct {
-	// The source contract address.
-	Source common.Address `json:"source,omitempty"`
-
 	// The address of the contract that will be upgraded.
-	Target common.Address `json:"target,omitempty"`
+	Address common.Address `json:"address,omitempty"`
+
+	// The memory slot.
+	Slot *big.Int `json:"slot,omitempty"`
+
+	// The new cap to be set.
+	Value *big.Int `json:"value,omitempty"`
 }
 
 // StateUpgradeStateConfig implements the StateUpgradeConfig interface.
 type StateUpgradeStateConfig struct {
 	UpgradeableConfig
-	InitialStateUpgradeStateConfig *StateUpgradeStateConfigStruct `json:"initialStateUpgradeStateConfig,omitempty"`
+	InitialStateUpgradeStateConfig *StateUpgradeStateConfigStruct `json:"config,omitempty"`
 }
 
 func init() {
@@ -72,14 +75,13 @@ func (c *StateUpgradeStateConfig) RunUpgrade(_ ChainConfig, state StateDB, _ Blo
 	// 3) If BlockTimestamp is 1000, this will be called while processing the first block
 	// whose timestamp is >= 1000
 
-	// Set the code.
-	log.Info("Running StateUpgradeState Config", "config", c)
+	// Set the storage slot.
+	log.Info("Running State Upgrader State", "config", c)
 	if c.InitialStateUpgradeStateConfig != nil {
-		// Load the account of the source contract.
-		log.Info("Setting the code", "source", c.InitialStateUpgradeStateConfig.Source, "target", c.InitialStateUpgradeStateConfig.Target, "code", state.GetCode(c.InitialStateUpgradeStateConfig.Source))
-		state.SetCode(c.InitialStateUpgradeStateConfig.Target, state.GetCode(c.InitialStateUpgradeStateConfig.Source))
+		log.Info("Setting the storage", "address", c.InitialStateUpgradeStateConfig.Address, "slot", c.InitialStateUpgradeStateConfig.Slot, "value", c.InitialStateUpgradeStateConfig.Value)
+		state.SetState(c.InitialStateUpgradeStateConfig.Address, common.BigToHash(c.InitialStateUpgradeStateConfig.Slot), common.BigToHash(c.InitialStateUpgradeStateConfig.Value))
 	} else {
-		log.Error("Code Upgrader Config is not set")
+		log.Error("State Upgrader Config is not set")
 	}
 }
 

--- a/stateupgrade/state_upgrade_config.go
+++ b/stateupgrade/state_upgrade_config.go
@@ -1,0 +1,42 @@
+// (c) 2019-2020, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package stateupgrade
+
+import (
+	"fmt"
+	"math/big"
+)
+
+// StateUpgradeConfig defines the interface for a state upgrade configuration.
+type StateUpgradeConfig interface {
+	// Timestamp returns the timestamp at which this stateful precompile should be enabled.
+	// 1) 0 indicates that the state upgrade should be enabled from genesis.
+	// 2) n indicates that the state upgrade should be enabled in the first block with timestamp >= [n].
+	// 3) nil indicates that the state upgrade is never enabled.
+	Timestamp() *big.Int
+	// IsDisabled returns true if this network upgrade should disable the precompile.
+	IsDisabled() bool
+	// Equal returns true if the provided argument configures the same precompile with the same parameters.
+	Equal(config StateUpgradeConfig) bool
+	// RunUpgrade is called on the first block where the stateful precompile should be enabled.
+	// This allows the stateful precompile to configure its own state via [StateDB] and [BlockContext] as necessary.
+	// This function must be deterministic since it will impact the EVM state. If a change to the
+	// config causes a change to the state modifications made in Configure, then it cannot be safely
+	// made to the config after the network upgrade has gone into effect.
+	//
+	// RunUpgrade is called on the first block where the stateful precompile should be enabled. This
+	// provides the config the ability to set its initial state and should only modify the state within
+	// its own address space.
+	RunUpgrade(ChainConfig, StateDB, BlockContext)
+	// Verify is called on startup and an error is treated as fatal. Configure can assume the Config has passed verification.
+	Verify() error
+
+	fmt.Stringer
+}
+
+// RunUpgrade calls the RunUpgrade method on [config] if it is non-nil.
+// Assumes that [stateUpgradeConfig] is non-nil.
+func RunUpgrade(chainConfig ChainConfig, blockContext BlockContext, stateUpgradeConfig StateUpgradeConfig, state StateDB) {
+	stateUpgradeConfig.RunUpgrade(chainConfig, state, blockContext)
+}

--- a/stateupgrade/upgradeable.go
+++ b/stateupgrade/upgradeable.go
@@ -1,0 +1,37 @@
+// (c) 2022 Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package stateupgrade
+
+import (
+	"math/big"
+
+	"github.com/ava-labs/subnet-evm/utils"
+)
+
+// UpgradeableConfig contains the timestamp for the upgrade along with
+// a boolean [Disable]. If [Disable] is set, the upgrade deactivates
+// the precompile and resets its storage.
+type UpgradeableConfig struct {
+	BlockTimestamp *big.Int `json:"blockTimestamp"`
+	Disable        bool     `json:"disable,omitempty"`
+}
+
+// Timestamp returns the timestamp this network upgrade goes into effect.
+func (c *UpgradeableConfig) Timestamp() *big.Int {
+	return c.BlockTimestamp
+}
+
+// IsDisabled returns true if the network upgrade deactivates the precompile.
+func (c *UpgradeableConfig) IsDisabled() bool {
+	return c.Disable
+}
+
+// Equal returns true iff [other] has the same blockTimestamp and has the
+// same on value for the Disable flag.
+func (c *UpgradeableConfig) Equal(other *UpgradeableConfig) bool {
+	if other == nil {
+		return false
+	}
+	return c.Disable == other.Disable && utils.BigNumEqual(c.BlockTimestamp, other.BlockTimestamp)
+}


### PR DESCRIPTION
## Why this should be merged

After discussion with @aaronbuchwald relating to https://github.com/ava-labs/subnet-evm/pull/451, we determined that it would be useful to have a new state upgrade system get built to complement the precompile system.

A State Upgrade is similar to a precompile in that it can do things that aren't usually possible via smart contracts alone. Because these actions are so powerful, it makes the most sense for them to be applied atomically during a network upgrade, rather than having an ongoing mechanism in place to 'call' them. This reduces the security risks and the chances of accidental mistakes.

This system would differ from the Precompile system in the following ways:

1. State Upgrades happen atomically, and as such do not have a notion of being enabled or disabled. Rather, they are executed at a given timestamp.
2. Because State Upgrades are not continuously enabled, there is no need for a callable address or methods.

This system will cover 4 basic state upgrades, as follows:

1. Modifying the code of a given contract.
2. Modifying the value of a storage slot for a given address.
3. Modifying the balance of a given account.
4. Deploying a contract to a given address.

## How this works

State Upgrades can be configured to execute at a given timestamp, in the upgrade.json file, very similarly to Precompiles. When the block is mined where that timestamp has passed, the State Upgrade that is configured will be executed.

## How this was tested

There need to be tests written for each type of state upgrade. Currently the only test is for code upgrading.

## How is this documented

There needs to be more documentation added for this feature, currently only the code documents the feature.
