### PR TITLE
goreleaser match all tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - '*'
 
 jobs:
   release:


### PR DESCRIPTION
This PR will match all goreleaser tags.

This will allow triggering goreleaser on a tag with `-fuji`. We should follow this up with a fix that runs goreleaser on any tag that does not include "rc", so that we can push non-standard tags.