### PR TITLE
start v0.4.12 release cycle

### DIFF
--- a/.github/workflows/lint-tests-release.yml
+++ b/.github/workflows/lint-tests-release.yml
@@ -16,6 +16,9 @@ jobs:
       - uses: actions/checkout@v3
       - run: ./scripts/lint_allowed_geth_imports.sh
         shell: bash
+      - uses: actions/setup-go@v3
+        with:
+          go-version: "1.19"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:

--- a/compatibility.json
+++ b/compatibility.json
@@ -1,5 +1,6 @@
 {
   "rpcChainVMProtocolVersion": {
+    "v0.4.12": 24,
     "v0.4.11": 24,
     "v0.4.10": 23,
     "v0.4.9": 23,

--- a/plugin/evm/version.go
+++ b/plugin/evm/version.go
@@ -11,7 +11,7 @@ var (
 	// GitCommit is set by the build script
 	GitCommit string
 	// Version is the version of Subnet EVM
-	Version string = "v0.4.11"
+	Version string = "v0.4.12"
 )
 
 func init() {

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Set up the versions to be used - populate ENV variables only if they are not already populated
-SUBNET_EVM_VERSION=${SUBNET_EVM_VERSION:-'v0.4.11'}
+SUBNET_EVM_VERSION=${SUBNET_EVM_VERSION:-'v0.4.12'}
 # Don't export them as they're used in the context of other calls
 AVALANCHEGO_VERSION=${AVALANCHE_VERSION:-'v1.9.10'}
 GINKGO_VERSION=${GINKGO_VERSION:-'v2.2.0'}


### PR DESCRIPTION
## Why this should be merged
Begins the new release cycle

## How this works
Bumps version in versions.sh and adds the compatibility.json rpcchain expectation.

## How this was tested
UT

## How is this documented
N/A