### PR TITLE
simplify functionSignatureRegex

### DIFF
--- a/precompile/contract/utils.go
+++ b/precompile/contract/utils.go
@@ -20,7 +20,7 @@ const (
 	ReadGasCostPerSlot  = 5_000
 )
 
-var functionSignatureRegex = regexp.MustCompile(`[\w]+\(((([\w]+)?)|((([\w]+),)+([\w]+)))\)`)
+var functionSignatureRegex = regexp.MustCompile(`\w+\((\w*|(\w+,)+\w+)\)`)
 
 // CalculateFunctionSelector returns the 4 byte function selector that results from [functionSignature]
 // Ex. the function setBalance(addr address, balance uint256) should be passed in as the string:


### PR DESCRIPTION
Simplifies the function signature regex (removes unneeded [] and () and combines +? to *)