### PR TITLE
Fix build script

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -50,4 +50,4 @@ fi
 
 # Build Subnet EVM, which is run as a subprocess
 echo "Building Subnet EVM @ GitCommit: $SUBNET_EVM_COMMIT at $BINARY_PATH"
-go build -ldflags "-X github.com/ava-labs/subnet-evm/plugin/evm.GitCommit=$SUBNET_EVM_COMMIT $STATIC_LD_FLAGS" -o "$BINARY_PATH" "plugin/"*.go
+go build -ldflags "-X github.com/ava-labs/subnet-evm/plugin/evm.GitCommit=$SUBNET_EVM_COMMIT -X github.com/ava-labs/subnet-evm/plugin/evm.Version=$SUBNET_EVM_VERSION $STATIC_LD_FLAGS" -o "$BINARY_PATH" "plugin/"*.go


### PR DESCRIPTION
## Why this should be merged
To follow the documentation guide found [here](https://docs.avax.network/build/subnet/deploy/custom-vm-subnet).

## How this works
Specifies the version sourced at `scripts/versions.sh` as a build argument. 

## How this was tested
By following the documentation guide previously mentioned and obtaining a correct result.

## How is this documented
N/A
