### PR TITLE
Codeowners fix (specific dir overrides global)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,7 @@
 
 # Specific directories:
 
-peer/ @anusha-ctrl
-contract-examples/ @anusha-ctrl
-scripts/ @anusha-ctrl
+peer/ @anusha-ctrl @ceyonur @darioush @aaronbuchwald
+contract-examples/ @anusha-ctrl @ceyonur @darioush @aaronbuchwald
+scripts/ @anusha-ctrl @ceyonur @darioush @aaronbuchwald
+


### PR DESCRIPTION
## Why this should be merged
CODEOWNERS matching on specific dirs overrides the global pattern match.

## How this works
github

## How this was tested
N/A

## How is this documented
N/A