### PR TITLE
plugin/evm: remove unncessary tx.Hash op in map iter

### DIFF
--- a/plugin/evm/gossiper.go
+++ b/plugin/evm/gossiper.go
@@ -328,9 +328,9 @@ func (n *pushGossiper) gossipTxs(force bool) (int, error) {
 	}
 	n.lastGossiped = time.Now()
 	txs := make([]*types.Transaction, 0, len(n.txsToGossip))
-	for _, tx := range n.txsToGossip {
+	for txHash, tx := range n.txsToGossip {
 		txs = append(txs, tx)
-		delete(n.txsToGossip, tx.Hash())
+		delete(n.txsToGossip, txHash)
 	}
 
 	selectedTxs := make([]*types.Transaction, 0)


### PR DESCRIPTION
## Why this should be merged

Simplify, eliminate unnecessary Hash op.

## How this works

Just use the key in map iteration.

## How this was tested

N/A

## How is this documented

N/A