### PR TITLE
parseInt from ENV var

### DIFF
--- a/contract-examples/hardhat.config.ts
+++ b/contract-examples/hardhat.config.ts
@@ -4,7 +4,7 @@ import "./tasks.ts"
 // HardHat users must populate these environment variables in order to connect to their subnet-evm instance
 // Since the blockchainID is not known in advance, there's no good default to use and we use the C-Chain here.
 var local_rpc_uri = process.env.RPC_URI || "http://127.0.0.1:9650/ext/bc/C/rpc"
-var local_chain_id = process.env.CHAIN_ID || 99999
+var local_chain_id = parseInt(process.env.CHAIN_ID,10) || 99999
 
 export default {
   solidity: {


### PR DESCRIPTION
## Why this should be merged

Hardhat network config expects this to be an integer rather than a string.

## How this works

Parses string env var to int.

## How this was tested

On a local network.

## How is this documented

This is a bugfix.
