### PR TITLE
Add ability to specify commit of avalanchego in ci

### DIFF
--- a/scripts/install_avalanchego_release.sh
+++ b/scripts/install_avalanchego_release.sh
@@ -11,41 +11,118 @@ source "$SUBNET_EVM_PATH"/scripts/versions.sh
 # Load the constants
 source "$SUBNET_EVM_PATH"/scripts/constants.sh
 
-VERSION=$AVALANCHEGO_VERSION
-
 ############################
 # download avalanchego
 # https://github.com/ava-labs/avalanchego/releases
 GOARCH=$(go env GOARCH)
 GOOS=$(go env GOOS)
-BASEDIR=${BASE_DIR:-"/tmp/avalanchego-release"}
+BASEDIR=${BASEDIR:-"/tmp/avalanchego-release"}
+AVALANCHEGO_BUILD_PATH=${AVALANCHEGO_BUILD_PATH:-${BASEDIR}/avalanchego}
+
 mkdir -p ${BASEDIR}
-AVAGO_DOWNLOAD_URL=https://github.com/ava-labs/avalanchego/releases/download/${VERSION}/avalanchego-linux-${GOARCH}-${VERSION}.tar.gz
-AVAGO_DOWNLOAD_PATH=${BASEDIR}/avalanchego-linux-${GOARCH}-${VERSION}.tar.gz
+
+AVAGO_DOWNLOAD_URL=https://github.com/ava-labs/avalanchego/releases/download/${AVALANCHEGO_VERSION}/avalanchego-linux-${GOARCH}-${AVALANCHEGO_VERSION}.tar.gz
+AVAGO_DOWNLOAD_PATH=${BASEDIR}/avalanchego-linux-${GOARCH}-${AVALANCHEGO_VERSION}.tar.gz
+
 if [[ ${GOOS} == "darwin" ]]; then
-  AVAGO_DOWNLOAD_URL=https://github.com/ava-labs/avalanchego/releases/download/${VERSION}/avalanchego-macos-${VERSION}.zip
-  AVAGO_DOWNLOAD_PATH=${BASEDIR}/avalanchego-macos-${VERSION}.zip
+  AVAGO_DOWNLOAD_URL=https://github.com/ava-labs/avalanchego/releases/download/${AVALANCHEGO_VERSION}/avalanchego-macos-${AVALANCHEGO_VERSION}.zip
+  AVAGO_DOWNLOAD_PATH=${BASEDIR}/avalanchego-macos-${AVALANCHEGO_VERSION}.zip
 fi
 
-AVALANCHEGO_BUILD_PATH=${AVALANCHEGO_BUILD_PATH:-${BASEDIR}/avalanchego-${VERSION}}
-mkdir -p $AVALANCHEGO_BUILD_PATH
+BUILD_DIR=${AVALANCHEGO_BUILD_PATH}-${AVALANCHEGO_VERSION}
 
-if [[ ! -f ${AVAGO_DOWNLOAD_PATH} ]]; then
-  echo "downloading avalanchego ${VERSION} at ${AVAGO_DOWNLOAD_URL} to ${AVAGO_DOWNLOAD_PATH}"
-  curl -L ${AVAGO_DOWNLOAD_URL} -o ${AVAGO_DOWNLOAD_PATH}
-fi
-echo "extracting downloaded avalanchego to ${AVALANCHEGO_BUILD_PATH}"
-if [[ ${GOOS} == "linux" ]]; then
-  mkdir -p ${AVALANCHEGO_BUILD_PATH} && tar xzvf ${AVAGO_DOWNLOAD_PATH} --directory ${AVALANCHEGO_BUILD_PATH} --strip-components 1
-elif [[ ${GOOS} == "darwin" ]]; then
-  unzip ${AVAGO_DOWNLOAD_PATH} -d ${AVALANCHEGO_BUILD_PATH}
-  mv ${AVALANCHEGO_BUILD_PATH}/build/* ${AVALANCHEGO_BUILD_PATH}
-  rm -rf ${AVALANCHEGO_BUILD_PATH}/build/
+extract_archive() {
+  mkdir -p ${BUILD_DIR}
+
+  if [[ ${AVAGO_DOWNLOAD_PATH} == *.tar.gz ]]; then
+    tar xzvf ${AVAGO_DOWNLOAD_PATH} --directory ${BUILD_DIR} --strip-components 1
+  elif [[ ${AVAGO_DOWNLOAD_PATH} == *.zip ]]; then
+    unzip ${AVAGO_DOWNLOAD_PATH} -d ${BUILD_DIR}
+    mv ${BUILD_DIR}/build/* ${BUILD_DIR}
+    rm -rf ${BUILD_DIR}/build/
+  fi
+}
+
+# first check if we already have the archive
+if [[ -f ${AVAGO_DOWNLOAD_PATH} ]]; then
+  # if the download path already exists, extract and exit
+  echo "found avalanchego ${AVALANCHEGO_VERSION} at ${AVAGO_DOWNLOAD_PATH}"
+
+  extract_archive
+else
+  # try to download the archive if it exists
+  if curl -s --head --request GET ${AVAGO_DOWNLOAD_URL} | grep "302" > /dev/null; then
+    echo "${AVAGO_DOWNLOAD_URL} found"
+    echo "downloading to ${AVAGO_DOWNLOAD_PATH}"
+    curl -L ${AVAGO_DOWNLOAD_URL} -o ${AVAGO_DOWNLOAD_PATH}
+
+    extract_archive
+  else
+    # else the version is a git commitish (or it's invalid)
+    GIT_CLONE_URL=https://github.com/ava-labs/avalanchego.git
+    GIT_CLONE_PATH=${BASEDIR}/avalanchego-repo/
+    
+    # check to see if the repo already exists, if not clone it 
+    if [[ ! -d ${GIT_CLONE_PATH} ]]; then
+      echo "cloning ${GIT_CLONE_URL} to ${GIT_CLONE_PATH}"
+      git clone --no-checkout ${GIT_CLONE_URL} ${GIT_CLONE_PATH}
+    fi
+
+    # check to see if the commitish exists in the repo
+    WORKDIR=$(pwd)
+
+    cd ${GIT_CLONE_PATH}
+
+    git fetch
+
+    echo "checking out ${AVALANCHEGO_VERSION}"
+
+    set +e
+    # try to checkout the branch
+    git checkout origin/${AVALANCHEGO_VERSION} > /dev/null 2>&1
+    CHECKOUT_STATUS=$?
+    set -e
+
+    # if it's not a branch, try to checkout the commit 
+    if [[ $CHECKOUT_STATUS -ne 0 ]]; then
+      set +e
+      git checkout ${AVALANCHEGO_VERSION} > /dev/null 2>&1
+      CHECKOUT_STATUS=$?
+      set -e
+
+      if [[ $CHECKOUT_STATUS -ne 0 ]]; then
+        echo
+        echo "'${VERSION}' is not a valid release tag, commit hash, or branch name"
+        exit 1
+      fi
+    fi
+
+    COMMIT=$(git rev-parse HEAD)
+
+    # use the commit hash instead of the branch name or tag
+    BUILD_DIR=${AVALANCHEGO_BUILD_PATH}-${COMMIT}
+
+    # if the build-directory doesn't exist, build avalanchego
+    if [[ ! -d ${BUILD_DIR} ]]; then    
+      echo "building avalanchego ${COMMIT} to ${BUILD_DIR}"
+      ./scripts/build.sh
+      mkdir -p ${BUILD_DIR}
+
+      mv ${GIT_CLONE_PATH}/build/* ${BUILD_DIR}/
+    fi
+
+    cd $WORKDIR
+  fi
 fi
 
 AVALANCHEGO_PATH=${AVALANCHEGO_BUILD_PATH}/avalanchego
 AVALANCHEGO_PLUGIN_DIR=${AVALANCHEGO_BUILD_PATH}/plugins
 
-echo "Installed AvalancheGo release ${VERSION}"
+mkdir -p ${AVALANCHEGO_BUILD_PATH}
+    
+cp ${BUILD_DIR}/avalanchego ${AVALANCHEGO_PATH}
+
+
+echo "Installed AvalancheGo release ${AVALANCHEGO_VERSION}"
 echo "AvalancheGo Path: ${AVALANCHEGO_PATH}"
 echo "Plugin Dir: ${AVALANCHEGO_PLUGIN_DIR}"

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -3,7 +3,8 @@
 # Set up the versions to be used - populate ENV variables only if they are not already populated
 SUBNET_EVM_VERSION=${SUBNET_EVM_VERSION:-'v0.4.12'}
 # Don't export them as they're used in the context of other calls
-AVALANCHEGO_VERSION=${AVALANCHE_VERSION:-'v1.9.11'}
+AVALANCHE_VERSION=${AVALANCHE_VERSION:-'v1.9.11'}
+AVALANCHEGO_VERSION=${AVALANCHEGO_VERSION:-$AVALANCHE_VERSION}
 GINKGO_VERSION=${GINKGO_VERSION:-'v2.2.0'}
 
 # This won't be used, but it's here to make code syncs easier


### PR DESCRIPTION
## Why this should be merged

Resolves #500

## How this works

use the `AVALANCHE_VERSION` environment variable to specify a commit or branch name (or tag without a prebuilt binary).

## How this was tested

tested here for a `commit`:
https://github.com/ava-labs/subnet-evm/actions/runs/4512439095/jobs/7945887581

<img width="1112" alt="Screenshot 2023-03-24 at 10 54 24 AM" src="https://user-images.githubusercontent.com/3286504/227560140-f46f9a84-6aa5-40a1-80d8-70565e573d29.png">

and here for a `branch`:
https://github.com/ava-labs/subnet-evm/actions/runs/4512412729/jobs/7945824005

<img width="1115" alt="Screenshot 2023-03-24 at 10 56 36 AM" src="https://user-images.githubusercontent.com/3286504/227560978-fcf86e14-0ce0-4c32-b7a8-008fb9082852.png">

## How is this documented

documentation for the whole process needs to be added
