### PR TITLE
Add ignore unnecessary import to precompile contract template

### DIFF
--- a/accounts/abi/bind/precompilebind/precompile_contract_template.go
+++ b/accounts/abi/bind/precompilebind/precompile_contract_template.go
@@ -64,6 +64,7 @@ const (
 // CUSTOM CODE STARTS HERE
 // Reference imports to suppress errors from unused imports. This code and any unnecessary imports can be removed.
 var (
+	_ = abi.JSON
 	_ = errors.New
 	_ = big.NewInt
 )


### PR DESCRIPTION
## Why this should be merged

This PR fixes a possible unused import in the generated code from the contract template if the ABI package is not used.

## How this works

Adds an `_ = abi.JSON` so that the generated file is still valid.

## How this was tested

CI

## How is this documented

No documentation changes necessary.