### PR TITLE
Add manual dispatch for goreleaser GH Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,11 @@
 name: Release
 
 on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to include in artifact name'
+        required: true
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'


### PR DESCRIPTION
## Why this should be merged

This PR adds a manual dispatch for running goreleaser.

## How this works

This adds the ability to run a manual GitHub action with a tag to include in the artifact name as a required input in order to manually generate binaries from goreleaser.

## How this was tested

Tested locally with [act](https://github.com/nektos/act) to ensure that the manual workflow takes in the expected input. OSX cross failed due to missing GITHUB_PATH, but this should work in CI.

## How is this documented

Self-documenting.