### PR TITLE
Update warp readme

### DIFF
--- a/x/warp/README.md
+++ b/x/warp/README.md
@@ -11,82 +11,30 @@ It is intended to allow communication between arbitrary Custom Virtual Machines 
 
 ## How does Avalanche Warp Messaging Work
 
-Avalanche Warp Messaging relies on the Avalanche P-Chain to provide a read-only view of every Subnet's validator set. In Avalanche, the P-Chain is used to maintain the Primary Network's validator set, create new subnets and blockchains, and maintain the validator sets of each Subnet. As of the Banff Upgrade, Avalanche enables registering a BLS Public Key alongside a validator.
+Avalanche Warp Messaging uses BLS Multi-Signatures with Public-Key Aggregation where every Avalanche validator registers a public key alongside its NodeID on the Avalanche P-Chain.
 
-In order to be a validator of an Avalanche Subnet, a node must also validate the Avalanche Primary Network. This means each Subnet validator has read access to the P-Chain state.
+Every Subnet needs read access to the Avalanche P-Chain to provide weighted sets of BLS Public Keys that correspond to the validator sets of each Subnet on the Avalanche Network. Avalanche Warp Messaging provides a basic primitive for signing messages with an aggregation of signatures from a source Subnet, and the ability for any Subnet to verify that message was signed by a threshold of validators from the source subent.
 
-With just those two things:
-- Read access to all Subnet validator sets through the P-Chain
-- BLS Public Keys registered on the P-Chain
+For more details on Avalanche Warp Messaging, see the AvalancheGo [Warp README](https://github.com/ava-labs/avalanchego/blob/warp-readme/vms/platformvm/warp/README.md).
 
-We can build a generic Avalanche Warp Messaging Protocol. :point_down:
+## Integrating Avalanche Warp Messaging into the EVM
 
-### Subnet to Subnet
+### Flow of Sending / Receiving a Warp Message within the EVM
 
-The validator set of Subnet A can send a message on behalf of any blockchain on its Subnet.
+The Avalanche Warp Precompile enables this flow to send a message from blockchain A to blockchain B:
 
-For example, let's say that there are two Subnets: Subnet A and Subnet B each with a single Blockchain we'll call Blockchain A and Blockchain B.
+1. Call the Warp Precompile `sendWarpMessage` function with the arguments for the UnsignedMessage
+2. Warp Precompile emits an event / log containing the `UnsignedMessage` specified by the caller of `sendWarpMessage`
+3. Network accepts the block containing the `UnsignedMessage` in the log, so that validators are willing to sign the message
+4. An off-chain relayer queries the validators for their signatures of the message and aggregate the signatures to create a `SignedMessage`
+5. The off-chain relayer encodes the `SignedMessage` as the [predicate](#predicate-encoding) in of a transaction to deliver on blockchain B
+6. The transaction is delivered on blockchain B, the signature is verified prior to executing the block, and the message is accessible via the Warp Precompile's `getVerifiedWarpMessage` during the execution of that transaction
 
-First, Blockchain A produces a BLS Multisignature of a message to send to Blockchain B:
-
-1. A transaction is issued on Blockchain A to send a message to Subnet B
-2. The transaction is accepted on Blockchain A (must wait for acceptance)
-3. The VM powering Blockchain A (ex: Subnet-EVM) should either
-    a) be willing to sign the message to allow an off-chain relayer to aggregate signatures from the Subnet's validator set (existing implementation)
-    b) aggregate signatures from the validator set of Subnet A to produce its own aggregate signature
-
-The signature of Subnet A's validator set attests to the message being sent by Blockchain A.
-
-To receive the message, Blockchain B must be running a Snowman VM that is wrapped in the Snowman++ ProposerVM. The ProposerVM provides the P-Chain Context which a block on Blockchain B was issued in. See [here](https://github.com/ava-labs/avalanchego/tree/v1.10.4/vms/proposervm#snowman-block-extension) for more details on the ProposerVM block wrapper. The ProposerVM header includes a P-Chain height at which the block was validated. This P-Chain height determines the canonical state of the P-Chain to use for verification of all Avalanche Warp Messages.
-
-To validate and deliver the message, an off-chain component delivers the signed message from Blockchain A to Blockchain B (this is out of scope for Avalanche Warp Messaging itself).
-
-When Blockchain B receives the message, it validates and delivers/executes the message:
-
-1. Read the SourceChainID of the signed message (Blockchain A)
-2. Look up the SubnetID that validates Blockchain A: Subnet A
-3. Look up the validator set of Subnet A and the registered BLS Public Keys of Subnet A at the P-Chain height specified by the ProposerVM header
-4. Filter the validators of Subnet A to include only the validators that the signed message claims as signers
-5. Verify the claimed included validators represent a sufficient quorum of stake to verify the message
-6. Aggregate the BLS Public Keys of the claimed signers into an aggregated BLS Public Key
-7. Validate the aggregate signature matches the claimed aggregate BLS Public Key
-
-After verifying the message, Blockchain B can define its own semantics of how to deliver or execute the message.
-
-### Subnet to C-Chain (Primary Network)
-
-Subnet to C-Chain Warp Messaging is a special case of Avalanche Warp Messaging. The C-Chain can efficiently verify a signature produced by another Subnet, so the implementation for the C-Chain to receive an Avalanche Warp Message can and will use the same code as is planned for Subnet-EVM.
-
-### C-Chain to Subnet
-
-To support C-Chain to Subnet communication, or more generally Primary Network to Subnet communication, we special case the C-Chain for two reasons:
-
-1. Every Subnet validator validates the C-Chain
-2. The Primary Network has the largest possible number of validators
-
-Since the Primary Network has the largest possible number of validators for any Subnet on Avalanche, it would also be the most expensive Subnet to verify Avalanche Warp Messages from (most signatures required to verify it). Luckily, we can do something much smarter.
-
-When a Subnet receives a message from a blockchain on the Primary Network, we use the validator set of the receiving Subnet instead of the entire network when validating the message. This means that the C-Chain sending a message can be the exact same as Subnet to Subnet communciation.
-
-However, when Subnet B receives a message from the C-Chain, it changes the semantics to the following:
-
-1. Read the SourceChainID of the signed message (C-Chain)
-2. Look up the SubnetID that validates C-Chain: Primary Network
-3. Look up the validator set of Subnet B (instead of the Primary Network) and the registered BLS Public Keys of Subnet B at the P-Chain height specified by the ProposerVM header
-4. Filter the validators of Subnet B to include only the validators that the signed message claims as signers
-5. Verify the claimed included validators represent a sufficient quorum of stake to verify the message
-6. Aggregate the BLS Public Keys of the claimed signers into an aggregated BLS Public Key
-7. Validate the aggregate signature matches the claimed aggregate BLS Public Key
-
-This means that if Subnet B has 10 equally weighted validators, then C-Chain to Subnet communication only requires a threshold of stake from those 10 validators rather than a threshold of the stake of the Primary Network.
-
-Since the security of Subnet B depends on the validators of Subnet B already, changing the requirements of verifying the message from verifying a signature from the entire Primary Network to only Subnet B's validator set does not change the security of Subnet B!
-
-## Warp Precompile
+### Warp Precompile
 
 The Warp Precompile is broken down into three functions defined in the Solidity interface file [here](../../../contracts/contracts/interfaces/IWarpMessenger.sol).
 
-### sendWarpMessage
+#### sendWarpMessage
 
 `sendWarpMessage` is used to send a verifiable message. Calling this function results in sending a message with the following contents:
 
@@ -109,7 +57,7 @@ Additionally, the `SourceChainID` is excluded because anyone parsing the chain c
 The actual `message` is the entire [Avalanche Warp Unsigned Message](https://github.com/ava-labs/avalanchego/blob/master/vms/platformvm/warp/unsigned_message.go#L14) including the Subnet-EVM [Addressed Payload](../../../warp/payload/payload.go).
 
 
-### getVerifiedMessage
+#### getVerifiedMessage
 
 `getVerifiedMessage` is used to read the contents of the delivered Avalanche Warp Message into the expected format.
 
@@ -117,7 +65,7 @@ It returns the message if present and a boolean indicating if a message is prese
 
 To use this function, the transaction must include the signed Avalanche Warp Message encoded in the [predicate](#predicate-encoding) of the transaction. Prior to executing a block, the VM iterates through transactions and pre-verifies all predicates. If a transaction's predicate is invalid, then it is considered invalid to include in the block and dropped.
 
-This gives the following properties:
+This leads to the following advantages:
 
 1. The EVM execution does not need to verify the Warp Message at runtime (no signature verification or external calls to the P-Chain)
 2. The EVM can deterministically re-execute and re-verify blocks assuming the predicate was verified by the network (eg., in bootstrapping)
@@ -126,13 +74,14 @@ This pre-verification is performed using the ProposerVM Block header during [blo
 
 Note: in order to support the notion of an `AnycastID` for the `DestinationChainID`, `getVerifiedMessage` and the predicate DO NOT require that the `DestinationChainID` matches the `blockchainID` currently running. Instead, callers of `getVerifiedMessage` should use `getBlockchainID()` to decide how they should interpret the message. In other words, does the `destinationChainID` match either the local `blockchainID` or the `AnycastID`.
 
-### getBlockchainID
+#### getBlockchainID
 
 `getBlockchainID` returns the blockchainID of the blockchain that Subnet-EVM is running on.
 
 This is different from the conventional Ethereum ChainID registered to https://chainlist.org/.
 
 The `blockchainID` in Avalanche refers to the txID that created the blockchain on the Avalanche P-Chain ([docs](https://docs.avax.network/specs/platform-transaction-serialization#unsigned-create-chain-tx)).
+
 
 ### Predicate Encoding
 
@@ -141,6 +90,30 @@ Avalanche Warp Messages are encoded as a signed Avalanche [Warp Message](https:/
 Since the predicate is encoded into the [Transaction Access List](https://eips.ethereum.org/EIPS/eip-2930), it is packed into 32 byte hashes intended to declare storage slots that should be pre-warmed into the cache prior to transaction execution.
 
 Therefore, we use the [Predicate Utils](../../../utils/predicate/README.md) package to encode the actual byte slice of size N into the access list.
+
+### Performance Optimization: C-Chain to Subnet
+
+To support C-Chain to Subnet communication, or more generally Primary Network to Subnet communication, we special case the C-Chain for two reasons:
+
+1. Every Subnet validator validates the C-Chain
+2. The Primary Network has the largest possible number of validators
+
+Since the Primary Network has the largest possible number of validators for any Subnet on Avalanche, it would also be the most expensive Subnet to verify Avalanche Warp Messages from (most signatures/public keys required to verify it). Luckily, we can do something much smarter.
+
+When a Subnet receives a message from a blockchain on the Primary Network, we use the validator set of the receiving Subnet instead of the entire network when validating the message. This means that the C-Chain sending a message can be the exact same as Subnet to Subnet communciation.
+
+However, when Subnet B receives a message from the C-Chain, it changes the semantics to the following:
+
+1. Read the SourceChainID of the signed message (C-Chain)
+2. Look up the SubnetID that validates C-Chain: Primary Network
+3. Look up the validator set of Subnet B (instead of the Primary Network) and the registered BLS Public Keys of Subnet B at the P-Chain height specified by the ProposerVM header
+4. Continue Warp Message verification using the validator set of Subnet B instead of the Primary Network
+
+This means that C-Chain to Subnet communication only requires a threshold of stake on the receiving subnet to sign the message instead of a threshold of stake for the entire Primary Network.
+
+This assumes that the security of Subnet B already depends on the validators of Subnet B to behave virtuously. Therefore, requiring a threshold of stake from the receiving Subnet's validator set instead of the whole Primary Network does not meaningfully change security of the receiving Subnet.
+
+Note: this special case is ONLY applied during Warp Message verification. The message sent by the Primary Network will still contain the Avalanche C-Chain's blockchainID as the sourceChainID and signatures will be served by querying the C-Chain directly.
 
 ## Design Considerations
 
@@ -181,7 +154,7 @@ The Warp Precompile was designed with the intention of minimizing the trusted co
 
 The Warp Precompile itself provides ONLY the following ability:
 
-send a verified message from a caller on blockchain A to a destination address on blockchain B
+- Send a verifiable message from a caller on blockchain A to a destination address on blockchain B
 
 #### Explicitly Not Provided / Built on Top
 


### PR DESCRIPTION
## Why this should be merged

This PR improves the README in `x/warp` and references the new Warp README in AvalancheGo instead of explaining everything in one place.

## How this works

Updates the Warp README

## How this was tested

n/a

## How is this documented

This PR is documentation