### PR TITLE
add debug log for dropped pending txs notifications

### DIFF
--- a/plugin/evm/block_builder.go
+++ b/plugin/evm/block_builder.go
@@ -109,6 +109,7 @@ func (b *blockBuilder) needToBuild() bool {
 func (b *blockBuilder) markBuilding() {
 	// If the engine has not called BuildBlock, no need to send another message.
 	if b.buildSent {
+		log.Debug("previous PendingTxs notification still pending in consensus")
 		return
 	}
 	b.buildBlockTimer.Cancel() // Cancel any future attempt from the timer to send a PendingTxs message


### PR DESCRIPTION
## Why this should be merged

Adds debug log for when we skip a build block notification 

## How this works

Adds debug log

## How this was tested

Did not

## How is this documented

N/A