### PR TITLE
Fix precompile test gen template

### DIFF
--- a/accounts/abi/bind/precompilebind/precompile_contract_test_template.go
+++ b/accounts/abi/bind/precompilebind/precompile_contract_test_template.go
@@ -155,7 +155,7 @@ func Benchmark{{.Contract.Type}}(b *testing.B) {
 	// Benchmark tests.
 	for name, test := range tests {
 		b.Run(name, func(b *testing.B) {
-			test.Bench(b, Module, state.NewStateDB(b))
+			test.Bench(b, Module, state.NewTestStateDB(b))
 		})
 	}
 	{{- end}}


### PR DESCRIPTION
## Why this should be merged

This pull requests fixes the following bugs regarding the function Benchmark in `precompile_contract_test_template.go` : 

- We capitalize `module` (an undefined variable) so that we can pass in the variable `Module` defined in `module.go` for a given precompile
- We rename `newStateDB(b)` (an undefined function) to `state.NewTestStateDB(b)` (the function used to define a new test state for testing a precompile)

## How this works

We modified the arguments to `test.Bench` within `Benchmark`

## How this was tested

After running `./scripts/build_test.sh` in precompile-evm, we are able to compile` precompile_contract_test_template.go
`
## How is this documented
