### PR TITLE
Warp preparation updates

### DIFF
--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -35,6 +35,7 @@ import (
 	commonEng "github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/snow/validators"
 	avalancheConstants "github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/avalanchego/utils/crypto/bls"
 	"github.com/ava-labs/avalanchego/utils/formatting"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/version"
@@ -60,6 +61,8 @@ import (
 	"github.com/ava-labs/subnet-evm/rpc"
 	"github.com/ava-labs/subnet-evm/trie"
 	"github.com/ava-labs/subnet-evm/vmerrs"
+
+	avalancheWarp "github.com/ava-labs/avalanchego/vms/platformvm/warp"
 )
 
 var (
@@ -141,6 +144,12 @@ func NewContext() *snow.Context {
 			return subnetID, nil
 		},
 	}
+	blsSecretKey, err := bls.NewSecretKey()
+	if err != nil {
+		panic(err)
+	}
+	ctx.WarpSigner = avalancheWarp.NewSigner(blsSecretKey, ctx.ChainID)
+	ctx.PublicKey = bls.PublicFromSecretKey(blsSecretKey)
 	return ctx
 }
 


### PR DESCRIPTION
## Why this should be merged

This PR ports two changes from the warp PR that are not specific to that PR
- Add BLS public key and Warp signer to VM snow context setup
- Fix handling of receipts in precompile acceptance

## How this was tested

CI

## How is this documented

Added a comment to the receipt handling to make it more explicit