### PR TITLE
deployExampleRewardManager.ts hardhat script fixed

### DIFF
--- a/contract-examples/scripts/deployExampleRewardManager.ts
+++ b/contract-examples/scripts/deployExampleRewardManager.ts
@@ -6,7 +6,7 @@ import { ethers } from "hardhat"
 
 
 const main = async (): Promise<any> => {
-  const Contract: ContractFactory = await ethers.getContractFactory("ExampleRewardDistributor")
+  const Contract: ContractFactory = await ethers.getContractFactory("ExampleRewardManager")
   const contract: Contract = await Contract.deploy()
 
   await contract.deployed()


### PR DESCRIPTION
## Why this should be merged
Fixed incorrect contract call in deployExampleRewardManager.ts hardhat script; getContractFactory now correctly calls "ExampleRewardManager"


