### PR TITLE
release tickers on shutdown

### DIFF
--- a/plugin/evm/gossiper.go
+++ b/plugin/evm/gossiper.go
@@ -235,8 +235,6 @@ func (n *pushGossiper) queuePriorityRegossipTxs() types.Transactions {
 func (n *pushGossiper) awaitEthTxGossip() {
 	n.shutdownWg.Add(1)
 	go n.ctx.Log.RecoverAndPanic(func() {
-		defer n.shutdownWg.Done()
-
 		var (
 			gossipTicker           = time.NewTicker(txsGossipInterval)
 			regossipTicker         = time.NewTicker(n.config.RegossipFrequency.Duration)
@@ -246,6 +244,7 @@ func (n *pushGossiper) awaitEthTxGossip() {
 			gossipTicker.Stop()
 			regossipTicker.Stop()
 			priorityRegossipTicker.Stop()
+			n.shutdownWg.Done()
 		}()
 
 		for {

--- a/plugin/evm/gossiper.go
+++ b/plugin/evm/gossiper.go
@@ -242,6 +242,11 @@ func (n *pushGossiper) awaitEthTxGossip() {
 			regossipTicker         = time.NewTicker(n.config.RegossipFrequency.Duration)
 			priorityRegossipTicker = time.NewTicker(n.config.PriorityRegossipFrequency.Duration)
 		)
+		defer func() {
+			gossipTicker.Stop()
+			regossipTicker.Stop()
+			priorityRegossipTicker.Stop()
+		}()
 
 		for {
 			select {


### PR DESCRIPTION
## Why this should be merged
Fewer leaked goroutines in stopped chains (eg in some unit tests).

## How this works
This releases tickers when the awaitEthTxGossip function returns.

## How this was tested
UTs

## How is this documented
No change.