### PR TITLE
Increase trie dirty default cache size to 512MB

### DIFF
--- a/plugin/evm/config.go
+++ b/plugin/evm/config.go
@@ -19,7 +19,7 @@ const (
 	defaultPruningEnabled                             = true
 	defaultCommitInterval                             = 4096
 	defaultTrieCleanCache                             = 512
-	defaultTrieDirtyCache                             = 256
+	defaultTrieDirtyCache                             = 512
 	defaultTrieDirtyCommitTarget                      = 20
 	defaultSnapshotCache                              = 256
 	defaultSyncableCommitInterval                     = defaultCommitInterval * 4


### PR DESCRIPTION
## Why this should be merged

This PR increases the trie dirty default cache size from 256MB to 512MB.

## How this works

Increases the default value

## How this was tested

CI

## How is this documented

na