### PR TITLE
Rename test_ to step_ for clarity

### DIFF
--- a/contract-examples/test/README.md
+++ b/contract-examples/test/README.md
@@ -1,6 +1,6 @@
 # Testing Precompiles
 
-If you can, put all of your test logic into DS-test tests. Prefix test functions with `test_`. There's also a `setUp` function that gets called before the test contract is deployed. The current best-practice is to re-deploy one test contract per `test` function called in `*.ts` test definitions. The `setUp` method should be called once, then `test_` functions passed in as the 2nd argument to `test("<description>", <test_function_name_OR_array_of_test_function_names>)` will be called in order. `test.only` and `test.skip` behave the same way as `it.only` and `it.skip`. There's also a `test.debug` that combines `test.only` with some extra event logging (you can use `emit log_string` to help debug Solidity test code).
+If you can, put all of your test logic into DS-test tests. Prefix test functions with `step_`. There's also a `setUp` function that gets called before the test contract is deployed. The current best-practice is to re-deploy one test contract per `test` function called in `*.ts` test definitions. The `setUp` method should be called once, then `step_` functions passed in as the 2nd argument to `test("<description>", <step_function_name_OR_array_of_step_function_names>)` will be called in order. `test.only` and `test.skip` behave the same way as `it.only` and `it.skip`. There's also a `test.debug` that combines `test.only` with some extra event logging (you can use `emit log_string` to help debug Solidity test code).
 
 The `test` function is a wrapper around Mocha's `it` function. It provides a normalized framework for running the
 majority of your test assertions inside of a smart-contract, using `DS-Test`.
@@ -37,7 +37,7 @@ test(
 Many contract functions can be called as a part of the same test:
 
 ```ts
-test("<test_name>", ["<test_fn1>", "<test_fn2>", "<test_fn3>"])
+test("<test_name>", ["<step_fn1>", "<step_fn2>", "<step_fn3>"])
 ```
 
 Individual test functions can describe their own overrides with the `overrides` property.

--- a/contract-examples/test/utils.ts
+++ b/contract-examples/test/utils.ts
@@ -16,7 +16,7 @@ const assert = require("assert")
  * ```
  * Many contract functions can be called as a part of the same test:
  * ```ts
- * test("<test_name>", ["<test_fn1>", "<test_fn2>", "<test_fn3>"])
+ * test("<test_name>", ["<step_fn1>", "<step_fn2>", "<step_fn3>"])
  * ```
  * Individual test functions can describe their own overrides with the `overrides` property.
  * If an object is passed in as the third argument to `test`, it will be used as the default overrides for all test
@@ -69,8 +69,8 @@ const buildTestFn = (fnNameOrObject: FnNameOrObject, overrides = {}, debug = fal
     return fnNameOrObject as MethodWithDebugAndOverrides
   })
 
-  // only `test_` prefixed functions can be called on the `DSTest` contracts to clearly separate tests and helpers
-  assert(fnObjects.every(({ method }) => method.startsWith('test_')), "Solidity test functions must be prefixed with 'test_'")
+  // only `step_` prefixed functions can be called on the `DSTest` contracts to clearly separate tests and helpers
+  assert(fnObjects.every(({ method }) => method.startsWith('step_')), "Solidity test functions must be prefixed with 'step_'")
 
   // return the test function that will be used by `it`
   // this function must be defined with the `function` keyword so that `this` is bound to the Mocha context


### PR DESCRIPTION
## Why this should be merged
In the DS-Test style tests, there is some ambiguity with what should/shouldn't constitue a test. This clears up that ambiguity by using `step_` as a clear differentiator of a prefixed method that should only be used in a testing context (as opposed to a helper). The issue with `test_` is that one might think they can fully understand a test from the `Solidity` method definition, without looking at how the method is being called from `TypeScript`. 

## How this works
Same as before, just a different name

## How this was tested

## How is this documented
