### PR TITLE
bump golangci-lint

### DIFF
--- a/.github/workflows/lint-tests-release.yml
+++ b/.github/workflows/lint-tests-release.yml
@@ -14,12 +14,15 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: "1.19"
       - run: ./scripts/lint_allowed_geth_imports.sh
         shell: bash
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.47
+          version: v1.51.2
           working-directory: .
           args: --timeout 3m
 


### PR DESCRIPTION
## Why this should be merged
Use the latest linter

## How this works
bumps the version numbers

## How this was tested
CI

## How is this documented
N/a