### PR TITLE
contracts: fix tx allow list test func name exmaple -> example

### DIFF
--- a/contracts/contracts/test/ExampleTxAllowListTest.sol
+++ b/contracts/contracts/test/ExampleTxAllowListTest.sol
@@ -33,7 +33,7 @@ contract ExampleTxAllowListTest is AllowListTest {
     assertTrue(!example.isAdmin(address(other)));
   }
 
-  function step_exmapleAllowListReturnsTestIsAdmin() public {
+  function step_exampleAllowListReturnsTestIsAdmin() public {
     ExampleTxAllowList example = new ExampleTxAllowList();
     assertTrue(example.isAdmin(address(this)));
   }

--- a/contracts/test/tx_allow_list.ts
+++ b/contracts/test/tx_allow_list.ts
@@ -35,7 +35,7 @@ describe("ExampleTxAllowList", function () {
 
   test("contract should report test address has on admin role", "step_noRoleIsNotAdmin")
 
-  test("contract should report admin address has admin role", "step_exmapleAllowListReturnsTestIsAdmin")
+  test("contract should report admin address has admin role", "step_exampleAllowListReturnsTestIsAdmin")
 
   test("should not let test address submit txs", [
     {


### PR DESCRIPTION
This PR fixes a typo from `exmaple -> example` in the tx allow list contract tests.