### PR TITLE
Add wrapped validator state for primary to subnet warp messages

### DIFF
--- a/warp/validators/state.go
+++ b/warp/validators/state.go
@@ -1,0 +1,50 @@
+// (c) 2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package validators
+
+import (
+	"context"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/snow/validators"
+)
+
+var _ validators.State = (*State)(nil)
+
+// State provides a special case used to handle Avalanche Warp Message verification for messages sent
+// from the Primary Network. Subnets have strictly fewer validators than the Primary Network, so we require
+// signatures from a threshold of the RECEIVING subnet validator set rather than the full Primary Network
+// since the receiving subnet already relies on a majority of its validators being correct.
+type State struct {
+	chainContext *snow.Context
+	validators.State
+}
+
+// NewState returns a wrapper of [validators.State] which special cases the handling of the Primary Network.
+//
+// The wrapped state will return the chainContext's Subnet validator set instead of the Primary Network when
+// the Primary Network SubnetID is passed in.
+func NewState(chainContext *snow.Context) *State {
+	return &State{
+		chainContext: chainContext,
+		State:        chainContext.ValidatorState,
+	}
+}
+
+func (s *State) GetValidatorSet(
+	ctx context.Context,
+	height uint64,
+	subnetID ids.ID,
+) (map[ids.NodeID]*validators.GetValidatorOutput, error) {
+	// If the subnetID is anything other than the Primary Network, this is a direct
+	// passthrough
+	if subnetID != ids.Empty {
+		return s.State.GetValidatorSet(ctx, height, subnetID)
+	}
+
+	// If the requested subnet is the primary network, then we return the validator
+	// set for the Subnet that is receiving the message instead.
+	return s.State.GetValidatorSet(ctx, height, s.chainContext.SubnetID)
+}

--- a/warp/validators/state.go
+++ b/warp/validators/state.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/snow/validators"
+	"github.com/ava-labs/avalanchego/utils/constants"
 )
 
 var _ validators.State = (*State)(nil)
@@ -40,7 +41,7 @@ func (s *State) GetValidatorSet(
 ) (map[ids.NodeID]*validators.GetValidatorOutput, error) {
 	// If the subnetID is anything other than the Primary Network, this is a direct
 	// passthrough
-	if subnetID != ids.Empty {
+	if subnetID != constants.PrimaryNetworkID {
 		return s.State.GetValidatorSet(ctx, height, subnetID)
 	}
 


### PR DESCRIPTION
## Why this should be merged

This PR adds a wrapped validator state type to pass in to warp message verification. This reduces the number of signatures required to verify a message from the primary network using the assumptions:

1. A subnet already relies on its own validator set
2. A subnet's validator set is also validating the primary network

## How this works

Wraps `validators.State` with a special case that will return the local snow context's validator set if the primary network validator set is requested.

## How this was tested

na

## How is this documented

comment in the code explaining the rationale