### PR TITLE
warp/aggregator: improve logs/error for signature aggregator

### DIFF
--- a/warp/aggregator/aggregation_job.go
+++ b/warp/aggregator/aggregation_job.go
@@ -65,9 +65,13 @@ func newSignatureAggregationJob(
 
 // Execute aggregates signatures for the requested message
 func (a *signatureAggregationJob) Execute(ctx context.Context) (*AggregateSignatureResult, error) {
+	log.Info("Fetching signature", "subnetID", a.subnetID, "height", a.height)
 	validators, totalWeight, err := avalancheWarp.GetCanonicalValidatorSet(ctx, a.state, a.height, a.subnetID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get validator set: %w", err)
+	}
+	if len(validators) == 0 {
+		return nil, fmt.Errorf("cannot aggregate signatures from subnet with no validators (SubnetID: %s, Height: %d)", a.subnetID, a.height)
 	}
 	signatureJobs := make([]*signatureJob, 0, len(validators))
 	for _, validator := range validators {


### PR DESCRIPTION
## Why this should be merged

- logs the subnetID and height at the start of a signature aggregation job
- adds an improved error when there are no validators to aggregate a signature from

This is in response to an unhelpful error reported in https://github.com/ava-labs/subnet-evm/issues/806

## How this was tested

CI

## How is this documented

na