### PR TITLE
Matches go-ethereum/pull/26912/files

### DIFF
--- a/eth/api.go
+++ b/eth/api.go
@@ -96,7 +96,7 @@ func (api *AdminAPI) ExportChain(file string, first *uint64, last *uint64) (bool
 		return false, errors.New("location would overwrite an existing file")
 	}
 	// Make sure we can create the file to export into
-	out, err := os.OpenFile(file, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.ModePerm)
+	out, err := os.OpenFile(file, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
## Why this should be merged
Follows upstream https://github.com/ethereum/go-ethereum/pull/26912

## How this works
Uses 0644 as file permission for newly created files in export chain

## How this was tested
CI

## How is this documented
No changes needed.