### PR TITLE
warp e2e: Single node primary network

### DIFF
--- a/tests/warp/warp_test.go
+++ b/tests/warp/warp_test.go
@@ -75,7 +75,7 @@ var _ = ginkgo.BeforeSuite(func() {
 	warpChainConfigPath = f.Name()
 
 	// Construct the network using the avalanche-network-runner
-	_, err = manager.StartDefaultNetwork(ctx)
+	_, err = manager.StartSingleNodeNetwork(ctx)
 	gomega.Expect(err).Should(gomega.BeNil())
 	err = manager.SetupNetwork(
 		ctx,


### PR DESCRIPTION
## Why this should be merged
Running multiple nodes only to process subnet transactions for local testing is not necessary,
it consumes resources and produces noisy logs.

## How this works
Passes some additional ANR options 

## How this was tested
CI + local

## How is this documented
N/A