### PR TITLE
try to fix lint job

### DIFF
--- a/.github/workflows/lint-tests-release.yml
+++ b/.github/workflows/lint-tests-release.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   lint_test:
     name: Lint
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - run: ./scripts/lint_allowed_geth_imports.sh


### PR DESCRIPTION
Seems ubuntu-18 support is end of life-d on github.
This PR bumps our linter to use ubuntu-20.04 
https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/