### PR TITLE
Ginkgo tests parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "18.x"
+          node-version: "18.15"
       - name: NPM Clean Install
         run: npm ci
         working-directory: ./contracts

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -28,7 +28,7 @@
   },
   "license": "BSD-3-Clause",
   "scripts": {
-    "build": "rm -rf dist/ && tsc -b",
+    "build": "rm -rf dist/ && tsc -b && npx hardhat compile --network local",
     "compile": "npx hardhat compile",
     "console": "npx hardhat console",
     "test": "npx hardhat test",
@@ -41,6 +41,6 @@
   },
   "engines": {
     "npm": ">6.0.0",
-    "node": ">=18.16.0"
+    "node": ">=18.15.0"
   }
 }

--- a/scripts/run_ginkgo.sh
+++ b/scripts/run_ginkgo.sh
@@ -20,12 +20,14 @@ echo "building precompile.test"
 # to install the ginkgo binary (required for test build and run)
 go install -v github.com/onsi/ginkgo/v2/ginkgo@${GINKGO_VERSION}
 
-ACK_GINKGO_RC=true ginkgo build ./tests/precompile ./tests/load
+TEST_SOURCE_ROOT=$(pwd)
+
+ACK_GINKGO_RC=true ginkgo build ./tests/load
 
 # By default, it runs all e2e test cases!
 # Use "--ginkgo.skip" to skip tests.
 # Use "--ginkgo.focus" to select tests.
-./tests/precompile/precompile.test \
+TEST_SOURCE_ROOT="$TEST_SOURCE_ROOT" ginkgo run -procs=5 tests/precompile \
   --ginkgo.vv \
   --ginkgo.label-filter=${GINKGO_LABEL_FILTER:-""}
 

--- a/tests/precompile/precompile_test.go
+++ b/tests/precompile/precompile_test.go
@@ -4,6 +4,7 @@
 package precompile
 
 import (
+	"os"
 	"testing"
 
 	ginkgo "github.com/onsi/ginkgo/v2"
@@ -19,6 +20,9 @@ func init() {
 }
 
 func TestE2E(t *testing.T) {
+	if basePath := os.Getenv("TEST_SOURCE_ROOT"); basePath != "" {
+		os.Chdir(basePath)
+	}
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	ginkgo.RunSpecs(t, "subnet-evm precompile ginkgo test suite")
 }

--- a/tests/precompile/solidity/suites.go
+++ b/tests/precompile/solidity/suites.go
@@ -12,7 +12,7 @@ import (
 	ginkgo "github.com/onsi/ginkgo/v2"
 )
 
-var _ = ginkgo.Describe("[Precompiles]", ginkgo.Ordered, func() {
+var _ = ginkgo.Describe("[Precompiles]", func() {
 	// Register the ping test first
 	utils.RegisterPingTest()
 
@@ -22,35 +22,35 @@ var _ = ginkgo.Describe("[Precompiles]", ginkgo.Ordered, func() {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 		defer cancel()
 
-		utils.RunDefaultHardhatTests(ctx, "contract_native_minter")
+		utils.RunDefaultHardhatTests(ctx, utils.BlockchainIDs["contract_native_minter"], "contract_native_minter")
 	})
 
 	ginkgo.It("tx allow list", ginkgo.Label("Precompile"), ginkgo.Label("TxAllowList"), func() {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 		defer cancel()
 
-		utils.RunDefaultHardhatTests(ctx, "tx_allow_list")
+		utils.RunDefaultHardhatTests(ctx, utils.BlockchainIDs["tx_allow_list"], "tx_allow_list")
 	})
 
 	ginkgo.It("contract deployer allow list", ginkgo.Label("Precompile"), ginkgo.Label("ContractDeployerAllowList"), func() {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 		defer cancel()
 
-		utils.RunDefaultHardhatTests(ctx, "contract_deployer_allow_list")
+		utils.RunDefaultHardhatTests(ctx, utils.BlockchainIDs["contract_deployer_allow_list"], "contract_deployer_allow_list")
 	})
 
 	ginkgo.It("fee manager", ginkgo.Label("Precompile"), ginkgo.Label("FeeManager"), func() {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 		defer cancel()
 
-		utils.RunDefaultHardhatTests(ctx, "fee_manager")
+		utils.RunDefaultHardhatTests(ctx, utils.BlockchainIDs["fee_manager"], "fee_manager")
 	})
 
 	ginkgo.It("reward manager", ginkgo.Label("Precompile"), ginkgo.Label("RewardManager"), func() {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 		defer cancel()
 
-		utils.RunDefaultHardhatTests(ctx, "reward_manager")
+		utils.RunDefaultHardhatTests(ctx, utils.BlockchainIDs["reward_manager"], "reward_manager")
 	})
 
 	// and then runs the hardhat tests for each one without forcing precompile developers to modify this file.

--- a/tests/utils/command.go
+++ b/tests/utils/command.go
@@ -5,8 +5,10 @@ package utils
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -58,13 +60,36 @@ func RegisterPingTest() {
 	})
 }
 
-// RegisterNodeRun registers a before suite that starts an AvalancheGo process to use for the e2e tests
-// and an after suite that stops the AvalancheGo process
+// At boot time subnets are created, one for each test suite. This global
+// variable has all the subnets IDs that can be used.
+//
+// One process creates the AvalancheGo node and all the subnets, and these
+// subnets IDs are passed to all other processes and stored in this global
+// variable
+var BlockchainIDs map[string]string
+
+// Timeout to boot the AvalancheGo node
+var bootAvalancheNodeTimeout = 5 * time.Minute
+
+// Timeout for the health API to check the AvalancheGo is ready
+var healthCheckTimeout = 5 * time.Second
+
 func RegisterNodeRun() {
-	// BeforeSuite starts an AvalancheGo process to use for the e2e tests
+	// Keep track of the AvalancheGo external bash script, it is null for most
+	// processes except the first process that starts AvalancheGo
 	var startCmd *cmd.Cmd
-	_ = ginkgo.BeforeSuite(func() {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+
+	// Our test suite runs in a separated processes, ginkgo hasI
+	// SynchronizedBeforeSuite() which is promised to run once, and its output is
+	// passed over to each worker.
+	//
+	// In here an AvalancheGo node instance is started, and subnets are created for
+	// each test case. Each test case has its own subnet, therefore all tests can
+	// run in parallel without any issue.
+	//
+	// This function also compiles all the solidity contracts
+	var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
+		ctx, cancel := context.WithTimeout(context.Background(), bootAvalancheNodeTimeout)
 		defer cancel()
 
 		wd, err := os.Getwd()
@@ -76,16 +101,34 @@ func RegisterNodeRun() {
 
 		// Assumes that startCmd will launch a node with HTTP Port at [utils.DefaultLocalNodeURI]
 		healthClient := health.NewClient(DefaultLocalNodeURI)
-		healthy, err := health.AwaitReady(ctx, healthClient, 5*time.Second, nil)
+		healthy, err := health.AwaitReady(ctx, healthClient, healthCheckTimeout, nil)
 		gomega.Expect(err).Should(gomega.BeNil())
 		gomega.Expect(healthy).Should(gomega.BeTrue())
 		log.Info("AvalancheGo node is healthy")
+
+		blockchainIds := make(map[string]string)
+		files, err := filepath.Glob("./tests/precompile/genesis/*.json")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		for _, file := range files {
+			basename := filepath.Base(file)
+			index := basename[:len(basename)-5]
+			blockchainIds[index] = CreateNewSubnet(ctx, file)
+		}
+
+		blockchainIDsBytes, err := json.Marshal(blockchainIds)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		return blockchainIDsBytes
+	}, func(data []byte) {
+		err := json.Unmarshal(data, &BlockchainIDs)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
-	ginkgo.AfterSuite(func() {
+	// SynchronizedAfterSuite() takes two functions, the first runs after each test suite is done and the second
+	// function is executed once when all the tests are done. This function is used
+	// to gracefully shutdown the AvalancheGo node.
+	var _ = ginkgo.SynchronizedAfterSuite(func() {}, func() {
 		gomega.Expect(startCmd).ShouldNot(gomega.BeNil())
 		gomega.Expect(startCmd.Stop()).Should(gomega.BeNil())
-		// TODO add a new node to bootstrap off of the existing node and ensure it can bootstrap all subnets
-		// created during the test
 	})
 }

--- a/tests/utils/subnet.go
+++ b/tests/utils/subnet.go
@@ -104,20 +104,15 @@ func GetDefaultChainURI(blockchainID string) string {
 	return fmt.Sprintf("%s/ext/bc/%s/rpc", DefaultLocalNodeURI, blockchainID)
 }
 
-// RunDefaultHardhatTests runs the hardhat tests on a new blockchain
+// RunDefaultHardhatTests runs the hardhat tests on a given blockchain ID
 // with default parameters. Default parameters are:
-// 1. Genesis file is located at ./tests/precompile/genesis/<test>.json
-// 2. Hardhat contract environment is located at ./contracts
-// 3. Hardhat test file is located at ./contracts/test/<test>.ts
-// 4. npx is available in the ./contracts directory
-func RunDefaultHardhatTests(ctx context.Context, test string) {
-	log.Info("Executing HardHat tests on a new blockchain", "test", test)
-
-	genesisFilePath := fmt.Sprintf("./tests/precompile/genesis/%s.json", test)
-
-	blockchainID := CreateNewSubnet(ctx, genesisFilePath)
+// 1. Hardhat contract environment is located at ./contracts
+// 2. Hardhat test file is located at ./contracts/test/<test>.ts
+// 3. npx is available in the ./contracts directory
+func RunDefaultHardhatTests(ctx context.Context, blockchainID string, test string) {
 	chainURI := GetDefaultChainURI(blockchainID)
-	log.Info("Created subnet successfully", "ChainURI", chainURI)
+	log.Info("Executing HardHat tests on a new blockchain", "blockchainID", blockchainID, "test", test)
+	log.Info("Using subnet", "ChainURI", chainURI)
 
 	cmdPath := "./contracts"
 	// test path is relative to the cmd path


### PR DESCRIPTION
## Why this should be merged

This PR runs all the Ginkgo tests in parallel, making the whole testing time twice as fast.

## How this works

Ginkgo support running tests in parallel. This PR introduces a synchronized way to start an Avalanche Go node once, and setup one subnet for each tests to be run, and share those subnets IDs with the other processes.

## How this was tested

We should have a green pipeline.

## How is this documented
