### PR TITLE
add activation func to precompile functions

### DIFF
--- a/precompile/contract/contract.go
+++ b/precompile/contract/contract.go
@@ -16,7 +16,7 @@ const (
 type RunStatefulPrecompileFunc func(accessibleState AccessibleState, caller common.Address, addr common.Address, input []byte, suppliedGas uint64, readOnly bool) (ret []byte, remainingGas uint64, err error)
 
 // ActivationFunc defines a function that is used to determine if a function is active
-// The first return value is whether or not the function is active
+// The return value is whether or not the function is active
 type ActivationFunc func(AccessibleState) bool
 
 // StatefulPrecompileFunction defines a function implemented by a stateful precompile

--- a/precompile/contract/contract.go
+++ b/precompile/contract/contract.go
@@ -98,12 +98,12 @@ func (s *statefulPrecompileWithFunctionSelectors) Run(accessibleState Accessible
 	functionInput := input[SelectorLen:]
 	function, ok := s.functions[string(selector)]
 	if !ok {
-		return nil, suppliedGas, InvalidFunctionErr(selector)
+		return nil, suppliedGas, fmt.Errorf("invalid function selector %#x", selector)
 	}
 
 	// Check if the function is activated
 	if !function.IsActivated(accessibleState) {
-		return nil, suppliedGas, InvalidFunctionErr(selector)
+		return nil, suppliedGas, fmt.Errorf("invalid non-activated function selector %#x", selector)
 	}
 
 	return function.execute(accessibleState, caller, addr, functionInput, suppliedGas, readOnly)

--- a/precompile/contract/contract.go
+++ b/precompile/contract/contract.go
@@ -17,7 +17,7 @@ type RunStatefulPrecompileFunc func(accessibleState AccessibleState, caller comm
 
 // ActivationFunc defines a function that is used to determine if a function is active
 // The first return value is whether or not the function is active
-type ActivationFunc func(AccessibleState) (bool, error)
+type ActivationFunc func(AccessibleState) bool
 
 // StatefulPrecompileFunction defines a function implemented by a stateful precompile
 type StatefulPrecompileFunction struct {
@@ -30,9 +30,9 @@ type StatefulPrecompileFunction struct {
 	activation ActivationFunc
 }
 
-func (f *StatefulPrecompileFunction) IsActivated(accessibleState AccessibleState) (bool, error) {
+func (f *StatefulPrecompileFunction) IsActivated(accessibleState AccessibleState) bool {
 	if f.activation == nil {
-		return true, nil
+		return true
 	}
 	return f.activation(accessibleState)
 }
@@ -102,11 +102,7 @@ func (s *statefulPrecompileWithFunctionSelectors) Run(accessibleState Accessible
 	}
 
 	// Check if the function is activated
-	activated, err := function.IsActivated(accessibleState)
-	if err != nil {
-		return nil, suppliedGas, err
-	}
-	if !activated {
+	if !function.IsActivated(accessibleState) {
 		return nil, suppliedGas, InvalidFunctionErr(selector)
 	}
 

--- a/precompile/contract/utils.go
+++ b/precompile/contract/utils.go
@@ -88,7 +88,3 @@ func ParseABI(rawABI string) abi.ABI {
 
 	return parsed
 }
-
-func InvalidFunctionErr(selector []byte) error {
-	return fmt.Errorf("invalid function selector %#x", selector)
-}

--- a/precompile/contract/utils.go
+++ b/precompile/contract/utils.go
@@ -88,3 +88,7 @@ func ParseABI(rawABI string) abi.ABI {
 
 	return parsed
 }
+
+func InvalidFunctionErr(selector []byte) error {
+	return fmt.Errorf("invalid function selector %#x", selector)
+}


### PR DESCRIPTION
## Why this should be merged

Adds activation function to precompile functions. Activation Functions denotes that if the underlying precompile function has been activated or not.
If not activated it returns "signature not found" as if this function never exists.

## How this works

Changes new precompile function constructor 

## How this was tested

WIll be tested with manager role


