### PR TITLE
Update goreleaser to run on macos-latest and remove osx cross-compiler dependency

### DIFF
--- a/.github/workflows/lint-tests-release.yml
+++ b/.github/workflows/lint-tests-release.yml
@@ -75,7 +75,7 @@ jobs:
 
   release:
     # needs: [lint_test, unit_test, e2e_test, simulator_test]
-    runs-on: ubuntu-20.04
+    runs-on: macos-latest
     steps:
       - name: Git checkout
         uses: actions/checkout@v3
@@ -86,23 +86,6 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: 1.18
-      - name: Set up arm64 cross compiler
-        run: |
-          sudo apt-get -y update
-          sudo apt-get -y install gcc-aarch64-linux-gnu
-      - name: Checkout osxcross
-        uses: actions/checkout@v2
-        with:
-          repository: tpoechtrager/osxcross
-          path: osxcross
-      - name: Build osxcross
-        run: |
-          sudo apt-get -y install clang llvm-dev libxml2-dev uuid-dev libssl-dev bash patch make tar xz-utils bzip2 gzip sed cpio libbz2-dev
-          cd osxcross
-          wget https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX11.3.sdk.tar.xz -O tarballs/MacOSX11.3.sdk.tar.xz
-          echo cd4f08a75577145b8f05245a2975f7c81401d75e9535dcffbb879ee1deefcbf4 tarballs/MacOSX11.3.sdk.tar.xz | sha256sum -c -
-          UNATTENDED=1 ./build.sh
-          echo $PWD/target/bin >> $GITHUB_PATH
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:


### PR DESCRIPTION
## Why this should be merged

This PR removes the reliance on the OSX Cross Compiler dependency and addresses https://github.com/ava-labs/subnet-evm/issues/503.

## How this works

This changes the goreleaser job to run on macos-latest, so that there is no need to cross compile to macos.

## How this was tested

This is to be tested in CI

## How is this documented

There are no documentation changes necessary for this PR