### PR TITLE
Warp prep nits

### DIFF
--- a/plugin/evm/block.go
+++ b/plugin/evm/block.go
@@ -202,12 +202,6 @@ func (b *Block) ShouldVerifyWithContext(context.Context) (bool, error) {
 
 // VerifyWithContext implements the block.WithVerifyContext interface
 func (b *Block) VerifyWithContext(ctx context.Context, proposerVMBlockCtx *block.Context) error {
-	if proposerVMBlockCtx != nil {
-		log.Debug("Verifying block with context", "block", b.ID(), "height", b.Height())
-	} else {
-		log.Debug("Verifying block without context", "block", b.ID(), "height", b.Height())
-	}
-
 	return b.verify(&precompileconfig.ProposerPredicateContext{
 		PrecompilePredicateContext: precompileconfig.PrecompilePredicateContext{
 			SnowCtx: b.vm.ctx,
@@ -220,6 +214,11 @@ func (b *Block) VerifyWithContext(ctx context.Context, proposerVMBlockCtx *block
 // Enforces that the predicates are valid within [predicateContext].
 // Writes the block details to disk and the state to the trie manager iff writes=true.
 func (b *Block) verify(predicateContext *precompileconfig.ProposerPredicateContext, writes bool) error {
+	if predicateContext.ProposerVMBlockCtx != nil {
+		log.Debug("Verifying block with context", "block", b.ID(), "height", b.Height())
+	} else {
+		log.Debug("Verifying block without context", "block", b.ID(), "height", b.Height())
+	}
 	if err := b.syntacticVerify(); err != nil {
 		return fmt.Errorf("syntactic block verification failed: %w", err)
 	}

--- a/plugin/evm/config.go
+++ b/plugin/evm/config.go
@@ -47,7 +47,6 @@ const (
 	defaultPopulateMissingTriesParallelism            = 1024
 	defaultStateSyncServerTrieCache                   = 64 // MB
 	defaultAcceptedCacheSize                          = 32 // blocks
-	defaultWarpAPIEnabled                             = true
 
 	// defaultStateSyncMinBlocks is the minimum number of blocks the blockchain
 	// should be ahead of local last accepted to perform state sync.
@@ -225,7 +224,6 @@ func (c *Config) SetDefaults() {
 	c.RPCGasCap = defaultRpcGasCap
 	c.RPCTxFeeCap = defaultRpcTxFeeCap
 	c.MetricsExpensiveEnabled = defaultMetricsExpensiveEnabled
-	c.WarpAPIEnabled = defaultWarpAPIEnabled
 
 	c.TxPoolJournal = core.DefaultTxPoolConfig.Journal
 	c.TxPoolRejournal = Duration{core.DefaultTxPoolConfig.Rejournal}


### PR DESCRIPTION
## Why this should be merged

This PR addresses a few small nits from the warp prep changes.
- moves a debug log to a better location
- disables Warp API by default

## How this was tested

CI

## How is this documented

no documentation changes necessary.