### PR TITLE
Bump AvalancheGo dep to v1.9.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.10.0
-	github.com/ava-labs/avalanchego v1.9.9-rc.4
+	github.com/ava-labs/avalanchego v1.9.9
 	github.com/cespare/cp v0.1.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckarep/golang-set v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
-github.com/ava-labs/avalanchego v1.9.9-rc.4 h1:3KUGKGZ4+tcLz+E5jz3e+Ah6VDcLenv9fSwHiG8gTwg=
-github.com/ava-labs/avalanchego v1.9.9-rc.4/go.mod h1:mnM/wzJIaKXzLV323Yh0EbLtsicoaFSgaDESrED9dr0=
+github.com/ava-labs/avalanchego v1.9.9 h1:R7GBCjFBC/taZeJNJ4MtdniifC7j9eLwRezhCGa/wmc=
+github.com/ava-labs/avalanchego v1.9.9/go.mod h1:mnM/wzJIaKXzLV323Yh0EbLtsicoaFSgaDESrED9dr0=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -3,7 +3,7 @@
 # Set up the versions to be used - populate ENV variables only if they are not already populated
 SUBNET_EVM_VERSION=${SUBNET_EVM_VERSION:-'v0.4.9'}
 # Don't export them as they're used in the context of other calls
-AVALANCHEGO_VERSION=${AVALANCHE_VERSION:-'v1.9.9-rc.4'}
+AVALANCHEGO_VERSION=${AVALANCHE_VERSION:-'v1.9.9'}
 GINKGO_VERSION=${GINKGO_VERSION:-'v2.2.0'}
 
 # This won't be used, but it's here to make code syncs easier


### PR DESCRIPTION
## Why this should be merged

This PR bumps the AvalancheGo dependency to v1.9.9

## How this works

See above

## How this was tested

CI

## How is this documented

No doc changes necessary