### PR TITLE
Align on a single predicate type

### DIFF
--- a/core/predicate_check.go
+++ b/core/predicate_check.go
@@ -14,7 +14,7 @@ import (
 )
 
 // CheckPredicates checks that all precompile predicates are satisfied within the current [predicateContext] for [tx]
-func CheckPredicates(rules params.Rules, predicateContext *precompileconfig.ProposerPredicateContext, tx *types.Transaction) error {
+func CheckPredicates(rules params.Rules, predicateContext *precompileconfig.PredicateContext, tx *types.Transaction) error {
 	// Check that the transaction can cover its IntrinsicGas (including the gas required by the predicate) before
 	// verifying the predicate.
 	intrinsicGas, err := IntrinsicGas(tx.Data(), tx.AccessList(), tx.To() == nil, rules)
@@ -24,46 +24,15 @@ func CheckPredicates(rules params.Rules, predicateContext *precompileconfig.Prop
 	if tx.Gas() < intrinsicGas {
 		return fmt.Errorf("insufficient gas for predicate verification (%d) < intrinsic gas (%d)", tx.Gas(), intrinsicGas)
 	}
-	if err := checkPrecompilePredicates(rules, &predicateContext.PrecompilePredicateContext, tx); err != nil {
-		return err
-	}
-	return checkProposerPrecompilePredicates(rules, predicateContext, tx)
+	return checkPrecompilePredicates(rules, predicateContext, tx)
 }
 
-func checkPrecompilePredicates(rules params.Rules, predicateContext *precompileconfig.PrecompilePredicateContext, tx *types.Transaction) error {
+func checkPrecompilePredicates(rules params.Rules, predicateContext *precompileconfig.PredicateContext, tx *types.Transaction) error {
 	// Short circuit early if there are no precompile predicates to verify
-	if len(rules.PredicatePrecompiles) == 0 {
+	if len(rules.Predicates) == 0 {
 		return nil
 	}
-	precompilePredicates := rules.PredicatePrecompiles
-	// Track addresses that we've performed a predicate check for
-	precompileAddressChecks := make(map[common.Address]struct{})
-	for _, accessTuple := range tx.AccessList() {
-		address := accessTuple.Address
-		predicater, ok := precompilePredicates[address]
-		if !ok {
-			continue
-		}
-		// Return an error if we've already checked a predicate for this address
-		if _, ok := precompileAddressChecks[address]; ok {
-			return fmt.Errorf("predicate %s failed verification for tx %s: specified %s in access list multiple times", address, tx.Hash(), address)
-		}
-		precompileAddressChecks[address] = struct{}{}
-		predicateBytes := predicateutils.HashSliceToBytes(accessTuple.StorageKeys)
-		if err := predicater.VerifyPredicate(predicateContext, predicateBytes); err != nil {
-			return fmt.Errorf("predicate %s failed verification for tx %s: %w", address, tx.Hash(), err)
-		}
-	}
-
-	return nil
-}
-
-func checkProposerPrecompilePredicates(rules params.Rules, predicateContext *precompileconfig.ProposerPredicateContext, tx *types.Transaction) error {
-	// Short circuit early if there are no precompile predicates to verify
-	if len(rules.ProposerPredicates) == 0 {
-		return nil
-	}
-	precompilePredicates := rules.ProposerPredicates
+	precompilePredicates := rules.Predicates
 	// Track addresses that we've performed a predicate check for
 	precompileAddressChecks := make(map[common.Address]struct{})
 	for _, accessTuple := range tx.AccessList() {

--- a/core/predicate_check_test.go
+++ b/core/predicate_check_test.go
@@ -16,17 +16,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var (
-	_ precompileconfig.PrecompilePredicater = (*mockPredicater)(nil)
-	_ precompileconfig.ProposerPredicater   = (*mockProposerPredicater)(nil)
-)
+var _ precompileconfig.Predicater = (*mockPredicater)(nil)
 
 type mockPredicater struct {
-	predicateFunc    func(*precompileconfig.PrecompilePredicateContext, []byte) error
+	predicateFunc    func(*precompileconfig.PredicateContext, []byte) error
 	predicateGasFunc func([]byte) (uint64, error)
 }
 
-func (m *mockPredicater) VerifyPredicate(predicateContext *precompileconfig.PrecompilePredicateContext, b []byte) error {
+func (m *mockPredicater) VerifyPredicate(predicateContext *precompileconfig.PredicateContext, b []byte) error {
 	return m.predicateFunc(predicateContext, b)
 }
 
@@ -37,26 +34,9 @@ func (m *mockPredicater) PredicateGas(b []byte) (uint64, error) {
 	return m.predicateGasFunc(b)
 }
 
-type mockProposerPredicater struct {
-	predicateFunc    func(*precompileconfig.ProposerPredicateContext, []byte) error
-	predicateGasFunc func([]byte) (uint64, error)
-}
-
-func (m *mockProposerPredicater) VerifyPredicate(predicateContext *precompileconfig.ProposerPredicateContext, b []byte) error {
-	return m.predicateFunc(predicateContext, b)
-}
-
-func (m *mockProposerPredicater) PredicateGas(b []byte) (uint64, error) {
-	if m.predicateGasFunc == nil {
-		return 0, nil
-	}
-	return m.predicateGasFunc(b)
-}
-
 type predicateCheckTest struct {
 	address               common.Address
-	predicater            precompileconfig.PrecompilePredicater
-	proposerPredicater    precompileconfig.ProposerPredicater
+	predicater            precompileconfig.Predicater
 	accessList            types.AccessList
 	gas                   uint64
 	emptyProposerBlockCtx bool
@@ -81,23 +61,17 @@ func TestCheckPredicate(t *testing.T) {
 			}),
 			expectedErr: nil,
 		},
-		"proposer predicate, no access list passes": {
-			address:            common.HexToAddress("0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC"),
-			gas:                53000,
-			proposerPredicater: &mockProposerPredicater{predicateFunc: func(*precompileconfig.ProposerPredicateContext, []byte) error { return nil }},
-			expectedErr:        nil,
-		},
 		"predicate, no access list passes": {
 			address:     common.HexToAddress("0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC"),
 			gas:         53000,
-			predicater:  &mockPredicater{predicateFunc: func(*precompileconfig.PrecompilePredicateContext, []byte) error { return nil }},
+			predicater:  &mockPredicater{predicateFunc: func(*precompileconfig.PredicateContext, []byte) error { return nil }},
 			expectedErr: nil,
 		},
 		"predicate with valid access list passes": {
 			address: common.HexToAddress("0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC"),
 			gas:     53000,
 			predicater: &mockPredicater{
-				predicateFunc: func(_ *precompileconfig.PrecompilePredicateContext, b []byte) error {
+				predicateFunc: func(_ *precompileconfig.PredicateContext, b []byte) error {
 					if !bytes.Equal(b, common.Hash{1}.Bytes()) {
 						return fmt.Errorf("unexpected bytes: 0x%x", b)
 					}
@@ -118,52 +92,7 @@ func TestCheckPredicate(t *testing.T) {
 			address: common.HexToAddress("0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC"),
 			gas:     153000,
 			predicater: &mockPredicater{
-				predicateFunc: func(_ *precompileconfig.PrecompilePredicateContext, b []byte) error {
-					if !bytes.Equal(b, common.Hash{1}.Bytes()) {
-						return fmt.Errorf("unexpected bytes: 0x%x", b)
-					}
-					return nil
-				},
-				predicateGasFunc: func(b []byte) (uint64, error) {
-					return 100_000, nil
-				},
-			},
-			accessList: types.AccessList([]types.AccessTuple{
-				{
-					Address: common.HexToAddress("0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC"),
-					StorageKeys: []common.Hash{
-						{1},
-					},
-				},
-			}),
-			expectedErr: nil,
-		},
-		"proposer predicate with valid access list passes": {
-			address: common.HexToAddress("0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC"),
-			gas:     53000,
-			proposerPredicater: &mockProposerPredicater{
-				predicateFunc: func(_ *precompileconfig.ProposerPredicateContext, b []byte) error {
-					if !bytes.Equal(b, common.Hash{1}.Bytes()) {
-						return fmt.Errorf("unexpected bytes: 0x%x", b)
-					}
-					return nil
-				},
-			},
-			accessList: types.AccessList([]types.AccessTuple{
-				{
-					Address: common.HexToAddress("0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC"),
-					StorageKeys: []common.Hash{
-						{1},
-					},
-				},
-			}),
-			expectedErr: nil,
-		},
-		"proposer predicate with valid access list and non-empty PredicateGas passes": {
-			address: common.HexToAddress("0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC"),
-			gas:     153000,
-			proposerPredicater: &mockProposerPredicater{
-				predicateFunc: func(_ *precompileconfig.ProposerPredicateContext, b []byte) error {
+				predicateFunc: func(_ *precompileconfig.PredicateContext, b []byte) error {
 					if !bytes.Equal(b, common.Hash{1}.Bytes()) {
 						return fmt.Errorf("unexpected bytes: 0x%x", b)
 					}
@@ -187,7 +116,7 @@ func TestCheckPredicate(t *testing.T) {
 			address: common.HexToAddress("0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC"),
 			gas:     53000,
 			predicater: &mockPredicater{
-				predicateFunc: func(_ *precompileconfig.PrecompilePredicateContext, b []byte) error {
+				predicateFunc: func(_ *precompileconfig.PredicateContext, b []byte) error {
 					if !bytes.Equal(b, common.Hash{1}.Bytes()) {
 						return fmt.Errorf("unexpected bytes: 0x%x", b)
 					}
@@ -203,33 +132,6 @@ func TestCheckPredicate(t *testing.T) {
 				},
 			}),
 			expectedErr: fmt.Errorf("unexpected bytes: 0x%x", common.Hash{2}.Bytes()),
-		},
-		"proposer predicate with invalid access list errors": {
-			address: common.HexToAddress("0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC"),
-			gas:     53000,
-			proposerPredicater: &mockProposerPredicater{
-				predicateFunc: func(_ *precompileconfig.ProposerPredicateContext, b []byte) error {
-					if !bytes.Equal(b, common.Hash{1}.Bytes()) {
-						return fmt.Errorf("unexpected bytes: 0x%x", b)
-					}
-					return nil
-				},
-			},
-			accessList: types.AccessList([]types.AccessTuple{
-				{
-					Address: common.HexToAddress("0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC"),
-					StorageKeys: []common.Hash{
-						{2},
-					},
-				},
-			}),
-			expectedErr: fmt.Errorf("unexpected bytes: 0x%x", common.Hash{2}.Bytes()),
-		},
-		"proposer predicate with empty proposer block ctx passes": {
-			address:               common.HexToAddress("0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC"),
-			gas:                   53000,
-			proposerPredicater:    &mockProposerPredicater{predicateFunc: func(_ *precompileconfig.ProposerPredicateContext, b []byte) error { return nil }},
-			emptyProposerBlockCtx: true,
 		},
 	} {
 		test := test
@@ -237,11 +139,8 @@ func TestCheckPredicate(t *testing.T) {
 			require := require.New(t)
 			// Create the rules from TestChainConfig and update the predicates based on the test params
 			rules := params.TestChainConfig.AvalancheRules(common.Big0, 0)
-			if test.proposerPredicater != nil {
-				rules.ProposerPredicates[test.address] = test.proposerPredicater
-			}
 			if test.predicater != nil {
-				rules.PredicatePrecompiles[test.address] = test.predicater
+				rules.Predicates[test.address] = test.predicater
 			}
 
 			// Specify only the access list, since this test should not depend on any other values
@@ -249,7 +148,7 @@ func TestCheckPredicate(t *testing.T) {
 				AccessList: test.accessList,
 				Gas:        test.gas,
 			})
-			predicateContext := &precompileconfig.ProposerPredicateContext{}
+			predicateContext := &precompileconfig.PredicateContext{}
 			if !test.emptyProposerBlockCtx {
 				predicateContext.ProposerVMBlockCtx = &block.Context{}
 			}

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -64,7 +64,7 @@ func (miner *Miner) SetEtherbase(addr common.Address) {
 	miner.worker.setEtherbase(addr)
 }
 
-func (miner *Miner) GenerateBlock(predicateContext *precompileconfig.ProposerPredicateContext) (*types.Block, error) {
+func (miner *Miner) GenerateBlock(predicateContext *precompileconfig.PredicateContext) (*types.Block, error) {
 	return miner.worker.commitNewWork(predicateContext)
 }
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -69,7 +69,7 @@ type environment struct {
 	size     uint64
 
 	rules            params.Rules
-	predicateContext *precompileconfig.ProposerPredicateContext
+	predicateContext *precompileconfig.PredicateContext
 
 	start time.Time // Time that block building began
 }
@@ -117,7 +117,7 @@ func (w *worker) setEtherbase(addr common.Address) {
 }
 
 // commitNewWork generates several new sealing tasks based on the parent block.
-func (w *worker) commitNewWork(predicateContext *precompileconfig.ProposerPredicateContext) (*types.Block, error) {
+func (w *worker) commitNewWork(predicateContext *precompileconfig.PredicateContext) (*types.Block, error) {
 	w.mu.RLock()
 	defer w.mu.RUnlock()
 
@@ -219,7 +219,7 @@ func (w *worker) commitNewWork(predicateContext *precompileconfig.ProposerPredic
 	return w.commit(env)
 }
 
-func (w *worker) createCurrentEnvironment(predicateContext *precompileconfig.ProposerPredicateContext, parent *types.Header, header *types.Header, tstart time.Time) (*environment, error) {
+func (w *worker) createCurrentEnvironment(predicateContext *precompileconfig.PredicateContext, parent *types.Header, header *types.Header, tstart time.Time) (*environment, error) {
 	state, err := w.chain.StateAt(parent.Root)
 	if err != nil {
 		return nil, err

--- a/plugin/evm/block.go
+++ b/plugin/evm/block.go
@@ -171,17 +171,15 @@ func (b *Block) syntacticVerify() error {
 
 // Verify implements the snowman.Block interface
 func (b *Block) Verify(context.Context) error {
-	return b.verify(&precompileconfig.ProposerPredicateContext{
-		PrecompilePredicateContext: precompileconfig.PrecompilePredicateContext{
-			SnowCtx: b.vm.ctx,
-		},
+	return b.verify(&precompileconfig.PredicateContext{
+		SnowCtx:            b.vm.ctx,
 		ProposerVMBlockCtx: nil,
 	}, true)
 }
 
 // ShouldVerifyWithContext implements the block.WithVerifyContext interface
 func (b *Block) ShouldVerifyWithContext(context.Context) (bool, error) {
-	proposerPredicates := b.vm.chainConfig.AvalancheRules(b.ethBlock.Number(), b.ethBlock.Timestamp()).ProposerPredicates
+	proposerPredicates := b.vm.chainConfig.AvalancheRules(b.ethBlock.Number(), b.ethBlock.Timestamp()).Predicates
 	// Short circuit early if there are no proposer predicates to verify
 	if len(proposerPredicates) == 0 {
 		return false, nil
@@ -204,10 +202,8 @@ func (b *Block) ShouldVerifyWithContext(context.Context) (bool, error) {
 
 // VerifyWithContext implements the block.WithVerifyContext interface
 func (b *Block) VerifyWithContext(ctx context.Context, proposerVMBlockCtx *block.Context) error {
-	return b.verify(&precompileconfig.ProposerPredicateContext{
-		PrecompilePredicateContext: precompileconfig.PrecompilePredicateContext{
-			SnowCtx: b.vm.ctx,
-		},
+	return b.verify(&precompileconfig.PredicateContext{
+		SnowCtx:            b.vm.ctx,
 		ProposerVMBlockCtx: proposerVMBlockCtx,
 	}, true)
 }
@@ -215,7 +211,7 @@ func (b *Block) VerifyWithContext(ctx context.Context, proposerVMBlockCtx *block
 // Verify the block is valid.
 // Enforces that the predicates are valid within [predicateContext].
 // Writes the block details to disk and the state to the trie manager iff writes=true.
-func (b *Block) verify(predicateContext *precompileconfig.ProposerPredicateContext, writes bool) error {
+func (b *Block) verify(predicateContext *precompileconfig.PredicateContext, writes bool) error {
 	if predicateContext.ProposerVMBlockCtx != nil {
 		log.Debug("Verifying block with context", "block", b.ID(), "height", b.Height())
 	} else {
@@ -248,7 +244,7 @@ func (b *Block) verify(predicateContext *precompileconfig.ProposerPredicateConte
 }
 
 // verifyPredicates verifies the predicates in the block are valid according to predicateContext.
-func (b *Block) verifyPredicates(predicateContext *precompileconfig.ProposerPredicateContext) error {
+func (b *Block) verifyPredicates(predicateContext *precompileconfig.PredicateContext) error {
 	rules := b.vm.chainConfig.AvalancheRules(b.ethBlock.Number(), b.ethBlock.Timestamp())
 
 	for _, tx := range b.ethBlock.Transactions() {

--- a/plugin/evm/block.go
+++ b/plugin/evm/block.go
@@ -179,9 +179,9 @@ func (b *Block) Verify(context.Context) error {
 
 // ShouldVerifyWithContext implements the block.WithVerifyContext interface
 func (b *Block) ShouldVerifyWithContext(context.Context) (bool, error) {
-	proposerPredicates := b.vm.chainConfig.AvalancheRules(b.ethBlock.Number(), b.ethBlock.Timestamp()).Predicates
-	// Short circuit early if there are no proposer predicates to verify
-	if len(proposerPredicates) == 0 {
+	predicates := b.vm.chainConfig.AvalancheRules(b.ethBlock.Number(), b.ethBlock.Timestamp()).Predicates
+	// Short circuit early if there are no predicates to verify
+	if len(predicates) == 0 {
 		return false, nil
 	}
 
@@ -189,7 +189,7 @@ func (b *Block) ShouldVerifyWithContext(context.Context) (bool, error) {
 	// the ProposerVMBlockCtx.
 	for _, tx := range b.ethBlock.Transactions() {
 		for _, accessTuple := range tx.AccessList() {
-			if _, ok := proposerPredicates[accessTuple.Address]; ok {
+			if _, ok := predicates[accessTuple.Address]; ok {
 				log.Debug("Block verification requires proposerVM context", "block", b.ID(), "height", b.Height())
 				return true, nil
 			}

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -665,10 +665,8 @@ func (vm *VM) buildBlockWithContext(ctx context.Context, proposerVMBlockCtx *blo
 	} else {
 		log.Debug("Building block without context")
 	}
-	predicateCtx := &precompileconfig.ProposerPredicateContext{
-		PrecompilePredicateContext: precompileconfig.PrecompilePredicateContext{
-			SnowCtx: vm.ctx,
-		},
+	predicateCtx := &precompileconfig.PredicateContext{
+		SnowCtx:            vm.ctx,
 		ProposerVMBlockCtx: proposerVMBlockCtx,
 	}
 

--- a/precompile/contract/interfaces.go
+++ b/precompile/contract/interfaces.go
@@ -51,8 +51,7 @@ type AccessibleState interface {
 	GetSnowContext() *snow.Context
 }
 
-// BlockContext defines an interface that provides information to a stateful precompile about the
-// current block. The BlockContext may be provided during both precompile activation and execution.
+// BlockContext defines the interface required to configure a precompile.
 type BlockContext interface {
 	Number() *big.Int
 	Timestamp() uint64

--- a/precompile/contract/interfaces.go
+++ b/precompile/contract/interfaces.go
@@ -51,7 +51,8 @@ type AccessibleState interface {
 	GetSnowContext() *snow.Context
 }
 
-// BlockContext defines the interface required to configure a precompile.
+// BlockContext defines an interface that provides information to a stateful precompile about the
+// current block. The BlockContext may be provided during both precompile activation and execution.
 type BlockContext interface {
 	Number() *big.Int
 	Timestamp() uint64

--- a/precompile/precompileconfig/config.go
+++ b/precompile/precompileconfig/config.go
@@ -46,6 +46,8 @@ type Predicater interface {
 
 // PredicateContext is the context passed in to the Predicater interface to verify
 // a precompile predicate within a specific ProposerVM header.
+// If the block is not verified within a ProposerVM header, then ProposerVMBlockCtx
+// may be nil.
 type PredicateContext struct {
 	SnowCtx *snow.Context
 	// ProposerVMBlockCtx defines the ProposerVM context the predicate is verified within

--- a/precompile/precompileconfig/config.go
+++ b/precompile/precompileconfig/config.go
@@ -32,44 +32,24 @@ type Config interface {
 	Verify(ChainConfig) error
 }
 
-// PrecompilePredicateContext is the context passed in to the PrecompilePredicater interface.
-type PrecompilePredicateContext struct {
-	SnowCtx *snow.Context
-}
-
-// PrecompilePredicater is an optional interface for StatefulPrecompileContracts to implement.
+// Predicater is an optional interface for StatefulPrecompileContracts to implement.
 // If implemented, the predicate will be enforced on every transaction in a block, prior to
 // the block's execution.
 // If VerifyPredicate returns an error, the block will fail verification with no further processing.
 // WARNING: If you are implementing a custom precompile, beware that subnet-evm
 // will not maintain backwards compatibility of this interface and your code should not
 // rely on this. Designed for use only by precompiles that ship with subnet-evm.
-type PrecompilePredicater interface {
+type Predicater interface {
 	PredicateGas(storageSlots []byte) (uint64, error)
-	VerifyPredicate(predicateContext *PrecompilePredicateContext, storageSlots []byte) error
+	VerifyPredicate(predicateContext *PredicateContext, storageSlots []byte) error
 }
 
-// ProposerPredicateContext is the context passed in to the ProposerPredicater interface to verify
-// a precompile predicate within a specific ProposerVM wrapper.
-type ProposerPredicateContext struct {
-	PrecompilePredicateContext
+// PredicateContext is the context passed in to the Predicater interface to verify
+// a precompile predicate within a specific ProposerVM header.
+type PredicateContext struct {
+	SnowCtx *snow.Context
 	// ProposerVMBlockCtx defines the ProposerVM context the predicate is verified within
 	ProposerVMBlockCtx *block.Context
-}
-
-// ProposerPredicater is an optional interface for StatefulPrecompiledContracts to implement.
-// If implemented, the predicate will be enforced on every transaction in a block, prior to
-// the block's execution.
-// If VerifyPredicate returns an error, the block will fail verification with no further processing.
-// Note: ProposerVMBlockCtx is guaranteed to be non-nil.
-// Precompiles should use ProposerPredicater instead of PrecompilePredicater iff their execution
-// depends on the ProposerVM Block Context.
-// WARNING: If you are implementing a custom precompile, beware that subnet-evm
-// will not maintain backwards compatibility of this interface and your code should not
-// rely on this. Designed for use only by precompiles that ship with subnet-evm.
-type ProposerPredicater interface {
-	PredicateGas(storageSlots []byte) (uint64, error)
-	VerifyPredicate(proposerPredicateContext *ProposerPredicateContext, storageSlots []byte) error
 }
 
 // SharedMemoryWriter defines an interface to allow a precompile's Accepter to write operations

--- a/precompile/testutils/test_predicate.go
+++ b/precompile/testutils/test_predicate.go
@@ -15,7 +15,7 @@ import (
 type PredicateTest struct {
 	Config precompileconfig.Config
 
-	ProposerPredicateContext *precompileconfig.ProposerPredicateContext
+	PredicateContext *precompileconfig.PredicateContext
 
 	StorageSlots         []byte
 	Gas                  uint64
@@ -29,7 +29,7 @@ func (test PredicateTest) Run(t testing.TB) {
 	var (
 		gas                  uint64
 		gasErr, predicateErr error
-		predicate            = test.Config.(precompileconfig.ProposerPredicater)
+		predicate            = test.Config.(precompileconfig.Predicater)
 	)
 
 	gas, gasErr = predicate.PredicateGas(test.StorageSlots)
@@ -43,7 +43,7 @@ func (test PredicateTest) Run(t testing.TB) {
 	}
 	require.Equal(test.Gas, gas)
 
-	predicateErr = predicate.VerifyPredicate(test.ProposerPredicateContext, test.StorageSlots)
+	predicateErr = predicate.VerifyPredicate(test.PredicateContext, test.StorageSlots)
 	if test.PredicateErr == nil {
 		require.NoError(predicateErr)
 	} else {

--- a/x/warp/config.go
+++ b/x/warp/config.go
@@ -20,9 +20,9 @@ import (
 )
 
 var (
-	_ precompileconfig.Config             = &Config{}
-	_ precompileconfig.ProposerPredicater = &Config{}
-	_ precompileconfig.Accepter           = &Config{}
+	_ precompileconfig.Config     = &Config{}
+	_ precompileconfig.Predicater = &Config{}
+	_ precompileconfig.Accepter   = &Config{}
 )
 
 var (
@@ -108,7 +108,7 @@ func (c *Config) Accept(acceptCtx *precompileconfig.AcceptContext, txHash common
 
 // verifyWarpMessage checks that [warpMsg] can be parsed as an addressed payload and verifies the Warp Message Signature
 // within [predicateContext].
-func (c *Config) verifyWarpMessage(predicateContext *precompileconfig.ProposerPredicateContext, warpMsg *warp.Message) error {
+func (c *Config) verifyWarpMessage(predicateContext *precompileconfig.PredicateContext, warpMsg *warp.Message) error {
 	// Use default quorum numerator unless config specifies a non-default option
 	quorumNumerator := params.WarpDefaultQuorumNumerator
 	if c.QuorumNumerator != 0 {
@@ -199,7 +199,7 @@ func (c *Config) PredicateGas(predicateBytes []byte) (uint64, error) {
 }
 
 // VerifyPredicate verifies the predicate represents a valid signed and properly formatted Avalanche Warp Message.
-func (c *Config) VerifyPredicate(predicateContext *precompileconfig.ProposerPredicateContext, predicateBytes []byte) error {
+func (c *Config) VerifyPredicate(predicateContext *precompileconfig.PredicateContext, predicateBytes []byte) error {
 	if predicateContext.ProposerVMBlockCtx == nil {
 		return errNoProposerCtxPredicate
 	}

--- a/x/warp/predicate_test.go
+++ b/x/warp/predicate_test.go
@@ -216,10 +216,8 @@ func createSnowCtx(validatorRanges []validatorRange) *snow.Context {
 func createValidPredicateTest(snowCtx *snow.Context, numKeys uint64, predicateBytes []byte) testutils.PredicateTest {
 	return testutils.PredicateTest{
 		Config: NewDefaultConfig(subnetEVMUtils.NewUint64(0)),
-		ProposerPredicateContext: &precompileconfig.ProposerPredicateContext{
-			PrecompilePredicateContext: precompileconfig.PrecompilePredicateContext{
-				SnowCtx: snowCtx,
-			},
+		PredicateContext: &precompileconfig.PredicateContext{
+			SnowCtx: snowCtx,
 			ProposerVMBlockCtx: &block.Context{
 				PChainHeight: 1,
 			},
@@ -243,10 +241,8 @@ func TestWarpNilProposerCtx(t *testing.T) {
 	predicateBytes := createPredicate(numKeys)
 	test := testutils.PredicateTest{
 		Config: NewDefaultConfig(subnetEVMUtils.NewUint64(0)),
-		ProposerPredicateContext: &precompileconfig.ProposerPredicateContext{
-			PrecompilePredicateContext: precompileconfig.PrecompilePredicateContext{
-				SnowCtx: snowCtx,
-			},
+		PredicateContext: &precompileconfig.PredicateContext{
+			SnowCtx:            snowCtx,
 			ProposerVMBlockCtx: nil,
 		},
 		StorageSlots: predicateBytes,
@@ -272,10 +268,8 @@ func TestInvalidPredicatePacking(t *testing.T) {
 
 	test := testutils.PredicateTest{
 		Config: NewDefaultConfig(subnetEVMUtils.NewUint64(0)),
-		ProposerPredicateContext: &precompileconfig.ProposerPredicateContext{
-			PrecompilePredicateContext: precompileconfig.PrecompilePredicateContext{
-				SnowCtx: snowCtx,
-			},
+		PredicateContext: &precompileconfig.PredicateContext{
+			SnowCtx: snowCtx,
 			ProposerVMBlockCtx: &block.Context{
 				PChainHeight: 1,
 			},
@@ -305,10 +299,8 @@ func TestInvalidWarpMessage(t *testing.T) {
 
 	test := testutils.PredicateTest{
 		Config: NewDefaultConfig(subnetEVMUtils.NewUint64(0)),
-		ProposerPredicateContext: &precompileconfig.ProposerPredicateContext{
-			PrecompilePredicateContext: precompileconfig.PrecompilePredicateContext{
-				SnowCtx: snowCtx,
-			},
+		PredicateContext: &precompileconfig.PredicateContext{
+			SnowCtx: snowCtx,
 			ProposerVMBlockCtx: &block.Context{
 				PChainHeight: 1,
 			},
@@ -351,10 +343,8 @@ func TestInvalidAddressedPayload(t *testing.T) {
 
 	test := testutils.PredicateTest{
 		Config: NewDefaultConfig(subnetEVMUtils.NewUint64(0)),
-		ProposerPredicateContext: &precompileconfig.ProposerPredicateContext{
-			PrecompilePredicateContext: precompileconfig.PrecompilePredicateContext{
-				SnowCtx: snowCtx,
-			},
+		PredicateContext: &precompileconfig.PredicateContext{
+			SnowCtx: snowCtx,
 			ProposerVMBlockCtx: &block.Context{
 				PChainHeight: 1,
 			},
@@ -396,10 +386,8 @@ func TestInvalidBitSet(t *testing.T) {
 	predicateBytes := predicateutils.PackPredicate(msg.Bytes())
 	test := testutils.PredicateTest{
 		Config: NewDefaultConfig(subnetEVMUtils.NewUint64(0)),
-		ProposerPredicateContext: &precompileconfig.ProposerPredicateContext{
-			PrecompilePredicateContext: precompileconfig.PrecompilePredicateContext{
-				SnowCtx: snowCtx,
-			},
+		PredicateContext: &precompileconfig.PredicateContext{
+			SnowCtx: snowCtx,
 			ProposerVMBlockCtx: &block.Context{
 				PChainHeight: 1,
 			},
@@ -446,10 +434,8 @@ func TestWarpSignatureWeightsDefaultQuorumNumerator(t *testing.T) {
 		}
 		tests[fmt.Sprintf("default quorum %d signature(s)", numSigners)] = testutils.PredicateTest{
 			Config: NewDefaultConfig(subnetEVMUtils.NewUint64(0)),
-			ProposerPredicateContext: &precompileconfig.ProposerPredicateContext{
-				PrecompilePredicateContext: precompileconfig.PrecompilePredicateContext{
-					SnowCtx: snowCtx,
-				},
+			PredicateContext: &precompileconfig.PredicateContext{
+				SnowCtx: snowCtx,
 				ProposerVMBlockCtx: &block.Context{
 					PChainHeight: 1,
 				},
@@ -493,10 +479,8 @@ func TestWarpSignatureWeightsNonDefaultQuorumNumerator(t *testing.T) {
 		name := fmt.Sprintf("non-default quorum %d signature(s)", numSigners)
 		tests[name] = testutils.PredicateTest{
 			Config: NewConfig(subnetEVMUtils.NewUint64(0), uint64(nonDefaultQuorumNumerator)),
-			ProposerPredicateContext: &precompileconfig.ProposerPredicateContext{
-				PrecompilePredicateContext: precompileconfig.PrecompilePredicateContext{
-					SnowCtx: snowCtx,
-				},
+			PredicateContext: &precompileconfig.PredicateContext{
+				SnowCtx: snowCtx,
 				ProposerVMBlockCtx: &block.Context{
 					PChainHeight: 1,
 				},


### PR DESCRIPTION
## Why this should be merged

This PR aligns precompile predicates on a single type instead of separating out into with/without the ProposerContext.

## How this works

as above

## How this was tested

CI

## How is this documented

na