### PR TITLE
Add signature aggregation helpers

### DIFF
--- a/params/avalanche_params.go
+++ b/params/avalanche_params.go
@@ -1,0 +1,8 @@
+// (c) 2019-2020, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package params
+
+const (
+	WarpQuorumDenominator uint64 = 100
+)

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -169,3 +169,7 @@ var (
 	MinimumDifficulty      = big.NewInt(131072) // The minimum that the difficulty may ever be.
 	DurationLimit          = big.NewInt(13)     // The decision boundary on the blocktime duration used to determine whether difficulty should go up or not.
 )
+
+const (
+	WarpQuorumDenominator uint64 = 100
+)

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -169,7 +169,3 @@ var (
 	MinimumDifficulty      = big.NewInt(131072) // The minimum that the difficulty may ever be.
 	DurationLimit          = big.NewInt(13)     // The decision boundary on the blocktime duration used to determine whether difficulty should go up or not.
 )
-
-const (
-	WarpQuorumDenominator uint64 = 100
-)

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -37,6 +37,8 @@ import (
 	"github.com/ava-labs/subnet-evm/sync/client/stats"
 	"github.com/ava-labs/subnet-evm/trie"
 	"github.com/ava-labs/subnet-evm/warp"
+	"github.com/ava-labs/subnet-evm/warp/aggregator"
+	warpValidators "github.com/ava-labs/subnet-evm/warp/validators"
 
 	// Force-load tracer engine to trigger registration
 	//
@@ -822,7 +824,8 @@ func (vm *VM) CreateHandlers(context.Context) (map[string]*commonEng.HTTPHandler
 	}
 
 	if vm.config.WarpAPIEnabled {
-		if err := handler.RegisterName("warp", &warp.WarpAPI{Backend: vm.warpBackend}); err != nil {
+		warpAggregator := aggregator.NewAggregator(vm.ctx.SubnetID, warpValidators.NewState(vm.ctx), &aggregator.NetworkSigner{Client: vm.client})
+		if err := handler.RegisterName("warp", warp.NewWarpAPI(vm.warpBackend, warpAggregator)); err != nil {
 			return nil, err
 		}
 		enabledAPIs = append(enabledAPIs, "warp")

--- a/warp/aggregator/aggregation_job.go
+++ b/warp/aggregator/aggregation_job.go
@@ -1,0 +1,135 @@
+// (c) 2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package aggregator
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow/validators"
+	"github.com/ava-labs/avalanchego/utils/crypto/bls"
+	"github.com/ava-labs/avalanchego/utils/set"
+	avalancheWarp "github.com/ava-labs/avalanchego/vms/platformvm/warp"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type signatureAggregationJob struct {
+	// SignatureBackend is assumed to be thread-safe and may be used by multiple signature aggregation jobs concurrently
+	client   SignatureBackend
+	height   uint64
+	subnetID ids.ID
+
+	quorumNum       uint64 // Minimum threshold at which to bother returning the resulting signature
+	cancelQuorumNum uint64 // Threshold at which to cancel further signature fetching
+	quorumDen       uint64 // Denominator to use when checking if we've reached the threshold
+	state           validators.State
+	msg             *avalancheWarp.UnsignedMessage
+}
+
+type AggregateSignatureResult struct {
+	SignatureWeight uint64
+	TotalWeight     uint64
+	Message         *avalancheWarp.Message
+}
+
+func NewSignatureAggregationJob(
+	client SignatureBackend,
+	height uint64,
+	subnetID ids.ID,
+	quorumNum uint64,
+	cancelQuorumNum uint64,
+	quorumDen uint64,
+	state validators.State,
+	msg *avalancheWarp.UnsignedMessage,
+) *signatureAggregationJob {
+	return &signatureAggregationJob{
+		client:          client,
+		height:          height,
+		subnetID:        subnetID,
+		quorumNum:       quorumNum,
+		cancelQuorumNum: cancelQuorumNum,
+		quorumDen:       quorumDen,
+		state:           state,
+		msg:             msg,
+	}
+}
+
+// Execute aggregates signatures for the requested message
+func (a *signatureAggregationJob) Execute(ctx context.Context) (*AggregateSignatureResult, error) {
+	validators, totalWeight, err := avalancheWarp.GetCanonicalValidatorSet(ctx, a.state, a.height, a.subnetID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get validator set: %w", err)
+	}
+	signatureJobs := make([]*signatureJob, 0, len(validators))
+	for _, validator := range validators {
+		signatureJobs = append(signatureJobs, newSignatureJob(a.client, validator, a.msg))
+	}
+
+	// signatureLock is used to access any of the signature attributes in the goroutines created below
+	signatureLock := sync.Mutex{}
+	blsSignatures := make([]*bls.Signature, 0, len(signatureJobs))
+	bitSet := set.NewBits()
+	signatureWeight := uint64(0)
+
+	// Create a child context to cancel signature fetching if we reach [cancelQuorumNum] threshold
+	signatureFetchCtx, signatureFetchCancel := context.WithCancel(ctx)
+	defer signatureFetchCancel()
+
+	wg := sync.WaitGroup{}
+	for i, signatureJob := range signatureJobs {
+		i := i
+		signatureJob := signatureJob
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			log.Info("Fetching warp signature", "nodeID", signatureJob.nodeID, "index", i)
+			blsSignature, err := signatureJob.Execute(signatureFetchCtx)
+			if err != nil {
+				log.Info("Failed to fetch signature at index %d: %s", i, signatureJob)
+				return
+			}
+			log.Info("Retrieved warp signature", "nodeID", signatureJob.nodeID, "index", i, "signature", hexutil.Bytes(bls.SignatureToBytes(blsSignature)))
+			// Add the signature and check if we've reached the requested threshold
+			signatureLock.Lock()
+			defer signatureLock.Unlock()
+
+			blsSignatures = append(blsSignatures, blsSignature)
+			bitSet.Add(i)
+			log.Info("Updated weight", "totalWeight", signatureWeight+signatureJob.weight, "addedWeight", signatureJob.weight)
+			signatureWeight += signatureJob.weight
+			// If the signature weight meets the requested threshold, cancel signature fetching
+			if err := avalancheWarp.VerifyWeight(signatureWeight, totalWeight, a.cancelQuorumNum, a.quorumDen); err == nil {
+				log.Info("Verify weight passed, exiting aggregation early", "cancelQuorumNum", a.cancelQuorumNum, "totalWeight", totalWeight, "signatureWeight", signatureWeight)
+				signatureFetchCancel()
+			}
+		}()
+	}
+	wg.Wait()
+
+	// If I failed to fetch sufficient signature stake, return an error
+	if err := avalancheWarp.VerifyWeight(signatureWeight, totalWeight, a.quorumNum, a.quorumDen); err != nil {
+		return nil, fmt.Errorf("failed to aggregate signature: %w", err)
+	}
+	// Otherwise, return the aggregate signature
+	aggregateSignature, err := bls.AggregateSignatures(blsSignatures)
+	if err != nil {
+		return nil, fmt.Errorf("failed to aggregate BLS signatures: %w", err)
+	}
+	warpSignature := &avalancheWarp.BitSetSignature{
+		Signers: bitSet.Bytes(),
+	}
+	copy(warpSignature.Signature[:], bls.SignatureToBytes(aggregateSignature))
+	msg, err := avalancheWarp.NewMessage(a.msg, warpSignature)
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct warp message: %w", err)
+	}
+	return &AggregateSignatureResult{
+		Message:         msg,
+		SignatureWeight: signatureWeight,
+		TotalWeight:     totalWeight,
+	}, nil
+}

--- a/warp/aggregator/aggregation_job.go
+++ b/warp/aggregator/aggregation_job.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
+// signatureAggregationJob fetches signatures for a single unsigned warp message.
 type signatureAggregationJob struct {
 	// SignatureBackend is assumed to be thread-safe and may be used by multiple signature aggregation jobs concurrently
 	client   SignatureBackend
@@ -40,7 +41,7 @@ type AggregateSignatureResult struct {
 	Message         *avalancheWarp.Message
 }
 
-func NewSignatureAggregationJob(
+func newSignatureAggregationJob(
 	client SignatureBackend,
 	height uint64,
 	subnetID ids.ID,

--- a/warp/aggregator/aggregation_job_test.go
+++ b/warp/aggregator/aggregation_job_test.go
@@ -46,7 +46,7 @@ func executeSignatureAggregationTest(t testing.TB, test signatureAggregationTest
 		&res.Message.UnsignedMessage,
 		test.job.state,
 		pChainHeight,
-		test.job.quorumNum,
+		test.job.minValidQuorumNum,
 		test.job.quorumDen,
 	))
 }

--- a/warp/aggregator/aggregation_job_test.go
+++ b/warp/aggregator/aggregation_job_test.go
@@ -53,7 +53,7 @@ func executeSignatureAggregationTest(t testing.TB, test signatureAggregationTest
 
 func TestSingleSignatureAggregator(t *testing.T) {
 	ctx := context.Background()
-	aggregationJob := NewSignatureAggregationJob(
+	aggregationJob := newSignatureAggregationJob(
 		&mockFetcher{
 			fetch: func(context.Context, ids.NodeID, *avalancheWarp.UnsignedMessage) (*bls.Signature, error) {
 				return blsSignatures[0], nil
@@ -100,7 +100,7 @@ func TestSingleSignatureAggregator(t *testing.T) {
 
 func TestAggregateAllSignatures(t *testing.T) {
 	ctx := context.Background()
-	aggregationJob := NewSignatureAggregationJob(
+	aggregationJob := newSignatureAggregationJob(
 		&mockFetcher{
 			fetch: func(_ context.Context, nodeID ids.NodeID, _ *avalancheWarp.UnsignedMessage) (*bls.Signature, error) {
 				for i, matchingNodeID := range nodeIDs {
@@ -156,7 +156,7 @@ func TestAggregateAllSignatures(t *testing.T) {
 
 func TestAggregateThresholdSignatures(t *testing.T) {
 	ctx := context.Background()
-	aggregationJob := NewSignatureAggregationJob(
+	aggregationJob := newSignatureAggregationJob(
 		&mockFetcher{
 			fetch: func(_ context.Context, nodeID ids.NodeID, _ *avalancheWarp.UnsignedMessage) (*bls.Signature, error) {
 				for i, matchingNodeID := range nodeIDs[:3] {
@@ -212,7 +212,7 @@ func TestAggregateThresholdSignatures(t *testing.T) {
 
 func TestAggregateThresholdSignaturesInsufficientWeight(t *testing.T) {
 	ctx := context.Background()
-	aggregationJob := NewSignatureAggregationJob(
+	aggregationJob := newSignatureAggregationJob(
 		&mockFetcher{
 			fetch: func(_ context.Context, nodeID ids.NodeID, _ *avalancheWarp.UnsignedMessage) (*bls.Signature, error) {
 				for i, matchingNodeID := range nodeIDs[:3] {
@@ -255,7 +255,7 @@ func TestAggregateThresholdSignaturesInsufficientWeight(t *testing.T) {
 
 func TestAggregateThresholdSignaturesBlockingRequests(t *testing.T) {
 	ctx := context.Background()
-	aggregationJob := NewSignatureAggregationJob(
+	aggregationJob := newSignatureAggregationJob(
 		&mockFetcher{
 			fetch: func(ctx context.Context, nodeID ids.NodeID, _ *avalancheWarp.UnsignedMessage) (*bls.Signature, error) {
 				for i, matchingNodeID := range nodeIDs[:3] {
@@ -315,7 +315,7 @@ func TestAggregateThresholdSignaturesBlockingRequests(t *testing.T) {
 func TestAggregateThresholdSignaturesParentCtxCancels(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	aggregationJob := NewSignatureAggregationJob(
+	aggregationJob := newSignatureAggregationJob(
 		&mockFetcher{
 			fetch: func(ctx context.Context, nodeID ids.NodeID, _ *avalancheWarp.UnsignedMessage) (*bls.Signature, error) {
 				// Block until the context is cancelled and return the error if not available

--- a/warp/aggregator/aggregation_job_test.go
+++ b/warp/aggregator/aggregation_job_test.go
@@ -1,0 +1,354 @@
+// (c) 2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package aggregator
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow/validators"
+	"github.com/ava-labs/avalanchego/utils/crypto/bls"
+	"github.com/ava-labs/avalanchego/utils/set"
+	avalancheWarp "github.com/ava-labs/avalanchego/vms/platformvm/warp"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	subnetID          = ids.GenerateTestID()
+	pChainHeight      = uint64(10)
+	getSubnetIDF      = func(ctx context.Context, chainID ids.ID) (ids.ID, error) { return subnetID, nil }
+	getCurrentHeightF = func(ctx context.Context) (uint64, error) { return pChainHeight, nil }
+)
+
+type signatureAggregationTest struct {
+	ctx         context.Context
+	job         *signatureAggregationJob
+	expectedRes *AggregateSignatureResult
+	expectedErr error
+}
+
+func executeSignatureAggregationTest(t testing.TB, test signatureAggregationTest) {
+	t.Helper()
+
+	res, err := test.job.Execute(test.ctx)
+	if test.expectedErr != nil {
+		require.ErrorIs(t, err, test.expectedErr)
+		return
+	}
+
+	require.Equal(t, res.SignatureWeight, test.expectedRes.SignatureWeight)
+	require.Equal(t, res.TotalWeight, test.expectedRes.TotalWeight)
+	require.NoError(t, res.Message.Signature.Verify(
+		context.Background(),
+		&res.Message.UnsignedMessage,
+		test.job.state,
+		pChainHeight,
+		test.job.quorumNum,
+		test.job.quorumDen,
+	))
+}
+
+func TestSingleSignatureAggregator(t *testing.T) {
+	ctx := context.Background()
+	aggregationJob := NewSignatureAggregationJob(
+		&mockFetcher{
+			fetch: func(context.Context, ids.NodeID, *avalancheWarp.UnsignedMessage) (*bls.Signature, error) {
+				return blsSignatures[0], nil
+			},
+		},
+		pChainHeight,
+		subnetID,
+		100,
+		100,
+		100,
+		&validators.TestState{
+			GetSubnetIDF:      getSubnetIDF,
+			GetCurrentHeightF: getCurrentHeightF,
+			GetValidatorSetF: func(ctx context.Context, height uint64, subnetID ids.ID) (map[ids.NodeID]*validators.GetValidatorOutput, error) {
+				return map[ids.NodeID]*validators.GetValidatorOutput{
+					nodeIDs[0]: {
+						NodeID:    nodeIDs[0],
+						PublicKey: blsPublicKeys[0],
+						Weight:    100,
+					},
+				}, nil
+			},
+		},
+		unsignedMsg,
+	)
+
+	signature := &avalancheWarp.BitSetSignature{
+		Signers: set.NewBits(0).Bytes(),
+	}
+	signedMessage, err := avalancheWarp.NewMessage(unsignedMsg, signature)
+	require.NoError(t, err)
+	copy(signature.Signature[:], bls.SignatureToBytes(blsSignatures[0]))
+	expectedRes := &AggregateSignatureResult{
+		SignatureWeight: 100,
+		TotalWeight:     100,
+		Message:         signedMessage,
+	}
+	executeSignatureAggregationTest(t, signatureAggregationTest{
+		ctx:         ctx,
+		job:         aggregationJob,
+		expectedRes: expectedRes,
+	})
+}
+
+func TestAggregateAllSignatures(t *testing.T) {
+	ctx := context.Background()
+	aggregationJob := NewSignatureAggregationJob(
+		&mockFetcher{
+			fetch: func(_ context.Context, nodeID ids.NodeID, _ *avalancheWarp.UnsignedMessage) (*bls.Signature, error) {
+				for i, matchingNodeID := range nodeIDs {
+					if matchingNodeID == nodeID {
+						return blsSignatures[i], nil
+					}
+				}
+				panic("request to unexpected nodeID")
+			},
+		},
+		pChainHeight,
+		subnetID,
+		100,
+		100,
+		100,
+		&validators.TestState{
+			GetSubnetIDF:      getSubnetIDF,
+			GetCurrentHeightF: getCurrentHeightF,
+			GetValidatorSetF: func(ctx context.Context, height uint64, subnetID ids.ID) (map[ids.NodeID]*validators.GetValidatorOutput, error) {
+				res := make(map[ids.NodeID]*validators.GetValidatorOutput)
+				for i := 0; i < 5; i++ {
+					res[nodeIDs[i]] = &validators.GetValidatorOutput{
+						NodeID:    nodeIDs[i],
+						PublicKey: blsPublicKeys[i],
+						Weight:    100,
+					}
+				}
+				return res, nil
+			},
+		},
+		unsignedMsg,
+	)
+
+	signature := &avalancheWarp.BitSetSignature{
+		Signers: set.NewBits(0, 1, 2, 3, 4).Bytes(),
+	}
+	signedMessage, err := avalancheWarp.NewMessage(unsignedMsg, signature)
+	require.NoError(t, err)
+	aggregateSignature, err := bls.AggregateSignatures(blsSignatures)
+	require.NoError(t, err)
+	copy(signature.Signature[:], bls.SignatureToBytes(aggregateSignature))
+	expectedRes := &AggregateSignatureResult{
+		SignatureWeight: 500,
+		TotalWeight:     500,
+		Message:         signedMessage,
+	}
+	executeSignatureAggregationTest(t, signatureAggregationTest{
+		ctx:         ctx,
+		job:         aggregationJob,
+		expectedRes: expectedRes,
+	})
+}
+
+func TestAggregateThresholdSignatures(t *testing.T) {
+	ctx := context.Background()
+	aggregationJob := NewSignatureAggregationJob(
+		&mockFetcher{
+			fetch: func(_ context.Context, nodeID ids.NodeID, _ *avalancheWarp.UnsignedMessage) (*bls.Signature, error) {
+				for i, matchingNodeID := range nodeIDs[:3] {
+					if matchingNodeID == nodeID {
+						return blsSignatures[i], nil
+					}
+				}
+				return nil, errors.New("what do we say to the god of death")
+			},
+		},
+		pChainHeight,
+		subnetID,
+		60,
+		60,
+		100,
+		&validators.TestState{
+			GetSubnetIDF:      getSubnetIDF,
+			GetCurrentHeightF: getCurrentHeightF,
+			GetValidatorSetF: func(ctx context.Context, height uint64, subnetID ids.ID) (map[ids.NodeID]*validators.GetValidatorOutput, error) {
+				res := make(map[ids.NodeID]*validators.GetValidatorOutput)
+				for i := 0; i < 5; i++ {
+					res[nodeIDs[i]] = &validators.GetValidatorOutput{
+						NodeID:    nodeIDs[i],
+						PublicKey: blsPublicKeys[i],
+						Weight:    100,
+					}
+				}
+				return res, nil
+			},
+		},
+		unsignedMsg,
+	)
+
+	signature := &avalancheWarp.BitSetSignature{
+		Signers: set.NewBits(0, 1, 2).Bytes(),
+	}
+	signedMessage, err := avalancheWarp.NewMessage(unsignedMsg, signature)
+	require.NoError(t, err)
+	aggregateSignature, err := bls.AggregateSignatures(blsSignatures)
+	require.NoError(t, err)
+	copy(signature.Signature[:], bls.SignatureToBytes(aggregateSignature))
+	expectedRes := &AggregateSignatureResult{
+		SignatureWeight: 300,
+		TotalWeight:     500,
+		Message:         signedMessage,
+	}
+	executeSignatureAggregationTest(t, signatureAggregationTest{
+		ctx:         ctx,
+		job:         aggregationJob,
+		expectedRes: expectedRes,
+	})
+}
+
+func TestAggregateThresholdSignaturesInsufficientWeight(t *testing.T) {
+	ctx := context.Background()
+	aggregationJob := NewSignatureAggregationJob(
+		&mockFetcher{
+			fetch: func(_ context.Context, nodeID ids.NodeID, _ *avalancheWarp.UnsignedMessage) (*bls.Signature, error) {
+				for i, matchingNodeID := range nodeIDs[:3] {
+					if matchingNodeID == nodeID {
+						return blsSignatures[i], nil
+					}
+				}
+				return nil, errors.New("what do we say to the god of death")
+			},
+		},
+		pChainHeight,
+		subnetID,
+		80,
+		80,
+		100,
+		&validators.TestState{
+			GetSubnetIDF:      getSubnetIDF,
+			GetCurrentHeightF: getCurrentHeightF,
+			GetValidatorSetF: func(ctx context.Context, height uint64, subnetID ids.ID) (map[ids.NodeID]*validators.GetValidatorOutput, error) {
+				res := make(map[ids.NodeID]*validators.GetValidatorOutput)
+				for i := 0; i < 5; i++ {
+					res[nodeIDs[i]] = &validators.GetValidatorOutput{
+						NodeID:    nodeIDs[i],
+						PublicKey: blsPublicKeys[i],
+						Weight:    100,
+					}
+				}
+				return res, nil
+			},
+		},
+		unsignedMsg,
+	)
+
+	executeSignatureAggregationTest(t, signatureAggregationTest{
+		ctx:         ctx,
+		job:         aggregationJob,
+		expectedErr: avalancheWarp.ErrInsufficientWeight,
+	})
+}
+
+func TestAggregateThresholdSignaturesBlockingRequests(t *testing.T) {
+	ctx := context.Background()
+	aggregationJob := NewSignatureAggregationJob(
+		&mockFetcher{
+			fetch: func(ctx context.Context, nodeID ids.NodeID, _ *avalancheWarp.UnsignedMessage) (*bls.Signature, error) {
+				for i, matchingNodeID := range nodeIDs[:3] {
+					if matchingNodeID == nodeID {
+						return blsSignatures[i], nil
+					}
+				}
+
+				// Block until the context is cancelled and return the error if not available
+				<-ctx.Done()
+				return nil, ctx.Err()
+			},
+		},
+		pChainHeight,
+		subnetID,
+		60,
+		60,
+		100,
+		&validators.TestState{
+			GetSubnetIDF:      getSubnetIDF,
+			GetCurrentHeightF: getCurrentHeightF,
+			GetValidatorSetF: func(ctx context.Context, height uint64, subnetID ids.ID) (map[ids.NodeID]*validators.GetValidatorOutput, error) {
+				res := make(map[ids.NodeID]*validators.GetValidatorOutput)
+				for i := 0; i < 5; i++ {
+					res[nodeIDs[i]] = &validators.GetValidatorOutput{
+						NodeID:    nodeIDs[i],
+						PublicKey: blsPublicKeys[i],
+						Weight:    100,
+					}
+				}
+				return res, nil
+			},
+		},
+		unsignedMsg,
+	)
+
+	signature := &avalancheWarp.BitSetSignature{
+		Signers: set.NewBits(0, 1, 2).Bytes(),
+	}
+	signedMessage, err := avalancheWarp.NewMessage(unsignedMsg, signature)
+	require.NoError(t, err)
+	aggregateSignature, err := bls.AggregateSignatures(blsSignatures)
+	require.NoError(t, err)
+	copy(signature.Signature[:], bls.SignatureToBytes(aggregateSignature))
+	expectedRes := &AggregateSignatureResult{
+		SignatureWeight: 300,
+		TotalWeight:     500,
+		Message:         signedMessage,
+	}
+	executeSignatureAggregationTest(t, signatureAggregationTest{
+		ctx:         ctx,
+		job:         aggregationJob,
+		expectedRes: expectedRes,
+	})
+}
+
+func TestAggregateThresholdSignaturesParentCtxCancels(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	aggregationJob := NewSignatureAggregationJob(
+		&mockFetcher{
+			fetch: func(ctx context.Context, nodeID ids.NodeID, _ *avalancheWarp.UnsignedMessage) (*bls.Signature, error) {
+				// Block until the context is cancelled and return the error if not available
+				<-ctx.Done()
+				return nil, ctx.Err()
+			},
+		},
+		pChainHeight,
+		subnetID,
+		60,
+		60,
+		100,
+		&validators.TestState{
+			GetSubnetIDF:      getSubnetIDF,
+			GetCurrentHeightF: getCurrentHeightF,
+			GetValidatorSetF: func(ctx context.Context, height uint64, subnetID ids.ID) (map[ids.NodeID]*validators.GetValidatorOutput, error) {
+				res := make(map[ids.NodeID]*validators.GetValidatorOutput)
+				for i := 0; i < 5; i++ {
+					res[nodeIDs[i]] = &validators.GetValidatorOutput{
+						NodeID:    nodeIDs[i],
+						PublicKey: blsPublicKeys[i],
+						Weight:    100,
+					}
+				}
+				return res, nil
+			},
+		},
+		unsignedMsg,
+	)
+
+	executeSignatureAggregationTest(t, signatureAggregationTest{
+		ctx:         ctx,
+		job:         aggregationJob,
+		expectedErr: avalancheWarp.ErrInsufficientWeight,
+	})
+}

--- a/warp/aggregator/aggregator.go
+++ b/warp/aggregator/aggregator.go
@@ -12,12 +12,14 @@ import (
 	"github.com/ava-labs/subnet-evm/params"
 )
 
+// Aggregator fulfills requests to aggregate signatures of a subnet's validator set for Avalanche Warp Messages.
 type Aggregator struct {
 	subnetID ids.ID
 	client   SignatureBackend
 	state    validators.State
 }
 
+// NewAggregator returns a signature aggregator, which will aggregate Warp Signatures for the given [
 func NewAggregator(subnetID ids.ID, state validators.State, client SignatureBackend) *Aggregator {
 	return &Aggregator{
 		subnetID: subnetID,
@@ -27,6 +29,9 @@ func NewAggregator(subnetID ids.ID, state validators.State, client SignatureBack
 }
 
 func (a *Aggregator) AggregateSignatures(ctx context.Context, unsignedMessage *avalancheWarp.UnsignedMessage, quorumNum uint64) (*AggregateSignatureResult, error) {
+	// Note: we use the current height as a best guess of the canonical validator set when the aggregated signature will be verified
+	// by the recipient chain. If the validator set changes from [pChainHeight] to the P-Chain height that is actually specified by the
+	// ProposerVM header when this message is verified, then the aggregate signature could become outdated and require re-aggregation.
 	pChainHeight, err := a.state.GetCurrentHeight(ctx)
 	if err != nil {
 		return nil, err

--- a/warp/aggregator/aggregator.go
+++ b/warp/aggregator/aggregator.go
@@ -1,0 +1,46 @@
+// (c) 2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package aggregator
+
+import (
+	"context"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow/validators"
+	avalancheWarp "github.com/ava-labs/avalanchego/vms/platformvm/warp"
+	"github.com/ava-labs/subnet-evm/params"
+)
+
+type Aggregator struct {
+	subnetID ids.ID
+	client   SignatureBackend
+	state    validators.State
+}
+
+func NewAggregator(subnetID ids.ID, state validators.State, client SignatureBackend) *Aggregator {
+	return &Aggregator{
+		subnetID: subnetID,
+		client:   client,
+		state:    state,
+	}
+}
+
+func (a *Aggregator) AggregateSignatures(ctx context.Context, unsignedMessage *avalancheWarp.UnsignedMessage, quorumNum uint64) (*AggregateSignatureResult, error) {
+	pChainHeight, err := a.state.GetCurrentHeight(ctx)
+	if err != nil {
+		return nil, err
+	}
+	job := NewSignatureAggregationJob(
+		a.client,
+		pChainHeight,
+		a.subnetID,
+		quorumNum,
+		quorumNum,
+		params.WarpQuorumDenominator,
+		a.state,
+		unsignedMessage,
+	)
+
+	return job.Execute(ctx)
+}

--- a/warp/aggregator/aggregator.go
+++ b/warp/aggregator/aggregator.go
@@ -36,7 +36,7 @@ func (a *Aggregator) AggregateSignatures(ctx context.Context, unsignedMessage *a
 	if err != nil {
 		return nil, err
 	}
-	job := NewSignatureAggregationJob(
+	job := newSignatureAggregationJob(
 		a.client,
 		pChainHeight,
 		a.subnetID,

--- a/warp/aggregator/network_signature_backend.go
+++ b/warp/aggregator/network_signature_backend.go
@@ -1,0 +1,64 @@
+// (c) 2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package aggregator
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/crypto/bls"
+	avalancheWarp "github.com/ava-labs/avalanchego/vms/platformvm/warp"
+	"github.com/ava-labs/subnet-evm/plugin/evm/message"
+)
+
+var _ SignatureBackend = (*NetworkSigner)(nil)
+
+type NetworkClient interface {
+	SendAppRequest(nodeID ids.NodeID, message []byte) ([]byte, error)
+}
+
+// networkSigner fetches warp signatures on behalf of the aggregator using VM App-Specific Messaging
+type NetworkSigner struct {
+	Client NetworkClient
+}
+
+// FetchWarpSignature attempts to fetch a BLS Signature of [unsignedWarpMessage] from [nodeID] until it succeeds or receives an invalid response
+//
+// Note: the caller should ensure that [ctx] is properly cancelled once the result is no longer needed from this call.
+func (s *NetworkSigner) FetchWarpSignature(ctx context.Context, nodeID ids.NodeID, unsignedWarpMessage *avalancheWarp.UnsignedMessage) (*bls.Signature, error) {
+	signatureReq := message.SignatureRequest{
+		MessageID: unsignedWarpMessage.ID(),
+	}
+	signatureReqBytes, err := message.RequestToBytes(message.Codec, signatureReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal signature request: %w", err)
+	}
+
+	delay := 100 * time.Millisecond
+	for ctx.Err() == nil {
+		signatureRes, err := s.Client.SendAppRequest(nodeID, signatureReqBytes)
+		// If the client fails to retrieve a response perform an exponential backoff.
+		// Note: it is up to the caller to ensure that [ctx] is eventually cancelled
+		if err != nil {
+			time.Sleep(delay)
+			delay *= 2
+			continue
+		}
+
+		var response message.SignatureResponse
+		if _, err := message.Codec.Unmarshal(signatureRes, &response); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal signature res: %w", err)
+		}
+
+		blsSignature, err := bls.SignatureFromBytes(response.Signature[:])
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse signature from res: %w", err)
+		}
+		return blsSignature, nil
+	}
+
+	return nil, fmt.Errorf("ctx expired fetching signature for message %s from %s: %w", unsignedWarpMessage.ID(), nodeID, ctx.Err())
+}

--- a/warp/aggregator/signature_job.go
+++ b/warp/aggregator/signature_job.go
@@ -1,0 +1,59 @@
+// (c) 2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package aggregator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/crypto/bls"
+	avalancheWarp "github.com/ava-labs/avalanchego/vms/platformvm/warp"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
+
+var errInvalidSignature = errors.New("invalid signature")
+
+// SignatureBackend defines the minimum network interface to perform signature aggregation
+type SignatureBackend interface {
+	// FetchWarpSignature attempts to fetch a BLS Signature from [nodeID] for [unsignedWarpMessage]
+	FetchWarpSignature(ctx context.Context, nodeID ids.NodeID, unsignedWarpMessage *avalancheWarp.UnsignedMessage) (*bls.Signature, error)
+}
+
+type signatureJob struct {
+	backend SignatureBackend
+	msg     *avalancheWarp.UnsignedMessage
+
+	nodeID    ids.NodeID
+	publicKey *bls.PublicKey
+	weight    uint64
+}
+
+func (s *signatureJob) String() string {
+	return fmt.Sprintf("(NodeID: %s, UnsignedMsgID: %s)", s.nodeID, s.msg.ID())
+}
+
+func newSignatureJob(backend SignatureBackend, validator *avalancheWarp.Validator, msg *avalancheWarp.UnsignedMessage) *signatureJob {
+	return &signatureJob{
+		backend:   backend,
+		msg:       msg,
+		nodeID:    validator.NodeIDs[0], // XXX: should we attempt to fetch from all nodeIDs and use the first valid response?
+		publicKey: validator.PublicKey,
+		weight:    validator.Weight,
+	}
+}
+
+// Execute attempts to fetch the signature from the nodeID specified in this job and then verifies and returns the signature
+func (s *signatureJob) Execute(ctx context.Context) (*bls.Signature, error) {
+	signature, err := s.backend.FetchWarpSignature(ctx, s.nodeID, s.msg)
+	if err != nil {
+		return nil, err
+	}
+
+	if !bls.Verify(s.publicKey, signature, s.msg.Bytes()) {
+		return nil, fmt.Errorf("%w: node %s returned invalid signature %s for msg %s", errInvalidSignature, s.nodeID, hexutil.Bytes(bls.SignatureToBytes(signature)), s.msg.ID())
+	}
+	return signature, nil
+}

--- a/warp/aggregator/signature_job.go
+++ b/warp/aggregator/signature_job.go
@@ -22,6 +22,7 @@ type SignatureBackend interface {
 	FetchWarpSignature(ctx context.Context, nodeID ids.NodeID, unsignedWarpMessage *avalancheWarp.UnsignedMessage) (*bls.Signature, error)
 }
 
+// signatureJob fetches a single signature using the injected dependency SignatureBackend and returns a verified signature of the requested message.
 type signatureJob struct {
 	backend SignatureBackend
 	msg     *avalancheWarp.UnsignedMessage
@@ -39,7 +40,7 @@ func newSignatureJob(backend SignatureBackend, validator *avalancheWarp.Validato
 	return &signatureJob{
 		backend:   backend,
 		msg:       msg,
-		nodeID:    validator.NodeIDs[0], // XXX: should we attempt to fetch from all nodeIDs and use the first valid response?
+		nodeID:    validator.NodeIDs[0], // TODO: update from a single nodeID to the original slice and use extra nodeIDs as backup.
 		publicKey: validator.PublicKey,
 		weight:    validator.Weight,
 	}

--- a/warp/aggregator/signature_job_test.go
+++ b/warp/aggregator/signature_job_test.go
@@ -1,0 +1,138 @@
+// (c) 2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package aggregator
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/crypto/bls"
+	avalancheWarp "github.com/ava-labs/avalanchego/vms/platformvm/warp"
+	"github.com/stretchr/testify/require"
+)
+
+type mockFetcher struct {
+	fetch func(ctx context.Context, nodeID ids.NodeID, unsignedWarpMessage *avalancheWarp.UnsignedMessage) (*bls.Signature, error)
+}
+
+func (m *mockFetcher) FetchWarpSignature(ctx context.Context, nodeID ids.NodeID, unsignedWarpMessage *avalancheWarp.UnsignedMessage) (*bls.Signature, error) {
+	return m.fetch(ctx, nodeID, unsignedWarpMessage)
+}
+
+var (
+	nodeIDs       []ids.NodeID
+	blsSecretKeys []*bls.SecretKey
+	blsPublicKeys []*bls.PublicKey
+	unsignedMsg   *avalancheWarp.UnsignedMessage
+	blsSignatures []*bls.Signature
+)
+
+func init() {
+	var err error
+	unsignedMsg, err = avalancheWarp.NewUnsignedMessage(ids.GenerateTestID(), ids.GenerateTestID(), []byte{1, 2, 3})
+	if err != nil {
+		panic(err)
+	}
+	for i := 0; i < 5; i++ {
+		nodeIDs = append(nodeIDs, ids.GenerateTestNodeID())
+
+		blsSecretKey, err := bls.NewSecretKey()
+		if err != nil {
+			panic(err)
+		}
+		blsPublicKey := bls.PublicFromSecretKey(blsSecretKey)
+		blsSignature := bls.Sign(blsSecretKey, unsignedMsg.Bytes())
+		blsSecretKeys = append(blsSecretKeys, blsSecretKey)
+		blsPublicKeys = append(blsPublicKeys, blsPublicKey)
+		blsSignatures = append(blsSignatures, blsSignature)
+	}
+}
+
+type signatureJobTest struct {
+	ctx               context.Context
+	job               *signatureJob
+	expectedSignature *bls.Signature
+	expectedErr       error
+}
+
+func executeSignatureJobTest(t testing.TB, test signatureJobTest) {
+	t.Helper()
+
+	blsSignature, err := test.job.Execute(test.ctx)
+	if test.expectedErr != nil {
+		require.ErrorIs(t, err, test.expectedErr)
+		return
+	}
+	require.NoError(t, err)
+	require.Equal(t, bls.SignatureToBytes(blsSignature), bls.SignatureToBytes(test.expectedSignature))
+}
+
+func TestSignatureRequestSuccess(t *testing.T) {
+	job := newSignatureJob(
+		&mockFetcher{
+			fetch: func(context.Context, ids.NodeID, *avalancheWarp.UnsignedMessage) (*bls.Signature, error) {
+				return blsSignatures[0], nil
+			},
+		},
+		&avalancheWarp.Validator{
+			NodeIDs:   nodeIDs[:1],
+			PublicKey: blsPublicKeys[0],
+			Weight:    10,
+		},
+		unsignedMsg,
+	)
+
+	executeSignatureJobTest(t, signatureJobTest{
+		ctx:               context.Background(),
+		job:               job,
+		expectedSignature: blsSignatures[0],
+	})
+}
+
+func TestSignatureRequestFails(t *testing.T) {
+	err := errors.New("expected error")
+	job := newSignatureJob(
+		&mockFetcher{
+			fetch: func(context.Context, ids.NodeID, *avalancheWarp.UnsignedMessage) (*bls.Signature, error) {
+				return nil, err
+			},
+		},
+		&avalancheWarp.Validator{
+			NodeIDs:   nodeIDs[:1],
+			PublicKey: blsPublicKeys[0],
+			Weight:    10,
+		},
+		unsignedMsg,
+	)
+
+	executeSignatureJobTest(t, signatureJobTest{
+		ctx:         context.Background(),
+		job:         job,
+		expectedErr: err,
+	})
+}
+
+func TestSignatureRequestInvalidSignature(t *testing.T) {
+	job := newSignatureJob(
+		&mockFetcher{
+			fetch: func(context.Context, ids.NodeID, *avalancheWarp.UnsignedMessage) (*bls.Signature, error) {
+				return blsSignatures[1], nil
+			},
+		},
+		&avalancheWarp.Validator{
+			NodeIDs:   nodeIDs[:1],
+			PublicKey: blsPublicKeys[0],
+			Weight:    10,
+		},
+		unsignedMsg,
+	)
+
+	executeSignatureJobTest(t, signatureJobTest{
+		ctx:         context.Background(),
+		job:         job,
+		expectedErr: errInvalidSignature,
+	})
+}

--- a/warp/backend.go
+++ b/warp/backend.go
@@ -11,8 +11,8 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
-	"github.com/ava-labs/avalanchego/utils/hashing"
 	avalancheWarp "github.com/ava-labs/avalanchego/vms/platformvm/warp"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 var _ WarpBackend = &warpBackend{}
@@ -25,6 +25,8 @@ type WarpBackend interface {
 
 	// GetSignature returns the signature of the requested message hash.
 	GetSignature(messageHash ids.ID) ([bls.SignatureLen]byte, error)
+	// GetMessage retrieves the [unsignedMessage] from the warp backend database if available
+	GetMessage(messageHash ids.ID) (*avalancheWarp.UnsignedMessage, error)
 }
 
 // warpBackend implements WarpBackend, keeps track of warp messages, and generates message signatures.
@@ -32,19 +34,21 @@ type warpBackend struct {
 	db             database.Database
 	snowCtx        *snow.Context
 	signatureCache *cache.LRU[ids.ID, [bls.SignatureLen]byte]
+	messageCache   *cache.LRU[ids.ID, *avalancheWarp.UnsignedMessage]
 }
 
 // NewWarpBackend creates a new WarpBackend, and initializes the signature cache and message tracking database.
-func NewWarpBackend(snowCtx *snow.Context, db database.Database, signatureCacheSize int) WarpBackend {
+func NewWarpBackend(snowCtx *snow.Context, db database.Database, cacheSize int) WarpBackend {
 	return &warpBackend{
 		db:             db,
 		snowCtx:        snowCtx,
-		signatureCache: &cache.LRU[ids.ID, [bls.SignatureLen]byte]{Size: signatureCacheSize},
+		signatureCache: &cache.LRU[ids.ID, [bls.SignatureLen]byte]{Size: cacheSize},
+		messageCache:   &cache.LRU[ids.ID, *avalancheWarp.UnsignedMessage]{Size: cacheSize},
 	}
 }
 
 func (w *warpBackend) AddMessage(unsignedMessage *avalancheWarp.UnsignedMessage) error {
-	messageID := hashing.ComputeHash256Array(unsignedMessage.Bytes())
+	messageID := unsignedMessage.ID()
 
 	// In the case when a node restarts, and possibly changes its bls key, the cache gets emptied but the database does not.
 	// So to avoid having incorrect signatures saved in the database after a bls key change, we save the full message in the database.
@@ -61,22 +65,19 @@ func (w *warpBackend) AddMessage(unsignedMessage *avalancheWarp.UnsignedMessage)
 
 	copy(signature[:], sig)
 	w.signatureCache.Put(messageID, signature)
+	log.Debug("Adding warp message to backend", "messageID", messageID)
 	return nil
 }
 
 func (w *warpBackend) GetSignature(messageID ids.ID) ([bls.SignatureLen]byte, error) {
+	log.Debug("Getting warp message from backend", "messageID", messageID)
 	if sig, ok := w.signatureCache.Get(messageID); ok {
 		return sig, nil
 	}
 
-	unsignedMessageBytes, err := w.db.Get(messageID[:])
+	unsignedMessage, err := w.GetMessage(messageID)
 	if err != nil {
 		return [bls.SignatureLen]byte{}, fmt.Errorf("failed to get warp message %s from db: %w", messageID.String(), err)
-	}
-
-	unsignedMessage, err := avalancheWarp.ParseUnsignedMessage(unsignedMessageBytes)
-	if err != nil {
-		return [bls.SignatureLen]byte{}, fmt.Errorf("failed to parse unsigned message %s: %w", messageID.String(), err)
 	}
 
 	var signature [bls.SignatureLen]byte
@@ -88,4 +89,23 @@ func (w *warpBackend) GetSignature(messageID ids.ID) ([bls.SignatureLen]byte, er
 	copy(signature[:], sig)
 	w.signatureCache.Put(messageID, signature)
 	return signature, nil
+}
+
+func (w *warpBackend) GetMessage(messageID ids.ID) (*avalancheWarp.UnsignedMessage, error) {
+	if message, ok := w.messageCache.Get(messageID); ok {
+		return message, nil
+	}
+
+	unsignedMessageBytes, err := w.db.Get(messageID[:])
+	if err != nil {
+		return nil, fmt.Errorf("failed to get warp message %s from db: %w", messageID.String(), err)
+	}
+
+	unsignedMessage, err := avalancheWarp.ParseUnsignedMessage(unsignedMessageBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse unsigned message %s: %w", messageID.String(), err)
+	}
+	w.messageCache.Put(messageID, unsignedMessage)
+
+	return unsignedMessage, nil
 }

--- a/warp/backend_test.go
+++ b/warp/backend_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
+	"github.com/ava-labs/avalanchego/utils/hashing"
 	avalancheWarp "github.com/ava-labs/avalanchego/vms/platformvm/warp"
 	"github.com/stretchr/testify/require"
 )

--- a/warp/backend_test.go
+++ b/warp/backend_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
-	"github.com/ava-labs/avalanchego/utils/hashing"
 	avalancheWarp "github.com/ava-labs/avalanchego/vms/platformvm/warp"
 	"github.com/stretchr/testify/require"
 )
@@ -37,7 +36,7 @@ func TestAddAndGetValidMessage(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify that a signature is returned successfully, and compare to expected signature.
-	messageID := hashing.ComputeHash256Array(unsignedMsg.Bytes())
+	messageID := unsignedMsg.ID()
 	signature, err := backend.GetSignature(messageID)
 	require.NoError(t, err)
 
@@ -54,7 +53,7 @@ func TestAddAndGetUnknownMessage(t *testing.T) {
 	require.NoError(t, err)
 
 	// Try getting a signature for a message that was not added.
-	messageID := hashing.ComputeHash256Array(unsignedMsg.Bytes())
+	messageID := unsignedMsg.ID()
 	_, err = backend.GetSignature(messageID)
 	require.Error(t, err)
 }
@@ -77,7 +76,7 @@ func TestZeroSizedCache(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify that a signature is returned successfully, and compare to expected signature.
-	messageID := hashing.ComputeHash256Array(unsignedMsg.Bytes())
+	messageID := unsignedMsg.ID()
 	signature, err := backend.GetSignature(messageID)
 	require.NoError(t, err)
 

--- a/warp/handlers/signature_request_test.go
+++ b/warp/handlers/signature_request_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
-	"github.com/ava-labs/avalanchego/utils/hashing"
 	avalancheWarp "github.com/ava-labs/avalanchego/vms/platformvm/warp"
 	"github.com/ava-labs/subnet-evm/plugin/evm/message"
 	"github.com/ava-labs/subnet-evm/warp"
@@ -32,12 +31,13 @@ func TestSignatureHandler(t *testing.T) {
 	msg, err := avalancheWarp.NewUnsignedMessage(snowCtx.ChainID, snowCtx.CChainID, []byte("test"))
 	require.NoError(t, err)
 
-	messageID := hashing.ComputeHash256Array(msg.Bytes())
+	messageID := msg.ID()
 	require.NoError(t, warpBackend.AddMessage(msg))
 	signature, err := warpBackend.GetSignature(messageID)
 	require.NoError(t, err)
 	unknownMessageID := ids.GenerateTestID()
 
+	emptySignature := [bls.SignatureLen]byte{}
 	mockHandlerStats := &stats.MockSignatureRequestHandlerStats{}
 	signatureRequestHandler := NewSignatureRequestHandler(warpBackend, message.Codec, mockHandlerStats)
 
@@ -62,7 +62,7 @@ func TestSignatureHandler(t *testing.T) {
 			setup: func() (request message.SignatureRequest, expectedResponse []byte) {
 				return message.SignatureRequest{
 					MessageID: unknownMessageID,
-				}, nil
+				}, emptySignature[:]
 			},
 			verifyStats: func(t *testing.T, stats *stats.MockSignatureRequestHandlerStats) {
 				require.EqualValues(t, 1, mockHandlerStats.SignatureRequestCount)

--- a/warp/handlers/stats/stats.go
+++ b/warp/handlers/stats/stats.go
@@ -30,11 +30,7 @@ type handlerStats struct {
 	signatureProcessingTime metrics.Timer
 }
 
-func NewStats(enabled bool) SignatureRequestHandlerStats {
-	if !enabled {
-		return &MockSignatureRequestHandlerStats{}
-	}
-
+func NewStats() SignatureRequestHandlerStats {
 	return &handlerStats{
 		signatureRequest:        metrics.GetOrRegisterCounter("signature_request_count", nil),
 		signatureHit:            metrics.GetOrRegisterCounter("signature_request_hit", nil),

--- a/warp/warp_client.go
+++ b/warp/warp_client.go
@@ -16,6 +16,7 @@ var _ WarpClient = (*warpClient)(nil)
 
 type WarpClient interface {
 	GetSignature(ctx context.Context, messageID ids.ID) ([]byte, error)
+	GetAggregateSignature(ctx context.Context, messageID ids.ID, quorumNum uint64) ([]byte, error)
 }
 
 // warpClient implementation for interacting with EVM [chain]
@@ -40,6 +41,16 @@ func (c *warpClient) GetSignature(ctx context.Context, messageID ids.ID) ([]byte
 	err := c.client.CallContext(ctx, &res, "warp_getSignature", messageID)
 	if err != nil {
 		return nil, fmt.Errorf("call to warp_getSignature failed. err: %w", err)
+	}
+	return res, err
+}
+
+// GetAggregateSignature requests the aggregate signature associated with messageID
+func (c *warpClient) GetAggregateSignature(ctx context.Context, messageID ids.ID, quorumNum uint64) ([]byte, error) {
+	var res hexutil.Bytes
+	err := c.client.CallContext(ctx, &res, "warp_getAggregateSignature", messageID, quorumNum)
+	if err != nil {
+		return nil, fmt.Errorf("call to warp_getAggregateSignature failed. err: %w", err)
 	}
 	return res, err
 }

--- a/warp/warp_client_fetcher.go
+++ b/warp/warp_client_fetcher.go
@@ -22,7 +22,7 @@ func NewWarpAPIFetcher(clients map[ids.NodeID]WarpClient) *warpAPIFetcher {
 	}
 }
 
-func (f warpAPIFetcher) FetchWarpSignature(ctx context.Context, nodeID ids.NodeID, unsignedWarpMessage *avalancheWarp.UnsignedMessage) (*bls.Signature, error) {
+func (f *warpAPIFetcher) FetchWarpSignature(ctx context.Context, nodeID ids.NodeID, unsignedWarpMessage *avalancheWarp.UnsignedMessage) (*bls.Signature, error) {
 	client, ok := f.clients[nodeID]
 	if !ok {
 		return nil, fmt.Errorf("no warp client for nodeID: %s", nodeID)

--- a/warp/warp_client_fetcher.go
+++ b/warp/warp_client_fetcher.go
@@ -1,0 +1,41 @@
+// (c) 2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package warp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/crypto/bls"
+	avalancheWarp "github.com/ava-labs/avalanchego/vms/platformvm/warp"
+)
+
+type warpAPIFetcher struct {
+	clients map[ids.NodeID]WarpClient
+}
+
+func NewWarpAPIFetcher(clients map[ids.NodeID]WarpClient) *warpAPIFetcher {
+	return &warpAPIFetcher{
+		clients: clients,
+	}
+}
+
+func (f warpAPIFetcher) FetchWarpSignature(ctx context.Context, nodeID ids.NodeID, unsignedWarpMessage *avalancheWarp.UnsignedMessage) (*bls.Signature, error) {
+	client, ok := f.clients[nodeID]
+	if !ok {
+		return nil, fmt.Errorf("no warp client for nodeID: %s", nodeID)
+	}
+
+	signatureBytes, err := client.GetSignature(ctx, unsignedWarpMessage.ID())
+	if err != nil {
+		return nil, err
+	}
+
+	signature, err := bls.SignatureFromBytes(signatureBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse signature from client %s: %w", nodeID, err)
+	}
+	return signature, nil
+}

--- a/warp/warp_service.go
+++ b/warp/warp_service.go
@@ -5,15 +5,12 @@ package warp
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/subnet-evm/warp/aggregator"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
-
-var errNoAggregator = errors.New("no aggregator to fetch signatures")
 
 // WarpAPI introduces snowman specific functionality to the evm
 type WarpAPI struct {
@@ -39,10 +36,6 @@ func (api *WarpAPI) GetSignature(ctx context.Context, messageID ids.ID) (hexutil
 
 // GetAggregateSignature fetches the aggregate signature for the requested [messageID]
 func (api *WarpAPI) GetAggregateSignature(ctx context.Context, messageID ids.ID, quorumNum uint64) (signedMessageBytes hexutil.Bytes, err error) {
-	// TODO: remove when updating vm.go so that the aggregator is always present
-	if api.aggregator == nil {
-		return nil, errNoAggregator
-	}
 	unsignedMessage, err := api.backend.GetMessage(messageID)
 	if err != nil {
 		return nil, err

--- a/warp/warp_service.go
+++ b/warp/warp_service.go
@@ -5,22 +5,55 @@ package warp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/subnet-evm/warp/aggregator"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
+var errNoAggregator = errors.New("no aggregator to fetch signatures")
+
 // WarpAPI introduces snowman specific functionality to the evm
 type WarpAPI struct {
-	Backend WarpBackend
+	backend    WarpBackend
+	aggregator *aggregator.Aggregator
+}
+
+func NewWarpAPI(backend WarpBackend, aggregator *aggregator.Aggregator) *WarpAPI {
+	return &WarpAPI{
+		backend:    backend,
+		aggregator: aggregator,
+	}
 }
 
 // GetSignature returns the BLS signature associated with a messageID.
 func (api *WarpAPI) GetSignature(ctx context.Context, messageID ids.ID) (hexutil.Bytes, error) {
-	signature, err := api.Backend.GetSignature(messageID)
+	signature, err := api.backend.GetSignature(messageID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get signature for with error %w", err)
 	}
 	return signature[:], nil
+}
+
+// GetAggregateSignature fetches the aggregate signature for the requested [messageID]
+func (api *WarpAPI) GetAggregateSignature(ctx context.Context, messageID ids.ID, quorumNum uint64) (signedMessageBytes hexutil.Bytes, err error) {
+	// TODO: remove when updating vm.go so that the aggregator is always present
+	if api.aggregator == nil {
+		return nil, errNoAggregator
+	}
+	unsignedMessage, err := api.backend.GetMessage(messageID)
+	if err != nil {
+		return nil, err
+	}
+
+	signatureResult, err := api.aggregator.AggregateSignatures(ctx, unsignedMessage, quorumNum)
+	if err != nil {
+		return nil, err
+	}
+	// TODO: return the signature and total weight as well to the caller for more complete details
+	// Need to decide on the best UI for this and write up documentation with the potential
+	// gotchas that could impact signed messages becoming invalid.
+	return hexutil.Bytes(signatureResult.Message.Bytes()), nil
 }


### PR DESCRIPTION
## Why this should be merged

This PR adds helpers to aggregate warp signatures using the network client and exposes an API endpoint, so that a client does not need to create its own network connection to request signature aggregation.

## How this works

This creates a backend interface for fetching signatures that can use either an API or the network client to fetch warp signatures, a signature job to attempt requesting a signature, and an aggregator, which creates goroutines to fetch each signature and cancels ongoing jobs once a sufficient amount of stake's signatures have been acquired.

## How this was tested

unit tests

## How is this documented

na