### PR TITLE
Enables trie clean cache rejournaling by default

### DIFF
--- a/plugin/evm/config.go
+++ b/plugin/evm/config.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/subnet-evm/core"
 	"github.com/ava-labs/subnet-evm/eth"
 	"github.com/ethereum/go-ethereum/common"
@@ -19,6 +20,7 @@ const (
 	defaultPruningEnabled                             = true
 	defaultCommitInterval                             = 4096
 	defaultTrieCleanCache                             = 512
+	defaultTrieCleanRejournal                         = 15 * time.Minute
 	defaultTrieDirtyCache                             = 256
 	defaultTrieDirtyCommitTarget                      = 20
 	defaultSnapshotCache                              = 256
@@ -219,7 +221,12 @@ func (c Config) EthBackendSettings() eth.Settings {
 	return eth.Settings{MaxBlocksPerRequest: c.MaxBlocksPerRequest}
 }
 
-func (c *Config) SetDefaults() {
+func (c *Config) SetDefaults(ctx *snow.Context) {
+	var trieCleanJournal string
+	if ctx != nil {
+		trieCleanJournal = ctx.ChainDataDir
+	}
+
 	c.EnabledEthAPIs = defaultEnabledAPIs
 	c.RPCGasCap = defaultRpcGasCap
 	c.RPCTxFeeCap = defaultRpcTxFeeCap
@@ -242,6 +249,8 @@ func (c *Config) SetDefaults() {
 	c.ContinuousProfilerMaxFiles = defaultContinuousProfilerMaxFiles
 	c.Pruning = defaultPruningEnabled
 	c.TrieCleanCache = defaultTrieCleanCache
+	c.TrieCleanJournal = trieCleanJournal
+	c.TrieCleanRejournal = Duration{defaultTrieCleanRejournal}
 	c.TrieDirtyCache = defaultTrieDirtyCache
 	c.TrieDirtyCommitTarget = defaultTrieDirtyCommitTarget
 	c.SnapshotCache = defaultSnapshotCache

--- a/plugin/evm/config.go
+++ b/plugin/evm/config.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/subnet-evm/core"
 	"github.com/ava-labs/subnet-evm/eth"
 	"github.com/ethereum/go-ethereum/common"
@@ -221,12 +220,7 @@ func (c Config) EthBackendSettings() eth.Settings {
 	return eth.Settings{MaxBlocksPerRequest: c.MaxBlocksPerRequest}
 }
 
-func (c *Config) SetDefaults(ctx *snow.Context) {
-	var trieCleanJournal string
-	if ctx != nil {
-		trieCleanJournal = ctx.ChainDataDir
-	}
-
+func (c *Config) SetDefaults(trieCleanJournalDir string) {
 	c.EnabledEthAPIs = defaultEnabledAPIs
 	c.RPCGasCap = defaultRpcGasCap
 	c.RPCTxFeeCap = defaultRpcTxFeeCap
@@ -249,7 +243,7 @@ func (c *Config) SetDefaults(ctx *snow.Context) {
 	c.ContinuousProfilerMaxFiles = defaultContinuousProfilerMaxFiles
 	c.Pruning = defaultPruningEnabled
 	c.TrieCleanCache = defaultTrieCleanCache
-	c.TrieCleanJournal = trieCleanJournal
+	c.TrieCleanJournal = trieCleanJournalDir
 	c.TrieCleanRejournal = Duration{defaultTrieCleanRejournal}
 	c.TrieDirtyCache = defaultTrieDirtyCache
 	c.TrieDirtyCommitTarget = defaultTrieDirtyCommitTarget

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"math/big"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -227,7 +228,7 @@ func (vm *VM) Initialize(
 	fxs []*commonEng.Fx,
 	appSender commonEng.AppSender,
 ) error {
-	vm.config.SetDefaults(chainCtx)
+	vm.config.SetDefaults(getDefaultTrieCleanJournalDir(chainCtx))
 	if len(configBytes) > 0 {
 		if err := json.Unmarshal(configBytes, &vm.config); err != nil {
 			return fmt.Errorf("failed to unmarshal config %s: %w", string(configBytes), err)
@@ -958,4 +959,11 @@ func attachEthService(handler *rpc.Server, apis []rpc.API, names []string) error
 	}
 
 	return nil
+}
+
+func getDefaultTrieCleanJournalDir(ctx *snow.Context) string {
+	if ctx == nil || ctx.ChainDataDir == "" {
+		return ""
+	}
+	return path.Join(ctx.ChainDataDir, "clean-trie-journal")
 }

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -227,7 +227,7 @@ func (vm *VM) Initialize(
 	fxs []*commonEng.Fx,
 	appSender commonEng.AppSender,
 ) error {
-	vm.config.SetDefaults()
+	vm.config.SetDefaults(chainCtx)
 	if len(configBytes) > 0 {
 		if err := json.Unmarshal(configBytes, &vm.config); err != nil {
 			return fmt.Errorf("failed to unmarshal config %s: %w", string(configBytes), err)

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -254,7 +254,7 @@ func TestVMConfigDefaults(t *testing.T) {
 	_, vm, _, _ := GenesisVM(t, false, "", configJSON, "")
 
 	var vmConfig Config
-	vmConfig.SetDefaults(nil)
+	vmConfig.SetDefaults("")
 	vmConfig.RPCTxFeeCap = txFeeCap
 	vmConfig.EnabledEthAPIs = enabledEthAPIs
 	require.Equal(t, vmConfig, vm.config, "VM Config should match default with overrides")
@@ -266,7 +266,7 @@ func TestVMNilConfig(t *testing.T) {
 
 	// VM Config should match defaults if no config is passed in
 	var vmConfig Config
-	vmConfig.SetDefaults(nil)
+	vmConfig.SetDefaults("")
 	require.Equal(t, vmConfig, vm.config, "VM Config should match default config")
 	require.NoError(t, vm.Shutdown(context.Background()))
 }
@@ -2633,7 +2633,7 @@ func TestAllowFeeRecipientEnabled(t *testing.T) {
 
 	etherBase := common.HexToAddress("0x0123456789")
 	c := Config{}
-	c.SetDefaults(nil)
+	c.SetDefaults("")
 	c.FeeRecipient = etherBase.String()
 	configJSON, err := json.Marshal(c)
 	if err != nil {
@@ -2693,7 +2693,7 @@ func TestRewardManagerPrecompileSetRewardAddress(t *testing.T) {
 
 	etherBase := common.HexToAddress("0x0123456789") // give custom ether base
 	c := Config{}
-	c.SetDefaults(nil)
+	c.SetDefaults("")
 	c.FeeRecipient = etherBase.String()
 	configJSON, err := json.Marshal(c)
 	require.NoError(t, err)
@@ -2834,7 +2834,7 @@ func TestRewardManagerPrecompileAllowFeeRecipients(t *testing.T) {
 	require.NoError(t, err)
 	etherBase := common.HexToAddress("0x0123456789") // give custom ether base
 	c := Config{}
-	c.SetDefaults(nil)
+	c.SetDefaults("")
 	c.FeeRecipient = etherBase.String()
 	configJSON, err := json.Marshal(c)
 	require.NoError(t, err)

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -254,7 +254,7 @@ func TestVMConfigDefaults(t *testing.T) {
 	_, vm, _, _ := GenesisVM(t, false, "", configJSON, "")
 
 	var vmConfig Config
-	vmConfig.SetDefaults()
+	vmConfig.SetDefaults(nil)
 	vmConfig.RPCTxFeeCap = txFeeCap
 	vmConfig.EnabledEthAPIs = enabledEthAPIs
 	require.Equal(t, vmConfig, vm.config, "VM Config should match default with overrides")
@@ -266,7 +266,7 @@ func TestVMNilConfig(t *testing.T) {
 
 	// VM Config should match defaults if no config is passed in
 	var vmConfig Config
-	vmConfig.SetDefaults()
+	vmConfig.SetDefaults(nil)
 	require.Equal(t, vmConfig, vm.config, "VM Config should match default config")
 	require.NoError(t, vm.Shutdown(context.Background()))
 }
@@ -2633,7 +2633,7 @@ func TestAllowFeeRecipientEnabled(t *testing.T) {
 
 	etherBase := common.HexToAddress("0x0123456789")
 	c := Config{}
-	c.SetDefaults()
+	c.SetDefaults(nil)
 	c.FeeRecipient = etherBase.String()
 	configJSON, err := json.Marshal(c)
 	if err != nil {
@@ -2693,7 +2693,7 @@ func TestRewardManagerPrecompileSetRewardAddress(t *testing.T) {
 
 	etherBase := common.HexToAddress("0x0123456789") // give custom ether base
 	c := Config{}
-	c.SetDefaults()
+	c.SetDefaults(nil)
 	c.FeeRecipient = etherBase.String()
 	configJSON, err := json.Marshal(c)
 	require.NoError(t, err)
@@ -2834,7 +2834,7 @@ func TestRewardManagerPrecompileAllowFeeRecipients(t *testing.T) {
 	require.NoError(t, err)
 	etherBase := common.HexToAddress("0x0123456789") // give custom ether base
 	c := Config{}
-	c.SetDefaults()
+	c.SetDefaults(nil)
 	c.FeeRecipient = etherBase.String()
 	configJSON, err := json.Marshal(c)
 	require.NoError(t, err)


### PR DESCRIPTION
## Why this should be merged
Writing the clean cache periodically may reduce the amount of time it takes to recover from an unclean shutdown.
Currently we have a default of 4096 blocks per commit interval which amounts to 1 root each ~2.3hrs
This means on an average unclean shutdown, nodes would have to reprocess (without snapshot) ~1.1hrs worth of blocks.

## How this works
Specifies default values for rejournal and the data directory for caching.

## How this was tested
existing UTs + manual testing w/ DFK subnet.

## How is this documented
TBD