### PR TITLE
Fix BlockContext comment

### DIFF
--- a/precompile/contract/interfaces.go
+++ b/precompile/contract/interfaces.go
@@ -63,9 +63,8 @@ type AccessibleState interface {
 	CallFromPrecompile(caller common.Address, addr common.Address, input []byte, gas uint64, value *big.Int) (ret []byte, leftOverGas uint64, err error)
 }
 
-// BlockContext defines an interface that provides information to a stateful precompile
-// about the block that activates the upgrade. The precompile can access this information
-// to initialize its state.
+// BlockContext defines an interface that provides information to a stateful precompile about the
+// current block. The BlockContext may be provided during both precompile activation and execution.
 type BlockContext interface {
 	Number() *big.Int
 	Timestamp() *big.Int


### PR DESCRIPTION
## Why this should be merged
The current comment suggest that the BlockContext supplied to the precompile during execution is the block context during the activation of the precompile upgrade. This is not the case. 

## How this works
Change comment to account both for execution and upgrade.

## How this was tested
No test necessary, since only a comment.
