### PR TITLE
Fix nil types tmpl

### DIFF
--- a/accounts/abi/bind/bind.go
+++ b/accounts/abi/bind/bind.go
@@ -662,6 +662,8 @@ func convertToNil(input abi.Type) string {
 		return "false"
 	case abi.AddressTy:
 		return "common.Address{}"
+	case abi.HashTy:
+		return "common.Hash{}"
 	case abi.FixedBytesTy:
 		return fmt.Sprintf("[%d]byte{}", input.Size)
 	case abi.BytesTy:

--- a/accounts/abi/bind/bind.go
+++ b/accounts/abi/bind/bind.go
@@ -650,6 +650,11 @@ func decapitalise(input string) string {
 func convertToNil(input abi.Type) string {
 	switch input.T {
 	case abi.IntTy, abi.UintTy:
+		parts := regexp.MustCompile(`(u)?int([0-9]*)`).FindStringSubmatch(input.String())
+		switch parts[2] {
+		case "8", "16", "32", "64":
+			return "0"
+		}
 		return "big.NewInt(0)"
 	case abi.StringTy:
 		return "\"\""
@@ -657,8 +662,12 @@ func convertToNil(input abi.Type) string {
 		return "false"
 	case abi.AddressTy:
 		return "common.Address{}"
-	case abi.HashTy:
-		return "common.Hash{}"
+	case abi.FixedBytesTy:
+		return fmt.Sprintf("[%d]byte{}", input.Size)
+	case abi.BytesTy:
+		return "[]byte{}"
+	case abi.FunctionTy:
+		return "[24]byte{}"
 	default:
 		return "nil"
 	}

--- a/accounts/abi/bind/bind.go
+++ b/accounts/abi/bind/bind.go
@@ -310,7 +310,6 @@ func BindHelper(types []string, abis []string, bytecodes []string, fsigs []map[s
 		"namedtype":     namedType[lang],
 		"capitalise":    capitalise,
 		"decapitalise":  decapitalise,
-		"convertToNil":  convertToNil,
 		"mkList":        mkList,
 	}
 
@@ -644,35 +643,6 @@ func decapitalise(input string) string {
 
 	goForm := abi.ToCamelCase(input)
 	return strings.ToLower(goForm[:1]) + goForm[1:]
-}
-
-// convertToNil converts any type to its proper nil form.
-func convertToNil(input abi.Type) string {
-	switch input.T {
-	case abi.IntTy, abi.UintTy:
-		parts := regexp.MustCompile(`(u)?int([0-9]*)`).FindStringSubmatch(input.String())
-		switch parts[2] {
-		case "8", "16", "32", "64":
-			return "0"
-		}
-		return "big.NewInt(0)"
-	case abi.StringTy:
-		return "\"\""
-	case abi.BoolTy:
-		return "false"
-	case abi.AddressTy:
-		return "common.Address{}"
-	case abi.HashTy:
-		return "common.Hash{}"
-	case abi.FixedBytesTy:
-		return fmt.Sprintf("[%d]byte{}", input.Size)
-	case abi.BytesTy:
-		return "[]byte{}"
-	case abi.FunctionTy:
-		return "[24]byte{}"
-	default:
-		return "nil"
-	}
 }
 
 // structured checks whether a list of ABI data types has enough information to

--- a/accounts/abi/bind/precompilebind/precompile_contract_template.go
+++ b/accounts/abi/bind/precompilebind/precompile_contract_template.go
@@ -153,21 +153,22 @@ func Pack{{.Normalized.Name}}(inputStruct {{capitalise .Normalized.Name}}Input) 
 {{else if len .Normalized.Inputs | eq 1 }}
 {{$method := .}}
 {{$input := index $method.Normalized.Inputs 0}}
-// Unpack{{capitalise .Normalized.Name}}Input attempts to unpack [input] into the {{bindtype $input.Type $structs}} type argument
+{{$bindedType := bindtype $input.Type $structs}}
+// Unpack{{capitalise .Normalized.Name}}Input attempts to unpack [input] into the {{$bindedType}} type argument
 // assumes that [input] does not include selector (omits first 4 func signature bytes)
-func Unpack{{capitalise .Normalized.Name}}Input(input []byte)({{bindtype $input.Type $structs}}, error) {
+func Unpack{{capitalise .Normalized.Name}}Input(input []byte)({{$bindedType}}, error) {
 res, err := {{$contract.Type}}ABI.UnpackInput("{{$method.Original.Name}}", input)
 if err != nil {
-	return {{convertToNil $input.Type}}, err
+	return *new({{$bindedType}}), err
 }
-unpacked := *abi.ConvertType(res[0], new({{bindtype $input.Type $structs}})).(*{{bindtype $input.Type $structs}})
+unpacked := *abi.ConvertType(res[0], new({{$bindedType}})).(*{{$bindedType}})
 return unpacked, nil
 }
 
-// Pack{{.Normalized.Name}} packs [{{decapitalise $input.Name}}] of type {{bindtype $input.Type $structs}} into the appropriate arguments for {{$method.Original.Name}}.
+// Pack{{.Normalized.Name}} packs [{{decapitalise $input.Name}}] of type {{$bindedType}} into the appropriate arguments for {{$method.Original.Name}}.
 // the packed bytes include selector (first 4 func signature bytes).
 // This function is mostly used for tests.
-func Pack{{$method.Normalized.Name}}( {{decapitalise $input.Name}} {{bindtype $input.Type $structs}},) ([]byte, error) {
+func Pack{{$method.Normalized.Name}}( {{decapitalise $input.Name}} {{$bindedType}},) ([]byte, error) {
 	return {{$contract.Type}}ABI.Pack("{{$method.Original.Name}}", {{decapitalise $input.Name}},)
 }
 {{else}}
@@ -192,9 +193,10 @@ func Pack{{capitalise .Normalized.Name}}Output (outputStruct {{capitalise .Norma
 {{else if len .Normalized.Outputs | eq 1 }}
 {{$method := .}}
 {{$output := index $method.Normalized.Outputs 0}}
-// Pack{{capitalise .Normalized.Name}}Output attempts to pack given {{decapitalise $output.Name}} of type {{bindtype $output.Type $structs}}
+{{$bindedType := bindtype $output.Type $structs}}
+// Pack{{capitalise .Normalized.Name}}Output attempts to pack given {{decapitalise $output.Name}} of type {{$bindedType}}
 // to conform the ABI outputs.
-func Pack{{$method.Normalized.Name}}Output ({{decapitalise $output.Name}} {{bindtype $output.Type $structs}}) ([]byte, error) {
+func Pack{{$method.Normalized.Name}}Output ({{decapitalise $output.Name}} {{$bindedType}}) ([]byte, error) {
 	return {{$contract.Type}}ABI.PackOutput("{{$method.Original.Name}}", {{decapitalise $output.Name}})
 }
 {{end}}


### PR DESCRIPTION
## Why this should be merged

Fixes int types for uint and int8,16,32,64. also adds byte types.

## How this works

changes the `converToNil` function and adds new cases.

## How this was tested

Locally generated precompile files

## How is this documented

No need as this is part of a generator tool
