### PR TITLE
e2e test: connect to appropriate chain

### DIFF
--- a/tests/utils/runner/network_manager.go
+++ b/tests/utils/runner/network_manager.go
@@ -249,8 +249,8 @@ func (n *NetworkManager) SetupNetwork(ctx context.Context, execPath string, bloc
 	}
 	nodeInfos := status.GetClusterInfo().GetNodeInfos()
 
-	for _, chainSpec := range blockchainSpecs {
-		blockchainIDStr := sresp.ChainIds[0]
+	for i, chainSpec := range blockchainSpecs {
+		blockchainIDStr := sresp.ChainIds[i]
 		blockchainID, err := ids.FromString(blockchainIDStr)
 		if err != nil {
 			panic(err)

--- a/tests/warp/warp_test.go
+++ b/tests/warp/warp_test.go
@@ -335,6 +335,15 @@ var _ = ginkgo.Describe("[Warp]", ginkgo.Ordered, func() {
 		log.Info("Transaction triggered new block", "blockHash", newHead.Hash())
 		nonce++
 
+		triggerTx, err = types.SignTx(types.NewTransaction(nonce, fundedAddress, common.Big1, 21_000, big.NewInt(225*params.GWei), nil), txSigner, fundedKey)
+		gomega.Expect(err).Should(gomega.BeNil())
+
+		err = chainBWSClient.SendTransaction(ctx, triggerTx)
+		gomega.Expect(err).Should(gomega.BeNil())
+		newHead = <-newHeads
+		log.Info("Transaction triggered new block", "blockHash", newHead.Hash())
+		nonce++
+
 		packedInput, err := warp.PackGetVerifiedWarpMessage()
 		gomega.Expect(err).Should(gomega.BeNil())
 		tx := predicateutils.NewPredicateTx(


### PR DESCRIPTION
## Why this should be merged
Fixes an issue which improperly assigns all e2e test endpoints to the first blockchain.

## How this works
Fixes the issue.
Also brings back a 2nd "triggerTx" on blockchain B in the warp test since otherwise the test gets stuck on waiting for a new block.

## How this was tested
CI

## How is this documented
N/A