### PR TITLE
Expand verify

### DIFF
--- a/accounts/abi/bind/precompilebind/precompile_config_template.go
+++ b/accounts/abi/bind/precompilebind/precompile_config_template.go
@@ -63,10 +63,10 @@ func NewDisableConfig(blockTimestamp *uint64) *Config {
 func (*Config) Key() string { return ConfigKey }
 
 // Verify tries to verify Config and returns an error accordingly.
-func (c *Config) Verify() error {
+func (c *Config) Verify(chainConfig precompileconfig.ChainConfig) error {
 	{{- if .Contract.AllowList}}
 	// Verify AllowList first
-	if err := c.AllowListConfig.Verify(); err != nil {
+	if err := c.AllowListConfig.Verify(chainConfig); err != nil {
 		return err
 	}
 	{{- end}}

--- a/accounts/abi/bind/precompilebind/precompile_module_template.go
+++ b/accounts/abi/bind/precompilebind/precompile_module_template.go
@@ -59,7 +59,7 @@ func (*configurator) MakeConfig() precompileconfig.Config {
 // This function is called by the EVM once per precompile contract activation.
 // You can use this function to set up your precompile contract's initial state,
 // by using the [cfg] config and [state] stateDB.
-func (*configurator) Configure(chainConfig contract.ChainConfig, cfg precompileconfig.Config, state contract.StateDB, _ contract.BlockContext) error {
+func (*configurator) Configure(chainConfig precompileconfig.ChainConfig, cfg precompileconfig.Config, state contract.StateDB, _ contract.BlockContext) error {
 	config, ok := cfg.(*Config)
 	if !ok {
 		return fmt.Errorf("incorrect config %T: %v", config, config)

--- a/params/precompile_upgrade.go
+++ b/params/precompile_upgrade.go
@@ -79,7 +79,7 @@ func (c *ChainConfig) verifyPrecompileUpgrades() error {
 
 	// verify genesis precompiles
 	for key, config := range c.GenesisPrecompiles {
-		if err := config.Verify(); err != nil {
+		if err := config.Verify(c); err != nil {
 			return err
 		}
 		// if the precompile is disabled at genesis, skip it.
@@ -132,7 +132,7 @@ func (c *ChainConfig) verifyPrecompileUpgrades() error {
 			return fmt.Errorf("PrecompileUpgrade (%s) at [%d]: config block timestamp (%v) <= previous timestamp (%v) of same key", key, i, *upgradeTimestamp, *lastTimestamp)
 		}
 
-		if err := upgrade.Verify(); err != nil {
+		if err := upgrade.Verify(c); err != nil {
 			return err
 		}
 

--- a/precompile/allowlist/allowlist_test.go
+++ b/precompile/allowlist/allowlist_test.go
@@ -43,7 +43,7 @@ func (d *dummyConfigurator) MakeConfig() precompileconfig.Config {
 }
 
 func (d *dummyConfigurator) Configure(
-	chainConfig contract.ChainConfig,
+	chainConfig precompileconfig.ChainConfig,
 	precompileConfig precompileconfig.Config,
 	state contract.StateDB,
 	blockContext contract.BlockContext,

--- a/precompile/allowlist/config.go
+++ b/precompile/allowlist/config.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/ava-labs/subnet-evm/precompile/contract"
+	"github.com/ava-labs/subnet-evm/precompile/precompileconfig"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -52,7 +53,7 @@ func areEqualAddressLists(current []common.Address, other []common.Address) bool
 }
 
 // Verify returns an error if there is an overlapping address between admin and enabled roles
-func (c *AllowListConfig) Verify() error {
+func (c *AllowListConfig) Verify(precompileconfig.ChainConfig) error {
 	addressMap := make(map[common.Address]Role) // tracks which addresses we have seen and their role
 
 	// check for duplicates in enabled list

--- a/precompile/contract/interfaces.go
+++ b/precompile/contract/interfaces.go
@@ -8,7 +8,6 @@ import (
 	"math/big"
 
 	"github.com/ava-labs/avalanchego/snow"
-	"github.com/ava-labs/subnet-evm/commontype"
 	"github.com/ava-labs/subnet-evm/precompile/precompileconfig"
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -17,16 +16,6 @@ import (
 type StatefulPrecompiledContract interface {
 	// Run executes the precompiled contract.
 	Run(accessibleState AccessibleState, caller common.Address, addr common.Address, input []byte, suppliedGas uint64, readOnly bool) (ret []byte, remainingGas uint64, err error)
-}
-
-// ChainContext defines an interface that provides information to a stateful precompile
-// about the chain configuration. The precompile can access this information to initialize
-// its state.
-type ChainConfig interface {
-	// GetFeeConfig returns the original FeeConfig that was set in the genesis.
-	GetFeeConfig() commontype.FeeConfig
-	// AllowedFeeRecipients returns true if fee recipients are allowed in the genesis.
-	AllowedFeeRecipients() bool
 }
 
 // StateDB is the interface for accessing EVM state
@@ -72,7 +61,7 @@ type BlockContext interface {
 type Configurator interface {
 	MakeConfig() precompileconfig.Config
 	Configure(
-		chainConfig ChainConfig,
+		chainConfig precompileconfig.ChainConfig,
 		precompileconfig precompileconfig.Config,
 		state StateDB,
 		blockContext BlockContext,

--- a/precompile/contract/mock_interfaces.go
+++ b/precompile/contract/mock_interfaces.go
@@ -7,7 +7,7 @@ import (
 	"math/big"
 
 	"github.com/ava-labs/avalanchego/snow"
-	"github.com/ava-labs/subnet-evm/commontype"
+	"github.com/ava-labs/subnet-evm/precompile/precompileconfig"
 )
 
 // TODO: replace with gomock library
@@ -36,13 +36,15 @@ type mockAccessibleState struct {
 	state        StateDB
 	blockContext *mockBlockContext
 	snowContext  *snow.Context
+	chainConfig  precompileconfig.ChainConfig
 }
 
-func NewMockAccessibleState(state StateDB, blockContext *mockBlockContext, snowContext *snow.Context) *mockAccessibleState {
+func NewMockAccessibleState(state StateDB, blockContext *mockBlockContext, snowContext *snow.Context, chainConfig precompileconfig.ChainConfig) *mockAccessibleState {
 	return &mockAccessibleState{
 		state:        state,
 		blockContext: blockContext,
 		snowContext:  snowContext,
+		chainConfig:  chainConfig,
 	}
 }
 
@@ -52,17 +54,4 @@ func (m *mockAccessibleState) GetBlockContext() BlockContext { return m.blockCon
 
 func (m *mockAccessibleState) GetSnowContext() *snow.Context { return m.snowContext }
 
-type mockChainState struct {
-	feeConfig            commontype.FeeConfig
-	allowedFeeRecipients bool
-}
-
-func (m *mockChainState) GetFeeConfig() commontype.FeeConfig { return m.feeConfig }
-func (m *mockChainState) AllowedFeeRecipients() bool         { return m.allowedFeeRecipients }
-
-func NewMockChainState(feeConfig commontype.FeeConfig, allowedFeeRecipients bool) *mockChainState {
-	return &mockChainState{
-		feeConfig:            feeConfig,
-		allowedFeeRecipients: allowedFeeRecipients,
-	}
-}
+func (m *mockAccessibleState) GetChainConfig() precompileconfig.ChainConfig { return m.chainConfig }

--- a/precompile/contracts/deployerallowlist/config.go
+++ b/precompile/contracts/deployerallowlist/config.go
@@ -53,4 +53,6 @@ func (c *Config) Equal(cfg precompileconfig.Config) bool {
 	return c.Upgrade.Equal(&other.Upgrade) && c.AllowListConfig.Equal(&other.AllowListConfig)
 }
 
-func (c *Config) Verify() error { return c.AllowListConfig.Verify() }
+func (c *Config) Verify(chainConfig precompileconfig.ChainConfig) error {
+	return c.AllowListConfig.Verify(chainConfig)
+}

--- a/precompile/contracts/deployerallowlist/module.go
+++ b/precompile/contracts/deployerallowlist/module.go
@@ -40,7 +40,7 @@ func (*configurator) MakeConfig() precompileconfig.Config {
 }
 
 // Configure configures [state] with the given [cfg] config.
-func (c *configurator) Configure(_ contract.ChainConfig, cfg precompileconfig.Config, state contract.StateDB, _ contract.BlockContext) error {
+func (c *configurator) Configure(_ precompileconfig.ChainConfig, cfg precompileconfig.Config, state contract.StateDB, _ contract.BlockContext) error {
 	config, ok := cfg.(*Config)
 	if !ok {
 		return fmt.Errorf("incorrect config %T: %v", config, config)

--- a/precompile/contracts/feemanager/config.go
+++ b/precompile/contracts/feemanager/config.go
@@ -66,8 +66,8 @@ func (c *Config) Equal(cfg precompileconfig.Config) bool {
 	return c.InitialFeeConfig.Equal(other.InitialFeeConfig)
 }
 
-func (c *Config) Verify() error {
-	if err := c.AllowListConfig.Verify(); err != nil {
+func (c *Config) Verify(chainConfig precompileconfig.ChainConfig) error {
+	if err := c.AllowListConfig.Verify(chainConfig); err != nil {
 		return err
 	}
 	if c.InitialFeeConfig == nil {

--- a/precompile/contracts/feemanager/module.go
+++ b/precompile/contracts/feemanager/module.go
@@ -40,7 +40,7 @@ func (*configurator) MakeConfig() precompileconfig.Config {
 }
 
 // Configure configures [state] with the desired admins based on [configIface].
-func (*configurator) Configure(chainConfig contract.ChainConfig, cfg precompileconfig.Config, state contract.StateDB, blockContext contract.BlockContext) error {
+func (*configurator) Configure(chainConfig precompileconfig.ChainConfig, cfg precompileconfig.Config, state contract.StateDB, blockContext contract.BlockContext) error {
 	config, ok := cfg.(*Config)
 	if !ok {
 		return fmt.Errorf("incorrect config %T: %v", config, config)

--- a/precompile/contracts/nativeminter/config.go
+++ b/precompile/contracts/nativeminter/config.go
@@ -80,7 +80,7 @@ func (c *Config) Equal(cfg precompileconfig.Config) bool {
 	return true
 }
 
-func (c *Config) Verify() error {
+func (c *Config) Verify(chainConfig precompileconfig.ChainConfig) error {
 	// ensure that all of the initial mint values in the map are non-nil positive values
 	for addr, amount := range c.InitialMint {
 		if amount == nil {
@@ -91,5 +91,5 @@ func (c *Config) Verify() error {
 			return fmt.Errorf("initial mint cannot contain invalid amount %v for address %s", bigIntAmount, addr)
 		}
 	}
-	return c.AllowListConfig.Verify()
+	return c.AllowListConfig.Verify(chainConfig)
 }

--- a/precompile/contracts/nativeminter/module.go
+++ b/precompile/contracts/nativeminter/module.go
@@ -41,7 +41,7 @@ func (*configurator) MakeConfig() precompileconfig.Config {
 }
 
 // Configure configures [state] with the desired admins based on [cfg].
-func (*configurator) Configure(_ contract.ChainConfig, cfg precompileconfig.Config, state contract.StateDB, _ contract.BlockContext) error {
+func (*configurator) Configure(_ precompileconfig.ChainConfig, cfg precompileconfig.Config, state contract.StateDB, _ contract.BlockContext) error {
 	config, ok := cfg.(*Config)
 	if !ok {
 		return fmt.Errorf("incorrect config %T: %v", config, config)

--- a/precompile/contracts/rewardmanager/config.go
+++ b/precompile/contracts/rewardmanager/config.go
@@ -86,13 +86,13 @@ func NewDisableConfig(blockTimestamp *uint64) *Config {
 
 func (*Config) Key() string { return ConfigKey }
 
-func (c *Config) Verify() error {
+func (c *Config) Verify(chainConfig precompileconfig.ChainConfig) error {
 	if c.InitialRewardConfig != nil {
 		if err := c.InitialRewardConfig.Verify(); err != nil {
 			return err
 		}
 	}
-	return c.AllowListConfig.Verify()
+	return c.AllowListConfig.Verify(chainConfig)
 }
 
 // Equal returns true if [cfg] is a [*RewardManagerConfig] and it has been configured identical to [c].

--- a/precompile/contracts/rewardmanager/module.go
+++ b/precompile/contracts/rewardmanager/module.go
@@ -40,7 +40,7 @@ func (*configurator) MakeConfig() precompileconfig.Config {
 }
 
 // Configure configures [state] with the initial state for the precompile.
-func (*configurator) Configure(chainConfig contract.ChainConfig, cfg precompileconfig.Config, state contract.StateDB, _ contract.BlockContext) error {
+func (*configurator) Configure(chainConfig precompileconfig.ChainConfig, cfg precompileconfig.Config, state contract.StateDB, _ contract.BlockContext) error {
 	config, ok := cfg.(*Config)
 	if !ok {
 		return fmt.Errorf("incorrect config %T: %v", config, config)

--- a/precompile/contracts/txallowlist/module.go
+++ b/precompile/contracts/txallowlist/module.go
@@ -40,7 +40,7 @@ func (*configurator) MakeConfig() precompileconfig.Config {
 }
 
 // Configure configures [state] with the initial state for the precompile.
-func (*configurator) Configure(chainConfig contract.ChainConfig, cfg precompileconfig.Config, state contract.StateDB, _ contract.BlockContext) error {
+func (*configurator) Configure(chainConfig precompileconfig.ChainConfig, cfg precompileconfig.Config, state contract.StateDB, _ contract.BlockContext) error {
 	config, ok := cfg.(*Config)
 	if !ok {
 		return fmt.Errorf("incorrect config %T: %v", config, config)

--- a/precompile/precompileconfig/config.go
+++ b/precompile/precompileconfig/config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
 	"github.com/ava-labs/avalanchego/vms/platformvm/warp"
+	"github.com/ava-labs/subnet-evm/commontype"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -28,7 +29,7 @@ type Config interface {
 	// Equal returns true if the provided argument configures the same precompile with the same parameters.
 	Equal(Config) bool
 	// Verify is called on startup and an error is treated as fatal. Configure can assume the Config has passed verification.
-	Verify() error
+	Verify(ChainConfig) error
 }
 
 // PrecompilePredicateContext is the context passed in to the PrecompilePredicater interface.
@@ -95,4 +96,14 @@ type AcceptContext struct {
 // rely on this. Designed for use only by precompiles that ship with subnet-evm.
 type Accepter interface {
 	Accept(acceptCtx *AcceptContext, txHash common.Hash, logIndex int, topics []common.Hash, logData []byte) error
+}
+
+// ChainContext defines an interface that provides information to a stateful precompile
+// about the chain configuration. The precompile can access this information to initialize
+// its state.
+type ChainConfig interface {
+	// GetFeeConfig returns the original FeeConfig that was set in the genesis.
+	GetFeeConfig() commontype.FeeConfig
+	// AllowedFeeRecipients returns true if fee recipients are allowed in the genesis.
+	AllowedFeeRecipients() bool
 }

--- a/precompile/precompileconfig/mock_config.go
+++ b/precompile/precompileconfig/mock_config.go
@@ -5,13 +5,16 @@
 package precompileconfig
 
 import (
+	"github.com/ava-labs/subnet-evm/commontype"
 	"github.com/ethereum/go-ethereum/common"
 )
 
-var _ Config = &noopStatefulPrecompileConfig{}
+var (
+	_ Config      = &noopStatefulPrecompileConfig{}
+	_ ChainConfig = &mockChainConfig{}
+)
 
-type noopStatefulPrecompileConfig struct {
-}
+type noopStatefulPrecompileConfig struct{}
 
 func NewNoopStatefulPrecompileConfig() *noopStatefulPrecompileConfig {
 	return &noopStatefulPrecompileConfig{}
@@ -37,6 +40,21 @@ func (n *noopStatefulPrecompileConfig) Equal(Config) bool {
 	return false
 }
 
-func (n *noopStatefulPrecompileConfig) Verify() error {
+func (n *noopStatefulPrecompileConfig) Verify(ChainConfig) error {
 	return nil
+}
+
+type mockChainConfig struct {
+	feeConfig            commontype.FeeConfig
+	allowedFeeRecipients bool
+}
+
+func (m *mockChainConfig) GetFeeConfig() commontype.FeeConfig { return m.feeConfig }
+func (m *mockChainConfig) AllowedFeeRecipients() bool         { return m.allowedFeeRecipients }
+
+func NewMockChainConfig(feeConfig commontype.FeeConfig, allowedFeeRecipients bool) *mockChainConfig {
+	return &mockChainConfig{
+		feeConfig:            feeConfig,
+		allowedFeeRecipients: allowedFeeRecipients,
+	}
 }

--- a/precompile/testutils/test_config.go
+++ b/precompile/testutils/test_config.go
@@ -13,6 +13,7 @@ import (
 // ConfigVerifyTest is a test case for verifying a config
 type ConfigVerifyTest struct {
 	Config        precompileconfig.Config
+	ChainConfig   precompileconfig.ChainConfig
 	ExpectedError string
 }
 
@@ -29,7 +30,7 @@ func RunVerifyTests(t *testing.T, tests map[string]ConfigVerifyTest) {
 			t.Helper()
 			require := require.New(t)
 
-			err := test.Config.Verify()
+			err := test.Config.Verify(test.ChainConfig)
 			if test.ExpectedError == "" {
 				require.NoError(err)
 			} else {

--- a/x/warp/config.go
+++ b/x/warp/config.go
@@ -72,7 +72,7 @@ func NewDisableConfig(blockTimestamp *uint64) *Config {
 func (*Config) Key() string { return ConfigKey }
 
 // Verify tries to verify Config and returns an error accordingly.
-func (c *Config) Verify() error {
+func (c *Config) Verify(precompileconfig.ChainConfig) error {
 	if c.QuorumNumerator > params.WarpQuorumDenominator {
 		return fmt.Errorf("cannot specify quorum numerator (%d) > quorum denominator (%d)", c.QuorumNumerator, params.WarpQuorumDenominator)
 	}

--- a/x/warp/config_test.go
+++ b/x/warp/config_test.go
@@ -9,102 +9,70 @@ import (
 
 	"github.com/ava-labs/subnet-evm/params"
 	"github.com/ava-labs/subnet-evm/precompile/precompileconfig"
+	"github.com/ava-labs/subnet-evm/precompile/testutils"
 	"github.com/ava-labs/subnet-evm/utils"
-	"github.com/stretchr/testify/require"
 )
 
-func TestVerifyWarpconfig(t *testing.T) {
-	tests := []struct {
-		name          string
-		config        precompileconfig.Config
-		ExpectedError string
-	}{
-		{
-			name:          "quorum numerator less than minimum",
-			config:        NewConfig(utils.NewUint64(3), params.WarpQuorumNumeratorMinimum-1),
+func TestVerify(t *testing.T) {
+	tests := map[string]testutils.ConfigVerifyTest{
+		"quorum numerator less than minimum": {
+			Config:        NewConfig(utils.NewUint64(3), params.WarpQuorumNumeratorMinimum-1),
 			ExpectedError: fmt.Sprintf("cannot specify quorum numerator (%d) < min quorum numerator (%d)", params.WarpQuorumNumeratorMinimum-1, params.WarpQuorumNumeratorMinimum),
 		},
-		{
-			name:          "quorum numerator greater than quorum denominator",
-			config:        NewConfig(utils.NewUint64(3), params.WarpQuorumDenominator+1),
+		"quorum numerator greater than quorum denominator": {
+			Config:        NewConfig(utils.NewUint64(3), params.WarpQuorumDenominator+1),
 			ExpectedError: fmt.Sprintf("cannot specify quorum numerator (%d) > quorum denominator (%d)", params.WarpQuorumDenominator+1, params.WarpQuorumDenominator),
 		},
-		{
-			name:   "default quorum numerator",
-			config: NewDefaultConfig(utils.NewUint64(3)),
+		"default quorum numerator": {
+			Config: NewDefaultConfig(utils.NewUint64(3)),
 		},
-		{
-			name:   "valid quorum numerator 1 less than denominator",
-			config: NewConfig(utils.NewUint64(3), params.WarpQuorumDenominator-1),
+		"valid quorum numerator 1 less than denominator": {
+			Config: NewConfig(utils.NewUint64(3), params.WarpQuorumDenominator-1),
 		},
-		{
-			name:   "valid quorum numerator 1 more than minimum",
-			config: NewConfig(utils.NewUint64(3), params.WarpQuorumNumeratorMinimum+1),
+		"valid quorum numerator 1 more than minimum": {
+			Config: NewConfig(utils.NewUint64(3), params.WarpQuorumNumeratorMinimum+1),
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require := require.New(t)
-
-			err := tt.config.Verify()
-			if tt.ExpectedError == "" {
-				require.NoError(err)
-			} else {
-				require.ErrorContains(err, tt.ExpectedError)
-			}
-		})
-	}
+	testutils.RunVerifyTests(t, tests)
 }
 
 func TestEqualWarpConfig(t *testing.T) {
-	tests := []struct {
-		name     string
-		config   precompileconfig.Config
-		other    precompileconfig.Config
-		expected bool
-	}{
-		{
-			name:     "non-nil config and nil other",
-			config:   NewDefaultConfig(utils.NewUint64(3)),
-			other:    nil,
-			expected: false,
+	tests := map[string]testutils.ConfigEqualTest{
+		"non-nil config and nil other": {
+			Config:   NewDefaultConfig(utils.NewUint64(3)),
+			Other:    nil,
+			Expected: false,
 		},
-		{
-			name:     "different type",
-			config:   NewDefaultConfig(utils.NewUint64(3)),
-			other:    precompileconfig.NewNoopStatefulPrecompileConfig(),
-			expected: false,
-		},
-		{
-			name:     "different timestamp",
-			config:   NewDefaultConfig(utils.NewUint64(3)),
-			other:    NewDefaultConfig(utils.NewUint64(4)),
-			expected: false,
-		},
-		{
-			name:     "different quorum numerator",
-			config:   NewConfig(utils.NewUint64(3), params.WarpQuorumNumeratorMinimum+1),
-			other:    NewConfig(utils.NewUint64(3), params.WarpQuorumNumeratorMinimum+2),
-			expected: false,
-		},
-		{
-			name:     "same default config",
-			config:   NewDefaultConfig(utils.NewUint64(3)),
-			other:    NewDefaultConfig(utils.NewUint64(3)),
-			expected: true,
-		},
-		{
-			name:     "same non-default config",
-			config:   NewConfig(utils.NewUint64(3), params.WarpQuorumNumeratorMinimum+5),
-			other:    NewConfig(utils.NewUint64(3), params.WarpQuorumNumeratorMinimum+5),
-			expected: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require := require.New(t)
 
-			require.Equal(tt.expected, tt.config.Equal(tt.other))
-		})
+		"different type": {
+			Config:   NewDefaultConfig(utils.NewUint64(3)),
+			Other:    precompileconfig.NewNoopStatefulPrecompileConfig(),
+			Expected: false,
+		},
+
+		"different timestamp": {
+			Config:   NewDefaultConfig(utils.NewUint64(3)),
+			Other:    NewDefaultConfig(utils.NewUint64(4)),
+			Expected: false,
+		},
+
+		"different quorum numerator": {
+			Config:   NewConfig(utils.NewUint64(3), params.WarpQuorumNumeratorMinimum+1),
+			Other:    NewConfig(utils.NewUint64(3), params.WarpQuorumNumeratorMinimum+2),
+			Expected: false,
+		},
+
+		"same default config": {
+			Config:   NewDefaultConfig(utils.NewUint64(3)),
+			Other:    NewDefaultConfig(utils.NewUint64(3)),
+			Expected: true,
+		},
+
+		"same non-default config": {
+			Config:   NewConfig(utils.NewUint64(3), params.WarpQuorumNumeratorMinimum+5),
+			Other:    NewConfig(utils.NewUint64(3), params.WarpQuorumNumeratorMinimum+5),
+			Expected: true,
+		},
 	}
+	testutils.RunEqualTests(t, tests)
 }

--- a/x/warp/module.go
+++ b/x/warp/module.go
@@ -47,7 +47,7 @@ func (*configurator) MakeConfig() precompileconfig.Config {
 }
 
 // Configure is a no-op for warp since it does not need to store any information in the state
-func (*configurator) Configure(chainConfig contract.ChainConfig, cfg precompileconfig.Config, state contract.StateDB, _ contract.BlockContext) error {
+func (*configurator) Configure(chainConfig precompileconfig.ChainConfig, cfg precompileconfig.Config, state contract.StateDB, _ contract.BlockContext) error {
 	config, ok := cfg.(*Config)
 	if !ok {
 		return fmt.Errorf("incorrect config %T: %v", config, config)


### PR DESCRIPTION
## Why this should be merged

Takes chainconfig to verify as a parameter so that custom verification depending on chain config (like network upgrades) can be done.
