### PR TITLE
Precompile pre post handling

### DIFF
--- a/core/predicate_check.go
+++ b/core/predicate_check.go
@@ -1,0 +1,40 @@
+// (c) 2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package core
+
+import (
+	"fmt"
+
+	"github.com/ava-labs/subnet-evm/core/types"
+	"github.com/ava-labs/subnet-evm/params"
+	"github.com/ava-labs/subnet-evm/precompile/contract"
+	"github.com/ava-labs/subnet-evm/precompile/modules"
+	"github.com/ava-labs/subnet-evm/utils"
+)
+
+// CheckPredicates checks that all precompile predicates are satisfied within the current [predicateContext] for [tx]
+func CheckPredicates(rules params.Rules, predicateContext *contract.PredicateContext, tx *types.Transaction) error {
+	precompileConfigs := rules.ActivePrecompiles
+	for _, accessTuple := range tx.AccessList() {
+		_, isPrecompile := precompileConfigs[accessTuple.Address]
+		if !isPrecompile {
+			continue
+		}
+
+		module, ok := modules.GetPrecompileModuleByAddress(accessTuple.Address)
+		if !ok {
+			return fmt.Errorf("accessed precompile config under address %s with no registered module", accessTuple.Address)
+		}
+		predicater, ok := module.Contract.(contract.Predicater)
+		if !ok {
+			continue
+		}
+
+		if err := predicater.VerifyPredicate(predicateContext, utils.HashSliceToBytes(accessTuple.StorageKeys)); err != nil {
+			return fmt.Errorf("predicate %s failed verification for tx %s: %w", accessTuple.Address, tx.Hash(), err)
+		}
+	}
+
+	return nil
+}

--- a/core/predicate_check.go
+++ b/core/predicate_check.go
@@ -24,7 +24,7 @@ func CheckPredicates(rules params.Rules, predicateContext *contract.PredicateCon
 
 		module, ok := modules.GetPrecompileModuleByAddress(accessTuple.Address)
 		if !ok {
-			return fmt.Errorf("accessed precompile config under address %s with no registered module", accessTuple.Address)
+			return fmt.Errorf("predicate accessed precompile config under address %s with no registered module", accessTuple.Address)
 		}
 		predicater, ok := module.Contract.(contract.Predicater)
 		if !ok {

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -39,6 +39,7 @@ import (
 	"github.com/ava-labs/subnet-evm/core/types"
 	"github.com/ava-labs/subnet-evm/metrics"
 	"github.com/ava-labs/subnet-evm/trie"
+	"github.com/ava-labs/subnet-evm/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
@@ -110,6 +111,9 @@ type StateDB struct {
 
 	// Per-transaction access list
 	accessList *accessList
+	// Ordered storage slots to be used in predicate verification as set in the tx access list.
+	// Only set in PrepareAccessList, and un-modified through execution.
+	predicateStorageSlots map[common.Address][]byte
 
 	// Journal of state modifications. This is the backbone of
 	// Snapshot and RevertToSnapshot.
@@ -156,17 +160,18 @@ func NewWithSnapshot(root common.Hash, db Database, snap snapshot.Snapshot) (*St
 		return nil, err
 	}
 	sdb := &StateDB{
-		db:                  db,
-		trie:                tr,
-		originalRoot:        root,
-		stateObjects:        make(map[common.Address]*stateObject),
-		stateObjectsPending: make(map[common.Address]struct{}),
-		stateObjectsDirty:   make(map[common.Address]struct{}),
-		logs:                make(map[common.Hash][]*types.Log),
-		preimages:           make(map[common.Hash][]byte),
-		journal:             newJournal(),
-		accessList:          newAccessList(),
-		hasher:              crypto.NewKeccakState(),
+		db:                    db,
+		trie:                  tr,
+		originalRoot:          root,
+		stateObjects:          make(map[common.Address]*stateObject),
+		stateObjectsPending:   make(map[common.Address]struct{}),
+		stateObjectsDirty:     make(map[common.Address]struct{}),
+		logs:                  make(map[common.Hash][]*types.Log),
+		preimages:             make(map[common.Hash][]byte),
+		journal:               newJournal(),
+		predicateStorageSlots: make(map[common.Address][]byte),
+		accessList:            newAccessList(),
+		hasher:                crypto.NewKeccakState(),
 	}
 	if snap != nil {
 		if snap.Root() != root {
@@ -674,6 +679,15 @@ func (db *StateDB) ForEachStorage(addr common.Address, cb func(key, value common
 	return nil
 }
 
+// copyPredicateStorageSlots creates a deep copy of the provided predicateStorageSlots map.
+func copyPredicateStorageSlots(predicateStorageSlots map[common.Address][]byte) map[common.Address][]byte {
+	res := make(map[common.Address][]byte)
+	for address, slots := range predicateStorageSlots {
+		res[address] = common.CopyBytes(slots)
+	}
+	return res
+}
+
 // Copy creates a deep, independent copy of the state.
 // Snapshots of the copied state cannot be applied to the copy.
 func (s *StateDB) Copy() *StateDB {
@@ -740,6 +754,7 @@ func (s *StateDB) Copy() *StateDB {
 	// However, it doesn't cost us much to copy an empty list, so we do it anyway
 	// to not blow up if we ever decide copy it in the middle of a transaction
 	state.accessList = s.accessList.Copy()
+	state.predicateStorageSlots = copyPredicateStorageSlots(s.predicateStorageSlots)
 
 	// If there's a prefetcher running, make an inactive copy of it that can
 	// only access data but does not actively preload (since the user will not
@@ -1060,11 +1075,16 @@ func (s *StateDB) PrepareAccessList(sender common.Address, dst *common.Address, 
 	for _, addr := range precompiles {
 		s.AddAddressToAccessList(addr)
 	}
+
+	// Note: If an address is specified multiple times in the access list, only the
+	// last storage slots provided for it are used in predicates.
+	s.predicateStorageSlots = make(map[common.Address][]byte)
 	for _, el := range list {
 		s.AddAddressToAccessList(el.Address)
 		for _, key := range el.StorageKeys {
 			s.AddSlotToAccessList(el.Address, key)
 		}
+		s.predicateStorageSlots[el.Address] = utils.HashSliceToBytes(el.StorageKeys)
 	}
 }
 
@@ -1101,4 +1121,14 @@ func (s *StateDB) AddressInAccessList(addr common.Address) bool {
 // SlotInAccessList returns true if the given (address, slot)-tuple is in the access list.
 func (s *StateDB) SlotInAccessList(addr common.Address, slot common.Hash) (addressPresent bool, slotPresent bool) {
 	return s.accessList.Contains(addr, slot)
+}
+
+// GetPredicateStorageSlots returns the storage slots associated with a given address, and whether or not
+// that address was included in the optional access list of the transaction.
+// The storage slots are returned in the same order as they appeared in the transaction.
+// These are the same storage slots that are used to verify any transaction
+// predicates for transactions with access list addresses that match a precompile address.
+func (s *StateDB) GetPredicateStorageSlots(address common.Address) ([]byte, bool) {
+	storageSlots, exists := s.predicateStorageSlots[address]
+	return storageSlots, exists
 }

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1118,6 +1118,8 @@ func (pool *TxPool) HasLocal(hash common.Hash) bool {
 	return pool.all.GetLocal(hash) != nil
 }
 
+// RemoveTx removes a single transaction from the queue, moving all subsequent
+// transactions back to the future queue.
 func (pool *TxPool) RemoveTx(hash common.Hash) {
 	pool.mu.Lock()
 	defer pool.mu.Unlock()

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -82,6 +82,7 @@ type StateDB interface {
 	Snapshot() int
 
 	AddLog(addr common.Address, topics []common.Hash, data []byte, blockNumber uint64)
+	GetPredicateStorageSlots(address common.Address) ([]byte, bool)
 	AddPreimage(common.Hash, []byte)
 
 	ForEachStorage(common.Address, func(common.Hash, common.Hash) bool) error

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.10.0
-	github.com/ava-labs/avalanchego v1.9.8
+	github.com/ava-labs/avalanchego v1.9.9-rc.1
 	github.com/cespare/cp v0.1.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckarep/golang-set v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/ava-labs/avalanchego v1.9.8 h1:5SHKqkWpBn9Pqxg2qpzDZ7FQqYFapzaCZwArapBdqAA=
 github.com/ava-labs/avalanchego v1.9.8/go.mod h1:t9+R55TgRJxYCekRf/EicIjHBeeEQT04TQxpaF98+yM=
+github.com/ava-labs/avalanchego v1.9.9-rc.1 h1:JR/KrBtFYR6pUuo+29JswQqwdk/fFYTukJwU3zJYYxA=
+github.com/ava-labs/avalanchego v1.9.9-rc.1/go.mod h1:t9+R55TgRJxYCekRf/EicIjHBeeEQT04TQxpaF98+yM=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ava-labs/subnet-evm/core"
 	"github.com/ava-labs/subnet-evm/core/types"
 	"github.com/ava-labs/subnet-evm/params"
+	"github.com/ava-labs/subnet-evm/precompile/contract"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/event"
 )
@@ -62,8 +63,8 @@ func (miner *Miner) SetEtherbase(addr common.Address) {
 	miner.worker.setEtherbase(addr)
 }
 
-func (miner *Miner) GenerateBlock() (*types.Block, error) {
-	return miner.worker.commitNewWork()
+func (miner *Miner) GenerateBlock(predicateContext *contract.PredicateContext) (*types.Block, error) {
+	return miner.worker.commitNewWork(predicateContext)
 }
 
 // SubscribePendingLogs starts delivering logs from pending transactions

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -44,6 +44,7 @@ import (
 	"github.com/ava-labs/subnet-evm/core/state"
 	"github.com/ava-labs/subnet-evm/core/types"
 	"github.com/ava-labs/subnet-evm/params"
+	"github.com/ava-labs/subnet-evm/precompile/contract"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
@@ -112,7 +113,7 @@ func (w *worker) setEtherbase(addr common.Address) {
 }
 
 // commitNewWork generates several new sealing tasks based on the parent block.
-func (w *worker) commitNewWork() (*types.Block, error) {
+func (w *worker) commitNewWork(predicateContext *contract.PredicateContext) (*types.Block, error) {
 	w.mu.RLock()
 	defer w.mu.RUnlock()
 
@@ -192,8 +193,11 @@ func (w *worker) commitNewWork() (*types.Block, error) {
 		return nil, err
 	}
 
-	// Fill the block with all available pending transactions.
+	// Get the pending txs from TxPool
 	pending := w.eth.TxPool().Pending(true)
+	// Filter out transactions that don't satisfy predicateContext and remove them from TxPool
+	rules := w.chainConfig.AvalancheRules(header.Number, new(big.Int).SetUint64(header.Time))
+	pending = w.enforcePredicates(rules, predicateContext, pending)
 
 	// Split the pending transactions into locals and remotes
 	localTxs := make(map[common.Address]types.Transactions)
@@ -390,4 +394,26 @@ func totalFees(block *types.Block, receipts []*types.Receipt) *big.Float {
 		feesWei.Add(feesWei, new(big.Int).Mul(new(big.Int).SetUint64(receipts[i].GasUsed), tx.GasPrice()))
 	}
 	return new(big.Float).Quo(new(big.Float).SetInt(feesWei), new(big.Float).SetInt(big.NewInt(params.Ether)))
+}
+
+// enforcePredicates takes a set of pending transactions (grouped by sender, and ordered by nonce) and returns a
+// subset of those transactions (grouped by sender) that satisfy predicateContext.
+// Any transaction sent by a given sender that is received after a transaction that does not
+// satisfy predicateContext is removed from the TxPool and is not included in the return value.
+func (w *worker) enforcePredicates(rules params.Rules, predicateContext *contract.PredicateContext, pending map[common.Address]types.Transactions) map[common.Address]types.Transactions {
+	result := make(map[common.Address]types.Transactions, len(pending))
+	for addr, txs := range pending {
+		for i, tx := range txs {
+			if err := core.CheckPredicates(rules, predicateContext, tx); err != nil {
+				log.Debug("Transaction predicate failed verification in miner", "sender", addr, "err", err)
+				w.eth.TxPool().RemoveTx(tx.Hash()) // RemoveTx will move all subsequent transactions back to the future queue
+				txs = txs[:i]                      // Cut off any transactions past the failed predicate
+				break
+			}
+		}
+		if len(txs) > 0 {
+			result[addr] = txs
+		}
+	}
+	return result
 }

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -3,7 +3,7 @@
 # Set up the versions to be used - populate ENV variables only if they are not already populated
 SUBNET_EVM_VERSION=${SUBNET_EVM_VERSION:-'v0.4.9'}
 # Don't export them as they're used in the context of other calls
-AVALANCHEGO_VERSION=${AVALANCHE_VERSION:-'v1.9.8'}
+AVALANCHEGO_VERSION=${AVALANCHE_VERSION:-'v1.9.9-rc.1'}
 GINKGO_VERSION=${GINKGO_VERSION:-'v2.2.0'}
 
 # This won't be used, but it's here to make code syncs easier

--- a/utils/bytes.go
+++ b/utils/bytes.go
@@ -3,6 +3,8 @@
 
 package utils
 
+import "github.com/ethereum/go-ethereum/common"
+
 // IncrOne increments bytes value by one
 func IncrOne(bytes []byte) {
 	index := len(bytes) - 1
@@ -15,4 +17,13 @@ func IncrOne(bytes []byte) {
 			index--
 		}
 	}
+}
+
+// HashSliceToBytes serializes a []common.Hash into a []byte
+func HashSliceToBytes(hashes []common.Hash) []byte {
+	bytes := make([]byte, common.HashLength*len(hashes))
+	for i, hash := range hashes {
+		copy(bytes[i*common.HashLength:(i+1)*common.HashLength], hash.Bytes())
+	}
+	return bytes
 }

--- a/utils/bytes_test.go
+++ b/utils/bytes_test.go
@@ -1,0 +1,65 @@
+// (c) 2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIncrOne(t *testing.T) {
+	type test struct {
+		input    []byte
+		expected []byte
+	}
+	for name, test := range map[string]test{
+		"increment no overflow no carry": {
+			input:    []byte{0, 0},
+			expected: []byte{0, 1},
+		},
+		"increment overflow": {
+			input:    []byte{255, 255},
+			expected: []byte{0, 0},
+		},
+		"increment carry": {
+			input:    []byte{0, 255},
+			expected: []byte{1, 0},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			output := common.CopyBytes(test.input)
+			IncrOne(output)
+			assert.Equal(t, output, test.expected)
+		})
+	}
+}
+
+func TestHashSliceToBytes(t *testing.T) {
+	type test struct {
+		input    []common.Hash
+		expected []byte
+	}
+	for name, test := range map[string]test{
+		"convert single hash": {
+			input: []common.Hash{
+				common.BytesToHash([]byte{1, 2, 3}),
+			},
+			expected: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3},
+		},
+		"convert hash slice": {
+			input: []common.Hash{
+				common.BytesToHash([]byte{1, 2, 3}),
+				common.BytesToHash([]byte{4, 5, 6}),
+			},
+			expected: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 5, 6},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			output := HashSliceToBytes(test.input)
+			assert.Equal(t, output, test.expected)
+		})
+	}
+}

--- a/warp/handlers/signature_request_test.go
+++ b/warp/handlers/signature_request_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
 	"github.com/ava-labs/avalanchego/utils/hashing"
-	"github.com/ava-labs/avalanchego/vms/platformvm/teleporter"
+	avalancheWarp "github.com/ava-labs/avalanchego/vms/platformvm/warp"
 	"github.com/ava-labs/subnet-evm/plugin/evm/message"
 	"github.com/ava-labs/subnet-evm/warp"
 	"github.com/ava-labs/subnet-evm/warp/handlers/stats"
@@ -26,10 +26,10 @@ func TestSignatureHandler(t *testing.T) {
 	blsSecretKey, err := bls.NewSecretKey()
 	require.NoError(t, err)
 
-	snowCtx.TeleporterSigner = teleporter.NewSigner(blsSecretKey, snowCtx.ChainID)
+	snowCtx.WarpSigner = avalancheWarp.NewSigner(blsSecretKey, snowCtx.ChainID)
 	warpBackend := warp.NewWarpBackend(snowCtx, database, 100)
 
-	msg, err := teleporter.NewUnsignedMessage(snowCtx.ChainID, snowCtx.CChainID, []byte("test"))
+	msg, err := avalancheWarp.NewUnsignedMessage(snowCtx.ChainID, snowCtx.CChainID, []byte("test"))
 	require.NoError(t, err)
 
 	messageID := hashing.ComputeHash256Array(msg.Bytes())


### PR DESCRIPTION
## Why this should be merged

This PR adds precompile predicate enforcement and onAccept handling that will be used by the warp and shared memory precompiles.

## How this works

This PR adds optional `Accepter` and `Predicater` interfaces, which are to be optionally implemented by precompile contracts (contract not config or module).

These optional interfaces are NOT intended to be used for custom precompiles outside of this repo and the comments in this PR reflect that. Making his an optional interface removes the need to include it in the precompile gen template and makes it so that a user of the precompilegen template does not even need to see or think about the `Accepter` or `Predicater` interface at all.

The predicate is enforced on the relevant access list when calling `VerifyWithContext` or `BuildWithContext`.

The Accept handling is performed during block acceptance within `plugin/evm/block.go`. This is a change from a previous implementation to simplify passing in the backend, so that it does not require changing as much code.

Additionally, the shared memory precompile will need to perform shared memory operations to be committed atomically alongside updating the block that is marked as last accepted.

I spent some time trying to make this logic work within `core/blockchain.go`, but found that it will be easier to maintain this within `plugin/evm/block.go`.

## How this was tested

This was tested via CI and should be a no-op change since no precompiles currently use the added optional interfaces.

Now that we have the module registration logic, we can implement a test case for this that includes its own implementation of a precompile that uses a predicate and on accept to test this.

## How is this documented

This is not intended for end users to touch, so there is not currently an accompanying documentation PR. We should document this in the future, but deferring that for now.