### PR TITLE
Add workflow dispatch for goreleaser and revert matching tags change

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,10 @@
 name: Release
 
 on:
+  workflow_dispatch:
   push:
     tags:
-      - '*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   release:


### PR DESCRIPTION
## Why this should be merged

This PR reverts the change to matching tags in https://github.com/ava-labs/subnet-evm/pull/607 to create the Cortina activation release and adds a manual workflow dispatch to trigger goreleaser when using non-standard tags.
