### PR TITLE
export gingkgo suites

### DIFF
--- a/contract-examples/package.json
+++ b/contract-examples/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "subnet-evm-contracts",
+  "name": "subnet-evm-contract-examples",
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
@@ -20,7 +20,11 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
-  "repository": "https://github.com/ava-labs/subnet-evm-contracts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ava-labs/subnet-evm/contract-examples.git",
+    "directory": "contract-examples"
+  },
   "license": "BSD-3-Clause",
   "scripts": {
     "compile": "npx hardhat compile",

--- a/contract-examples/package.json
+++ b/contract-examples/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "subnet-evm-contract-examples",
+  "name": "@avalabs/subnet-evm-contract-examples",
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",

--- a/contract-examples/package.json
+++ b/contract-examples/package.json
@@ -22,7 +22,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ava-labs/subnet-evm/contract-examples.git",
+    "url": "https://github.com/ava-labs/subnet-evm.git",
     "directory": "contract-examples"
   },
   "license": "BSD-3-Clause",

--- a/tests/load/load_test.go
+++ b/tests/load/load_test.go
@@ -12,39 +12,20 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ava-labs/avalanchego/api/health"
 	"github.com/ava-labs/subnet-evm/tests/utils"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/go-cmd/cmd"
 	ginkgo "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 )
 
-var startCmd *cmd.Cmd
+func init() {
+	utils.RegisterNodeRun()
+}
 
 func TestE2E(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	ginkgo.RunSpecs(t, "subnet-evm small load simulator test suite")
 }
-
-// BeforeSuite starts an AvalancheGo process to use for the e2e tests
-var _ = ginkgo.BeforeSuite(func() {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
-
-	wd, err := os.Getwd()
-	gomega.Expect(err).Should(gomega.BeNil())
-	log.Info("Starting AvalancheGo node", "wd", wd)
-	startCmd, err = utils.RunCommand("./scripts/run.sh")
-	gomega.Expect(err).Should(gomega.BeNil())
-
-	// Assumes that startCmd will launch a node with HTTP Port at [utils.DefaultLocalNodeURI]
-	healthClient := health.NewClient(utils.DefaultLocalNodeURI)
-	healthy, err := health.AwaitReady(ctx, healthClient, 5*time.Second, nil)
-	gomega.Expect(err).Should(gomega.BeNil())
-	gomega.Expect(healthy).Should(gomega.BeTrue())
-	log.Info("AvalancheGo node is healthy")
-})
 
 var _ = ginkgo.Describe("[Load Simulator]", ginkgo.Ordered, func() {
 	ginkgo.It("basic subnet load test", ginkgo.Label("load"), func() {
@@ -69,11 +50,4 @@ var _ = ginkgo.Describe("[Load Simulator]", ginkgo.Ordered, func() {
 		fmt.Printf("\nCombined output:\n\n%s\n", string(out))
 		gomega.Expect(err).Should(gomega.BeNil())
 	})
-})
-
-var _ = ginkgo.AfterSuite(func() {
-	gomega.Expect(startCmd).ShouldNot(gomega.BeNil())
-	gomega.Expect(startCmd.Stop()).Should(gomega.BeNil())
-	// TODO add a new node to bootstrap off of the existing node and ensure it can bootstrap all subnets
-	// created during the test
 })

--- a/tests/precompile/precompile_test.go
+++ b/tests/precompile/precompile_test.go
@@ -4,51 +4,21 @@
 package precompile
 
 import (
-	"context"
-	"os"
 	"testing"
-	"time"
 
-	"github.com/ava-labs/avalanchego/api/health"
-	"github.com/ava-labs/subnet-evm/tests/utils"
-	"github.com/ethereum/go-ethereum/log"
-	"github.com/go-cmd/cmd"
 	ginkgo "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 
 	// Import the solidity package, so that ginkgo maps out the tests declared within the package
 	_ "github.com/ava-labs/subnet-evm/tests/precompile/solidity"
+	"github.com/ava-labs/subnet-evm/tests/utils"
 )
 
-var startCmd *cmd.Cmd
+func init() {
+	utils.RegisterNodeRun()
+}
 
 func TestE2E(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	ginkgo.RunSpecs(t, "subnet-evm precompile ginkgo test suite")
 }
-
-// BeforeSuite starts an AvalancheGo process to use for the e2e tests
-var _ = ginkgo.BeforeSuite(func() {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
-
-	wd, err := os.Getwd()
-	gomega.Expect(err).Should(gomega.BeNil())
-	log.Info("Starting AvalancheGo node", "wd", wd)
-	startCmd, err = utils.RunCommand("./scripts/run.sh")
-	gomega.Expect(err).Should(gomega.BeNil())
-
-	// Assumes that startCmd will launch a node with HTTP Port at [utils.DefaultLocalNodeURI]
-	healthClient := health.NewClient(utils.DefaultLocalNodeURI)
-	healthy, err := health.AwaitReady(ctx, healthClient, 5*time.Second, nil)
-	gomega.Expect(err).Should(gomega.BeNil())
-	gomega.Expect(healthy).Should(gomega.BeTrue())
-	log.Info("AvalancheGo node is healthy")
-})
-
-var _ = ginkgo.AfterSuite(func() {
-	gomega.Expect(startCmd).ShouldNot(gomega.BeNil())
-	gomega.Expect(startCmd.Stop()).Should(gomega.BeNil())
-	// TODO add a new node to bootstrap off of the existing node and ensure it can bootstrap all subnets
-	// created during the test
-})

--- a/tests/precompile/solidity/suites.go
+++ b/tests/precompile/solidity/suites.go
@@ -12,11 +12,10 @@ import (
 	ginkgo "github.com/onsi/ginkgo/v2"
 )
 
-func init() {
-	utils.RegisterPingTest()
-}
-
 var _ = ginkgo.Describe("[Precompiles]", ginkgo.Ordered, func() {
+	// Register the ping test first
+	utils.RegisterPingTest()
+
 	// Each ginkgo It node specifies the name of the genesis file (in ./tests/precompile/genesis/)
 	// to use to launch the subnet and the name of the TS test file to run on the subnet (in ./contract-examples/tests/)
 	ginkgo.It("contract native minter", ginkgo.Label("Precompile"), ginkgo.Label("ContractNativeMinter"), func() {

--- a/tests/precompile/solidity/suites.go
+++ b/tests/precompile/solidity/suites.go
@@ -8,20 +8,13 @@ import (
 	"context"
 	"time"
 
-	"github.com/ava-labs/avalanchego/api/health"
 	"github.com/ava-labs/subnet-evm/tests/utils"
 	ginkgo "github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
-var _ = ginkgo.Describe("[Precompiles]", ginkgo.Ordered, func() {
-	ginkgo.It("ping the network", ginkgo.Label("setup"), func() {
-		client := health.NewClient(utils.DefaultLocalNodeURI)
-		healthy, err := client.Readiness(context.Background(), nil)
-		gomega.Expect(err).Should(gomega.BeNil())
-		gomega.Expect(healthy.Healthy).Should(gomega.BeTrue())
-	})
-})
+func init() {
+	utils.RegisterPingTest()
+}
 
 var _ = ginkgo.Describe("[Precompiles]", ginkgo.Ordered, func() {
 	// Each ginkgo It node specifies the name of the genesis file (in ./tests/precompile/genesis/)

--- a/tests/utils/command.go
+++ b/tests/utils/command.go
@@ -50,13 +50,11 @@ func RunCommand(bin string, args ...string) (*cmd.Cmd, error) {
 }
 
 func RegisterPingTest() {
-	ginkgo.Describe("[Precompiles]", ginkgo.Ordered, func() {
-		ginkgo.It("ping the network", ginkgo.Label("ping"), func() {
-			client := health.NewClient(DefaultLocalNodeURI)
-			healthy, err := client.Readiness(context.Background(), nil)
-			gomega.Expect(err).Should(gomega.BeNil())
-			gomega.Expect(healthy.Healthy).Should(gomega.BeTrue())
-		})
+	ginkgo.It("ping the network", ginkgo.Label("ping"), func() {
+		client := health.NewClient(DefaultLocalNodeURI)
+		healthy, err := client.Readiness(context.Background(), nil)
+		gomega.Expect(err).Should(gomega.BeNil())
+		gomega.Expect(healthy.Healthy).Should(gomega.BeTrue())
 	})
 }
 

--- a/tests/utils/command.go
+++ b/tests/utils/command.go
@@ -4,12 +4,17 @@
 package utils
 
 import (
+	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
+	"github.com/ava-labs/avalanchego/api/health"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/go-cmd/cmd"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 )
 
 // RunCommand starts the command [bin] with the given [args] and returns the command to the caller
@@ -42,4 +47,47 @@ func RunCommand(bin string, args ...string) (*cmd.Cmd, error) {
 	}()
 
 	return curCmd, nil
+}
+
+func RegisterPingTest() {
+	ginkgo.Describe("[Precompiles]", ginkgo.Ordered, func() {
+		ginkgo.It("ping the network", ginkgo.Label("ping"), func() {
+			client := health.NewClient(DefaultLocalNodeURI)
+			healthy, err := client.Readiness(context.Background(), nil)
+			gomega.Expect(err).Should(gomega.BeNil())
+			gomega.Expect(healthy.Healthy).Should(gomega.BeTrue())
+		})
+	})
+}
+
+// RegisterNodeRun registers a before suite that starts an AvalancheGo process to use for the e2e tests
+// and an after suite that stops the AvalancheGo process
+func RegisterNodeRun() {
+	// BeforeSuite starts an AvalancheGo process to use for the e2e tests
+	var startCmd *cmd.Cmd
+	_ = ginkgo.BeforeSuite(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cancel()
+
+		wd, err := os.Getwd()
+		gomega.Expect(err).Should(gomega.BeNil())
+		log.Info("Starting AvalancheGo node", "wd", wd)
+		cmd, err := RunCommand("./scripts/run.sh")
+		startCmd = cmd
+		gomega.Expect(err).Should(gomega.BeNil())
+
+		// Assumes that startCmd will launch a node with HTTP Port at [utils.DefaultLocalNodeURI]
+		healthClient := health.NewClient(DefaultLocalNodeURI)
+		healthy, err := health.AwaitReady(ctx, healthClient, 5*time.Second, nil)
+		gomega.Expect(err).Should(gomega.BeNil())
+		gomega.Expect(healthy).Should(gomega.BeTrue())
+		log.Info("AvalancheGo node is healthy")
+	})
+
+	ginkgo.AfterSuite(func() {
+		gomega.Expect(startCmd).ShouldNot(gomega.BeNil())
+		gomega.Expect(startCmd.Stop()).Should(gomega.BeNil())
+		// TODO add a new node to bootstrap off of the existing node and ensure it can bootstrap all subnets
+		// created during the test
+	})
 }


### PR DESCRIPTION
## Why this should be merged

It exports necessary test suite functions (before/after) to be used in other repos

## How this works

Moves common after/before suites to utils package and exports them.

## How this was tested

E2E tests 

## How is this documented

It will be documented through external precompile registration tutorial.
