### PR TITLE
Rename local var validationTrieProcTime

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1356,9 +1356,9 @@ func (bc *BlockChain) insertBlock(block *types.Block, writes bool) error {
 	storageUpdateTimer.Inc(statedb.StorageUpdates.Milliseconds()) // Storage updates are complete, we can mark them
 	accountHashTimer.Inc(statedb.AccountHashes.Milliseconds())    // Account hashes are complete, we can mark them
 	storageHashTimer.Inc(statedb.StorageHashes.Milliseconds())    // Storage hashes are complete, we can mark them
-	additionalTrieProc := statedb.AccountHashes + statedb.StorageHashes + statedb.AccountUpdates + statedb.StorageUpdates - trieproc
-	blockStateValidationTimer.Inc((time.Since(substart) - additionalTrieProc).Milliseconds())
-	blockTrieOpsTimer.Inc((trieproc + additionalTrieProc).Milliseconds())
+	validationTrieProcTime := statedb.AccountHashes + statedb.StorageHashes + statedb.AccountUpdates + statedb.StorageUpdates - trieproc
+	blockStateValidationTimer.Inc((time.Since(substart) - validationTrieProcTime).Milliseconds())
+	blockTrieOpsTimer.Inc((trieproc + validationTrieProcTime).Milliseconds())
 
 	// If [writes] are disabled, skip [writeBlockWithState] so that we do not write the block
 	// or the state trie to disk.


### PR DESCRIPTION
This PR renames a local variable to `validationTrieProcTime` for clarity