### PR TITLE
upload network runner artifact after e2e test run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,3 +81,10 @@ jobs:
       - name: Run E2E Tests
         shell: bash
         run: AVALANCHEGO_BUILD_PATH=/tmp/e2e-test/avalanchego DATA_DIR=/tmp/e2e-test/data ./scripts/run_ginkgo.sh
+      - name: Upload Artifact
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: subnet-evm-e2e-logs
+          path: /tmp/network-runner-root-data*/
+          retention-days: 5


### PR DESCRIPTION
## Why this should be merged

This PR uploads the anr data dir after the e2e tests run.

## How this works

Uses upload-artifact GH action to upload relevant data for debugging e2e tests

## How this was tested

CI

## How is this documented

na