### PR TITLE
Bump avalanchego to v1.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ The Subnet EVM runs in a separate process from the main AvalancheGo process and 
 [v0.4.8] AvalancheGo@v1.9.6-v1.9.8 (Protocol Version: 22)
 [v0.4.9] AvalancheGo@v1.9.9 (Protocol Version: 23)
 [v0.4.10] AvalancheGo@v1.9.9 (Protocol Version: 23)
-[v0.4.11] AvalancheGo@v1.9.10 (Protocol Version: 24)
-[v0.4.12] AvalancheGo@v1.9.10 (Protocol Version: 24)
+[v0.4.11] AvalancheGo@v1.9.10-v1.9.16 (Protocol Version: 24)
+[v0.4.12] AvalancheGo@v1.9.10-v1.9.16 (Protocol Version: 24)
+[v0.5.0] AvalancheGo@v1.10.0 (Protocol Version: 25)
 ```
 
 ## API

--- a/compatibility.json
+++ b/compatibility.json
@@ -1,5 +1,6 @@
 {
   "rpcChainVMProtocolVersion": {
+    "v0.5.0-fuji-rc.0": 25,
     "v0.4.12": 24,
     "v0.4.11": 24,
     "v0.4.10": 23,

--- a/compatibility.json
+++ b/compatibility.json
@@ -1,6 +1,6 @@
 {
   "rpcChainVMProtocolVersion": {
-    "v0.5.0-fuji-rc.0": 25,
+    "v0.5.0": 25,
     "v0.4.12": 24,
     "v0.4.11": 24,
     "v0.4.10": 23,

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.10.0
-	github.com/ava-labs/avalanchego v1.9.11
+	github.com/ava-labs/avalanchego v1.10.0-fuji-rc.2
 	github.com/cespare/cp v0.1.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckarep/golang-set v1.8.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.10.0
-	github.com/ava-labs/avalanchego v1.10.0-fuji-rc.2
+	github.com/ava-labs/avalanchego v1.10.0
 	github.com/cespare/cp v0.1.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckarep/golang-set v1.8.0
@@ -47,6 +47,7 @@ require (
 )
 
 require (
+	github.com/DataDog/zstd v1.5.2 // indirect
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
-github.com/ava-labs/avalanchego v1.9.11 h1:5hXHJMvErfaolWD7Hw9gZaVylck2shBaV/2NTHA0BfA=
-github.com/ava-labs/avalanchego v1.9.11/go.mod h1:nNc+4JCIJMaEt2xRmeMVAUyQwDIap7RvnMrfWD2Tpo8=
+github.com/ava-labs/avalanchego v1.10.0-fuji-rc.2 h1:2iGOJ2VEfilbCNkTwDtbbTasUt8MU49+J3il5xAZtFY=
+github.com/ava-labs/avalanchego v1.10.0-fuji-rc.2/go.mod h1:YlY/2lzBTE7BRd3T/XwPYN2dax7Olsy1lzevg+RLyNQ=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.1.0 h1:ksErzDEI1khOiGPgpwuI7x2ebx/uXQNw7xJpn9Eq1+I=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
+github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
+github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
@@ -61,8 +63,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
-github.com/ava-labs/avalanchego v1.10.0-fuji-rc.2 h1:2iGOJ2VEfilbCNkTwDtbbTasUt8MU49+J3il5xAZtFY=
-github.com/ava-labs/avalanchego v1.10.0-fuji-rc.2/go.mod h1:YlY/2lzBTE7BRd3T/XwPYN2dax7Olsy1lzevg+RLyNQ=
+github.com/ava-labs/avalanchego v1.10.0 h1:Rn6Nyd62OkzQG5QpCgtCGVXtjuiaEzxV000kqG9aUIg=
+github.com/ava-labs/avalanchego v1.10.0/go.mod h1:hTaSLGN4y/EmhmYd+yjUj9Lsm00q70V78jOYDdnLrgQ=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=

--- a/plugin/evm/version.go
+++ b/plugin/evm/version.go
@@ -11,7 +11,7 @@ var (
 	// GitCommit is set by the build script
 	GitCommit string
 	// Version is the version of Subnet EVM
-	Version string = "v0.5.0-fuji-rc.0"
+	Version string = "v0.5.0"
 )
 
 func init() {

--- a/plugin/evm/version.go
+++ b/plugin/evm/version.go
@@ -11,7 +11,7 @@ var (
 	// GitCommit is set by the build script
 	GitCommit string
 	// Version is the version of Subnet EVM
-	Version string = "v0.4.12"
+	Version string = "v0.5.0-fuji-rc.0"
 )
 
 func init() {

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 # Set up the versions to be used - populate ENV variables only if they are not already populated
-SUBNET_EVM_VERSION=${SUBNET_EVM_VERSION:-'v0.5.0-fuji-rc.0'}
+SUBNET_EVM_VERSION=${SUBNET_EVM_VERSION:-'v0.5.0'}
 # Don't export them as they're used in the context of other calls
-AVALANCHE_VERSION=${AVALANCHE_VERSION:-'v1.10.0-fuji-rc.2'}
+AVALANCHE_VERSION=${AVALANCHE_VERSION:-'v1.10.0'}
 AVALANCHEGO_VERSION=${AVALANCHEGO_VERSION:-$AVALANCHE_VERSION}
 GINKGO_VERSION=${GINKGO_VERSION:-'v2.2.0'}
 

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 # Set up the versions to be used - populate ENV variables only if they are not already populated
-SUBNET_EVM_VERSION=${SUBNET_EVM_VERSION:-'v0.4.12'}
+SUBNET_EVM_VERSION=${SUBNET_EVM_VERSION:-'v0.5.0-fuji-rc.0'}
 # Don't export them as they're used in the context of other calls
-AVALANCHE_VERSION=${AVALANCHE_VERSION:-'v1.9.11'}
+AVALANCHE_VERSION=${AVALANCHE_VERSION:-'v1.10.0-fuji-rc.2'}
 AVALANCHEGO_VERSION=${AVALANCHEGO_VERSION:-$AVALANCHE_VERSION}
 GINKGO_VERSION=${GINKGO_VERSION:-'v2.2.0'}
 

--- a/tests/load/load_test.go
+++ b/tests/load/load_test.go
@@ -40,7 +40,7 @@ var _ = ginkgo.BeforeSuite(func() {
 
 	// Assumes that startCmd will launch a node with HTTP Port at [utils.DefaultLocalNodeURI]
 	healthClient := health.NewClient(utils.DefaultLocalNodeURI)
-	healthy, err := health.AwaitReady(ctx, healthClient, 5*time.Second)
+	healthy, err := health.AwaitReady(ctx, healthClient, 5*time.Second, nil)
 	gomega.Expect(err).Should(gomega.BeNil())
 	gomega.Expect(healthy).Should(gomega.BeTrue())
 	log.Info("AvalancheGo node is healthy")

--- a/tests/precompile/precompile_test.go
+++ b/tests/precompile/precompile_test.go
@@ -40,7 +40,7 @@ var _ = ginkgo.BeforeSuite(func() {
 
 	// Assumes that startCmd will launch a node with HTTP Port at [utils.DefaultLocalNodeURI]
 	healthClient := health.NewClient(utils.DefaultLocalNodeURI)
-	healthy, err := health.AwaitReady(ctx, healthClient, 5*time.Second)
+	healthy, err := health.AwaitReady(ctx, healthClient, 5*time.Second, nil)
 	gomega.Expect(err).Should(gomega.BeNil())
 	gomega.Expect(healthy).Should(gomega.BeTrue())
 	log.Info("AvalancheGo node is healthy")

--- a/tests/precompile/solidity/suites.go
+++ b/tests/precompile/solidity/suites.go
@@ -17,7 +17,7 @@ import (
 var _ = ginkgo.Describe("[Precompiles]", ginkgo.Ordered, func() {
 	ginkgo.It("ping the network", ginkgo.Label("setup"), func() {
 		client := health.NewClient(utils.DefaultLocalNodeURI)
-		healthy, err := client.Readiness(context.Background())
+		healthy, err := client.Readiness(context.Background(), nil)
 		gomega.Expect(err).Should(gomega.BeNil())
 		gomega.Expect(healthy.Healthy).Should(gomega.BeTrue())
 	})


### PR DESCRIPTION
This PR bumps avalanchego dependency to v1.10.0-fuji-rc.2 for the Fuji Cortina Release.

This also updates the Subnet-EVM version to v0.5.0-fuji-rc.0