### PR TITLE
Update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,11 +6,11 @@
 
 # review whenever someone opens a pull request.
 
-* @ceyonur @darioush @patrick-ogrady @aaronbuchwald
+* @ceyonur @darioush @aaronbuchwald
 
 # These owners will be the owner of the contract-examples sub-directory.
 
-contract-examples/ @dasconnor @anusha-ctrl
+contract-examples/ @anusha-ctrl
 
 # These owners will be the owner of the scripts sub-directory.
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,10 +8,8 @@
 
 * @ceyonur @darioush @aaronbuchwald
 
-# These owners will be the owner of the contract-examples sub-directory.
+# Specific directories:
 
+peer/ @anusha-ctrl
 contract-examples/ @anusha-ctrl
-
-# These owners will be the owner of the scripts sub-directory.
-
 scripts/ @anusha-ctrl


### PR DESCRIPTION
## Why this should be merged

This updates CODEOWNERs to reflect current teams and ownership.

## How this works

Removes usernames of people that no longer own these pieces of the code.

## How this was tested

No testing for codeowners

## How is this documented

No documentation change is necessary for this change.