### PR TITLE
bump linting timeout to 10m

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           version: v1.51
           working-directory: .
-          args: --timeout 3m
+          args: --timeout 10m
 
   unit_test:
     name: Golang Unit Tests


### PR DESCRIPTION
## Why this should be merged

This PR bumps the linting timeout to 10min in CI since it has flaked a few times. For reference, AvalancheGo does not specify a linting timeout and takes around 4min.

## How this works

increases timeout

## How this was tested

ci

## How is this documented

n/a