### PR TITLE
Bump minimum golang version to v1.20.1

### DIFF
--- a/.github/workflows/lint-tests-release.yml
+++ b/.github/workflows/lint-tests-release.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go: ["1.18"]
+        go: ["1.20"]
         os: [ubuntu-20.04]
     steps:
       - uses: actions/checkout@v3
@@ -55,7 +55,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: "1.20"
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
@@ -85,7 +85,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: "1.20"
       - name: Set up arm64 cross compiler
         run: |
           sudo apt-get -y update
@@ -108,7 +108,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --clean --debug
           workdir: ./subnet-evm/
         env:
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret

--- a/.github/workflows/lint-tests-release.yml
+++ b/.github/workflows/lint-tests-release.yml
@@ -108,7 +108,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --clean --debug
+          args: release --clean
           workdir: ./subnet-evm/
         env:
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 ARG AVALANCHE_VERSION
 
 # ============= Compilation Stage ================
-FROM golang:1.18.5-buster AS builder
+FROM golang:1.20.1-buster AS builder
 RUN apt-get update && apt-get install -y --no-install-recommends bash=5.0-4 git=1:2.20.1-2+deb10u3 make=4.2.1-1.2 gcc=4:8.3.0-1 musl-dev=1.1.21-2 ca-certificates=20200601~deb10u2 linux-headers-amd64
 
 WORKDIR /build
@@ -15,7 +15,7 @@ WORKDIR /build
 COPY go.mod go.sum avalanchego* ./
 
 # Download avalanche dependencies using go mod
-RUN go mod download && go mod tidy -compat=1.18
+RUN go mod download && go mod tidy -compat=1.20
 
 # Copy the code into the container
 COPY . .

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ To support these changes, there have been a number of changes to the SubnetEVM b
 
 ### Clone Subnet-evm
 
-First install Go 1.18.1 or later. Follow the instructions [here](https://golang.org/doc/install). You can verify by running `go version`.
+First install Go 1.20.1 or later. Follow the instructions [here](https://golang.org/doc/install). You can verify by running `go version`.
 
 Set `$GOPATH` environment variable properly for Go to look for Go Workspaces. Please read [this](https://go.dev/doc/gopath_code) for details. You can verify by running `echo $GOPATH`.
 

--- a/accounts/abi/bind/bind_test.go
+++ b/accounts/abi/bind/bind_test.go
@@ -2136,7 +2136,7 @@ func golangBindings(t *testing.T, overload bool) {
 	if out, err := replacer.CombinedOutput(); err != nil {
 		t.Fatalf("failed to replace binding test dependency to current source tree: %v\n%s", err, out)
 	}
-	tidier := exec.Command(gocmd, "mod", "tidy", "-compat=1.18")
+	tidier := exec.Command(gocmd, "mod", "tidy", "-compat=1.20")
 	tidier.Dir = pkg
 	if out, err := tidier.CombinedOutput(); err != nil {
 		t.Fatalf("failed to tidy Go module file: %v\n%s", err, out)

--- a/cmd/simulator/go.mod
+++ b/cmd/simulator/go.mod
@@ -1,6 +1,6 @@
 module github.com/ava-labs/subnet-evm/cmd/simulator
 
-go 1.18
+go 1.20
 
 require (
 	github.com/ethereum/go-ethereum v1.10.26

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ava-labs/subnet-evm
 
-go 1.18
+go 1.20
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.10.0

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,7 +4,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-go_version_minimum="1.18.1"
+go_version_minimum="1.20.1"
 
 go_version() {
     go version | sed -nE -e 's/[^0-9.]+([0-9.]+).+/\1/p'


### PR DESCRIPTION
## Why this should be merged

Bumps the minimum golang version to v1.20.1.

## How this works

As above.

## How this was tested

CI

## How is this documented

Updated README
