### PR TITLE
precompile/precompileconfig: Add IsDUpgrade to precompileconfig ChainConfig interface

### DIFF
--- a/precompile/precompileconfig/config.go
+++ b/precompile/precompileconfig/config.go
@@ -88,4 +88,6 @@ type ChainConfig interface {
 	GetFeeConfig() commontype.FeeConfig
 	// AllowedFeeRecipients returns true if fee recipients are allowed in the genesis.
 	AllowedFeeRecipients() bool
+	// IsDUpgrade returns true if the time is after the DUpgrade.
+	IsDUpgrade(time uint64) bool
 }

--- a/precompile/precompileconfig/mocks.go
+++ b/precompile/precompileconfig/mocks.go
@@ -9,7 +9,7 @@ import (
 
 	commontype "github.com/ava-labs/subnet-evm/commontype"
 	common "github.com/ethereum/go-ethereum/common"
-	"go.uber.org/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockConfig is a mock of Config interface.
@@ -154,6 +154,20 @@ func (m *MockChainConfig) GetFeeConfig() commontype.FeeConfig {
 func (mr *MockChainConfigMockRecorder) GetFeeConfig() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFeeConfig", reflect.TypeOf((*MockChainConfig)(nil).GetFeeConfig))
+}
+
+// IsDUpgrade mocks base method.
+func (m *MockChainConfig) IsDUpgrade(arg0 uint64) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsDUpgrade", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsDUpgrade indicates an expected call of IsDUpgrade.
+func (mr *MockChainConfigMockRecorder) IsDUpgrade(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsDUpgrade", reflect.TypeOf((*MockChainConfig)(nil).IsDUpgrade), arg0)
 }
 
 // MockAccepter is a mock of Accepter interface.


### PR DESCRIPTION
This PR breaks out adding `IsDUpgrade` to the precompileconfig ChainConfig interface from https://github.com/ava-labs/subnet-evm/pull/801/files, which is needed to address: https://github.com/ava-labs/subnet-evm/pull/823#discussion_r1309368416