### PR TITLE
force register js tracer

### DIFF
--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -46,6 +46,7 @@ import (
 	// We must import this package (not referenced elsewhere) so that the native "callTracer"
 	// is added to a map of client-accessible tracers. In geth, this is done
 	// inside of cmd/geth.
+	_ "github.com/ava-labs/subnet-evm/eth/tracers/js"
 	_ "github.com/ava-labs/subnet-evm/eth/tracers/native"
 
 	"github.com/ava-labs/subnet-evm/precompile/precompileconfig"


### PR DESCRIPTION
## Why this should be merged

Closes #779 

## How this works

Force registers js tracer package to the vm

## How this was tested

locally tested to see if crashes.

## How is this documented

This is a bugfix.
