### PR TITLE
save e2e anr artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,3 +81,10 @@ jobs:
       - name: Run E2E Tests
         shell: bash
         run: AVALANCHEGO_BUILD_PATH=/tmp/e2e-test/avalanchego DATA_DIR=/tmp/e2e-test/data ./scripts/run_ginkgo.sh
+      - name: Upload Artifact
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: subnet-evm-e2e-logs
+          path: /tmp/network-runner-root-data*/
+          retention-days: 5


### PR DESCRIPTION
## Why this should be merged

It saves anr temporaries as CI artifact ready to download. Keep a record of full anr execution to better study/address problems/bug observed on CI, either during PR development or as a result of dependency changes. As CI is a particular env with limited resources, some times certain bugs are most easily observed here.

## How this works

## How this was tested

## How is this documented
