### PR TITLE
move state upgrade related functions to own file

### DIFF
--- a/params/precompile_upgrade.go
+++ b/params/precompile_upgrade.go
@@ -148,26 +148,6 @@ func (c *ChainConfig) verifyPrecompileUpgrades() error {
 	return nil
 }
 
-// verifyStateUpgrades checks [c.StateUpgrades] is well formed:
-// - the specified blockTimestamps must monotonically increase
-func (c *ChainConfig) verifyStateUpgrades() error {
-	var previousUpgradeTimestamp *big.Int
-	for i, upgrade := range c.StateUpgrades {
-		upgradeTimestamp := upgrade.BlockTimestamp
-		// Verify the upgrade's timestamp is greater than 0 (to avoid confusion with genesis).
-		if upgradeTimestamp.Cmp(common.Big0) <= 0 {
-			return fmt.Errorf("StateUpgrade[%d]: config block timestamp (%v) must be greater than 0", i, upgradeTimestamp)
-		}
-
-		// Verify specified timestamps are strictly monotonically increasing.
-		if previousUpgradeTimestamp != nil && upgradeTimestamp.Cmp(previousUpgradeTimestamp) <= 0 {
-			return fmt.Errorf("StateUpgrade[%d]: config block timestamp (%v) <= previous timestamp (%v)", i, upgradeTimestamp, previousUpgradeTimestamp)
-		}
-		previousUpgradeTimestamp = upgradeTimestamp
-	}
-	return nil
-}
-
 // getActivePrecompileConfig returns the most recent precompile config corresponding to [address].
 // If none have occurred, returns nil.
 func (c *ChainConfig) getActivePrecompileConfig(address common.Address, blockTimestamp *big.Int) precompileconfig.Config {
@@ -205,18 +185,6 @@ func (c *ChainConfig) GetActivatingPrecompileConfigs(address common.Address, fro
 		}
 	}
 	return configs
-}
-
-// GetActivatingStateUpgrades returns all state upgrades configured to activate during the
-// state transition from a block with timestamp [from] to a block with timestamp [to].
-func (c *ChainConfig) GetActivatingStateUpgrades(from *big.Int, to *big.Int, upgrades []StateUpgrade) []StateUpgrade {
-	activating := make([]StateUpgrade, 0)
-	for _, upgrade := range upgrades {
-		if utils.IsForkTransition(upgrade.BlockTimestamp, from, to) {
-			activating = append(activating, upgrade)
-		}
-	}
-	return activating
 }
 
 // CheckPrecompilesCompatible checks if [precompileUpgrades] are compatible with [c] at [headTimestamp].
@@ -271,44 +239,6 @@ func (c *ChainConfig) checkPrecompileCompatible(address common.Address, precompi
 			fmt.Sprintf("cannot retroactively enable PrecompileUpgrade[%d]", len(activeUpgrades)),
 			nil,
 			newUpgrades[len(activeUpgrades)].Timestamp(), // this indexes to the first element in newUpgrades after the end of activeUpgrades
-		)
-	}
-
-	return nil
-}
-
-// CheckStateUpgradesCompatible checks if [stateUpgrades] are compatible with [c] at [headTimestamp].
-func (c *ChainConfig) CheckStateUpgradesCompatible(stateUpgrades []StateUpgrade, lastTimestamp *big.Int) *ConfigCompatError {
-	// All active upgrades (from nil to [lastTimestamp]) must match.
-	activeUpgrades := c.GetActivatingStateUpgrades(nil, lastTimestamp, c.StateUpgrades)
-	newUpgrades := c.GetActivatingStateUpgrades(nil, lastTimestamp, stateUpgrades)
-
-	// Check activated upgrades are still present.
-	for i, upgrade := range activeUpgrades {
-		if len(newUpgrades) <= i {
-			// missing upgrade
-			return newCompatError(
-				fmt.Sprintf("missing StateUpgrade[%d]", i),
-				upgrade.BlockTimestamp,
-				nil,
-			)
-		}
-		// All upgrades that have activated must be identical.
-		if !upgrade.Equal(&newUpgrades[i]) {
-			return newCompatError(
-				fmt.Sprintf("StateUpgrade[%d]", i),
-				upgrade.BlockTimestamp,
-				newUpgrades[i].BlockTimestamp,
-			)
-		}
-	}
-	// then, make sure newUpgrades does not have additional upgrades
-	// that are already activated. (cannot perform retroactive upgrade)
-	if len(newUpgrades) > len(activeUpgrades) {
-		return newCompatError(
-			fmt.Sprintf("cannot retroactively enable StateUpgrade[%d]", len(activeUpgrades)),
-			nil,
-			newUpgrades[len(activeUpgrades)].BlockTimestamp, // this indexes to the first element in newUpgrades after the end of activeUpgrades
 		)
 	}
 

--- a/params/state_upgrade.go
+++ b/params/state_upgrade.go
@@ -4,9 +4,11 @@
 package params
 
 import (
+	"fmt"
 	"math/big"
 	"reflect"
 
+	"github.com/ava-labs/subnet-evm/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
@@ -31,4 +33,74 @@ type StateUpgradeAccount struct {
 
 func (s *StateUpgrade) Equal(other *StateUpgrade) bool {
 	return reflect.DeepEqual(s, other)
+}
+
+// verifyStateUpgrades checks [c.StateUpgrades] is well formed:
+// - the specified blockTimestamps must monotonically increase
+func (c *ChainConfig) verifyStateUpgrades() error {
+	var previousUpgradeTimestamp *big.Int
+	for i, upgrade := range c.StateUpgrades {
+		upgradeTimestamp := upgrade.BlockTimestamp
+		// Verify the upgrade's timestamp is greater than 0 (to avoid confusion with genesis).
+		if upgradeTimestamp.Cmp(common.Big0) <= 0 {
+			return fmt.Errorf("StateUpgrade[%d]: config block timestamp (%v) must be greater than 0", i, upgradeTimestamp)
+		}
+
+		// Verify specified timestamps are strictly monotonically increasing.
+		if previousUpgradeTimestamp != nil && upgradeTimestamp.Cmp(previousUpgradeTimestamp) <= 0 {
+			return fmt.Errorf("StateUpgrade[%d]: config block timestamp (%v) <= previous timestamp (%v)", i, upgradeTimestamp, previousUpgradeTimestamp)
+		}
+		previousUpgradeTimestamp = upgradeTimestamp
+	}
+	return nil
+}
+
+// GetActivatingStateUpgrades returns all state upgrades configured to activate during the
+// state transition from a block with timestamp [from] to a block with timestamp [to].
+func (c *ChainConfig) GetActivatingStateUpgrades(from *big.Int, to *big.Int, upgrades []StateUpgrade) []StateUpgrade {
+	activating := make([]StateUpgrade, 0)
+	for _, upgrade := range upgrades {
+		if utils.IsForkTransition(upgrade.BlockTimestamp, from, to) {
+			activating = append(activating, upgrade)
+		}
+	}
+	return activating
+}
+
+// CheckStateUpgradesCompatible checks if [stateUpgrades] are compatible with [c] at [headTimestamp].
+func (c *ChainConfig) CheckStateUpgradesCompatible(stateUpgrades []StateUpgrade, lastTimestamp *big.Int) *ConfigCompatError {
+	// All active upgrades (from nil to [lastTimestamp]) must match.
+	activeUpgrades := c.GetActivatingStateUpgrades(nil, lastTimestamp, c.StateUpgrades)
+	newUpgrades := c.GetActivatingStateUpgrades(nil, lastTimestamp, stateUpgrades)
+
+	// Check activated upgrades are still present.
+	for i, upgrade := range activeUpgrades {
+		if len(newUpgrades) <= i {
+			// missing upgrade
+			return newCompatError(
+				fmt.Sprintf("missing StateUpgrade[%d]", i),
+				upgrade.BlockTimestamp,
+				nil,
+			)
+		}
+		// All upgrades that have activated must be identical.
+		if !upgrade.Equal(&newUpgrades[i]) {
+			return newCompatError(
+				fmt.Sprintf("StateUpgrade[%d]", i),
+				upgrade.BlockTimestamp,
+				newUpgrades[i].BlockTimestamp,
+			)
+		}
+	}
+	// then, make sure newUpgrades does not have additional upgrades
+	// that are already activated. (cannot perform retroactive upgrade)
+	if len(newUpgrades) > len(activeUpgrades) {
+		return newCompatError(
+			fmt.Sprintf("cannot retroactively enable StateUpgrade[%d]", len(activeUpgrades)),
+			nil,
+			newUpgrades[len(activeUpgrades)].BlockTimestamp, // this indexes to the first element in newUpgrades after the end of activeUpgrades
+		)
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Why this should be merged
State Upgrade functions should stay in its own file

## How this works
Moves related functions to `state_upgrade.go`

## How this was tested
Existing UT should cover this

## How is this documented
No need
