### PR TITLE
Update github actions to ignore rcs

### DIFF
--- a/.github/workflows/lint-tests-release.yml
+++ b/.github/workflows/lint-tests-release.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
     tags:
-      - "*"
+      - 'v[0-9]+.[0-9]+.[0-9]+'
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Why this should be merged

This PR changes GH Actions to only run on tags that follow semantic versions and ignores rcs.

Addresses https://github.com/ava-labs/subnet-evm/issues/407

## How this works

This updates from matching all tags to matching semantic versions.

## How this was tested

Needs to be merged to test that rcs no longer trigger GH Actions to run and mark as latest release

## How is this documented

No documentation necessary for this change.
