### PR TITLE
Remove call from precompile

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -313,11 +313,6 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 	return ret, gas, err
 }
 
-// CallFromPrecompile invokes Call to execute the contract with the given input parameters.
-func (evm *EVM) CallFromPrecompile(caller common.Address, addr common.Address, input []byte, gas uint64, value *big.Int) (ret []byte, leftOverGas uint64, err error) {
-	return evm.Call(AccountRef(caller), addr, input, gas, value)
-}
-
 // CallCode executes the contract associated with the addr with the given input
 // as parameters. It also handles any necessary value transfer required and takes
 // the necessary steps to create accounts and reverses the state in case of an

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/gballet/go-libpcsclite v0.0.0-20191108122812-4678299bea08
 	github.com/go-cmd/cmd v1.4.1
+	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/rpc v1.2.0
 	github.com/gorilla/websocket v1.4.2
@@ -70,7 +71,6 @@ require (
 	github.com/go-sourcemap/sourcemap v2.1.3+incompatible // indirect
 	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/golang-jwt/jwt/v4 v4.3.0 // indirect
-	github.com/golang/mock v1.6.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/btree v1.1.2 // indirect

--- a/precompile/contract/interfaces.go
+++ b/precompile/contract/interfaces.go
@@ -60,7 +60,6 @@ type AccessibleState interface {
 	GetStateDB() StateDB
 	GetBlockContext() BlockContext
 	GetSnowContext() *snow.Context
-	CallFromPrecompile(caller common.Address, addr common.Address, input []byte, gas uint64, value *big.Int) (ret []byte, leftOverGas uint64, err error)
 }
 
 // BlockContext defines an interface that provides information to a stateful precompile about the

--- a/precompile/contract/mock_interfaces.go
+++ b/precompile/contract/mock_interfaces.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/subnet-evm/commontype"
-	"github.com/ethereum/go-ethereum/common"
 )
 
 // TODO: replace with gomock library
@@ -52,10 +51,6 @@ func (m *mockAccessibleState) GetStateDB() StateDB { return m.state }
 func (m *mockAccessibleState) GetBlockContext() BlockContext { return m.blockContext }
 
 func (m *mockAccessibleState) GetSnowContext() *snow.Context { return m.snowContext }
-
-func (m *mockAccessibleState) CallFromPrecompile(caller common.Address, addr common.Address, input []byte, gas uint64, value *big.Int) (ret []byte, leftOverGas uint64, err error) {
-	return nil, 0, nil
-}
 
 type mockChainState struct {
 	feeConfig            commontype.FeeConfig


### PR DESCRIPTION
## Why this should be merged

This PR removes `CallFromPrecompile` from the accessible state of a precompile. Precompile development has led to many bugs in the past in projects that extended the EVM.

This PR removes this functionality for now since it is not currently used. This is intended to support a "less is more" approach for encouraging safe development while using Precompile-EVM until there is clear demand and guidelines for how to implement stateful precompiles safely.

If there is significant demand to add it back, we can re-support it and add better documentation as well.

## How this works

Removes currently unused functionality.

## How this was tested

CI

## How is this documented

n/a