### PR TITLE
move blackhole check to module registerer

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -33,7 +33,6 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/ava-labs/subnet-evm/constants"
 	"github.com/ava-labs/subnet-evm/params"
 	"github.com/ava-labs/subnet-evm/precompile/contract"
 	"github.com/ava-labs/subnet-evm/precompile/modules"
@@ -163,9 +162,6 @@ func init() {
 		address := module.Address
 		if _, ok := PrecompileAllNativeAddresses[address]; ok {
 			panic(fmt.Errorf("precompile address collides with existing native address: %s", address))
-		}
-		if address == constants.BlackholeAddr {
-			panic(fmt.Errorf("cannot use address %s for stateful precompile - overlaps with blackhole address", address))
 		}
 	}
 }

--- a/precompile/modules/registerer.go
+++ b/precompile/modules/registerer.go
@@ -48,11 +48,12 @@ func ReservedAddress(addr common.Address) bool {
 func RegisterModule(stm Module) error {
 	address := stm.Address
 	key := stm.ConfigKey
-	if !ReservedAddress(address) {
-		return fmt.Errorf("address %s not in a reserved range", address)
-	}
+
 	if address == constants.BlackholeAddr {
 		return fmt.Errorf("address %s overlaps with blackhole address", address)
+	}
+	if !ReservedAddress(address) {
+		return fmt.Errorf("address %s not in a reserved range", address)
 	}
 
 	for _, registeredModule := range registeredModules {

--- a/precompile/modules/registerer.go
+++ b/precompile/modules/registerer.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/ava-labs/subnet-evm/constants"
 	"github.com/ava-labs/subnet-evm/utils"
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -49,6 +50,9 @@ func RegisterModule(stm Module) error {
 	key := stm.ConfigKey
 	if !ReservedAddress(address) {
 		return fmt.Errorf("address %s not in a reserved range", address)
+	}
+	if address == constants.BlackholeAddr {
+		return fmt.Errorf("address %s overlaps with blackhole address", address)
 	}
 
 	for _, registeredModule := range registeredModules {

--- a/precompile/modules/registerer_test.go
+++ b/precompile/modules/registerer_test.go
@@ -44,11 +44,16 @@ func TestInsertSortedByAddress(t *testing.T) {
 	require.Equal(t, []Module{module0, module1, module2, module3}, data)
 }
 
-func TestRegisterModule(t *testing.T) {
-	// test that blackhole address is not allowed
-	moduleBlackhole := Module{
+func TestRegisterModuleInvalidAddresses(t *testing.T) {
+	// Test the blockhole address cannot be registered
+	m := Module{
 		Address: constants.BlackholeAddr,
 	}
-	err := RegisterModule(moduleBlackhole)
+	err := RegisterModule(m)
 	require.ErrorContains(t, err, "overlaps with blackhole address")
+
+	// Test an address outside of the reserved ranges cannot be registered
+	m.Address = common.BigToAddress(big.NewInt(1))
+	err = RegisterModule(m)
+	require.ErrorContains(t, err, "not in a reserved range")
 }

--- a/precompile/modules/registerer_test.go
+++ b/precompile/modules/registerer_test.go
@@ -7,11 +7,12 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ava-labs/subnet-evm/constants"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
 
-func TestRegisterModule(t *testing.T) {
+func TestInsertSortedByAddress(t *testing.T) {
 	data := make([]Module, 0)
 	// test that the module is registered in sorted order
 	module1 := Module{
@@ -41,4 +42,13 @@ func TestRegisterModule(t *testing.T) {
 
 	data = insertSortedByAddress(data, module2)
 	require.Equal(t, []Module{module0, module1, module2, module3}, data)
+}
+
+func TestRegisterModule(t *testing.T) {
+	// test that blackhole address is not allowed
+	moduleBlackhole := Module{
+		Address: constants.BlackholeAddr,
+	}
+	err := RegisterModule(moduleBlackhole)
+	require.ErrorContains(t, err, "overlaps with blackhole address")
 }


### PR DESCRIPTION
## Why this should be merged

Precompile address check should be done during module registration. The previous check was in `core/vm` package `init()`. Precompile Registration also happens on `init` function on precompile packages. This means that if `core/vm` is imported before `precompile` package, it could actually skip checking if the registered address equals to the blackhole address. 

## How this works

Moves black hole address check from contracts init to `RegisterPrecompile`.

## How this was tested

Added unit test

## How is this documented
