### PR TITLE
add mock ci

### DIFF
--- a/.github/workflows/auto-generated-code-checker.yml
+++ b/.github/workflows/auto-generated-code-checker.yml
@@ -1,0 +1,24 @@
+name: Auto-Generated Code Checker
+on:
+  push:
+    tags:
+      - "*"
+    branches:
+      - master
+      - dev
+  pull_request:
+
+jobs:
+  mock_gen:
+    name: Mocks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '~1.19.12'
+          check-latest: true
+      - shell: bash
+        run: scripts/mock.gen.sh
+      - shell: bash
+        run: .github/workflows/check-clean-branch.sh

--- a/.github/workflows/check-clean-branch.sh
+++ b/.github/workflows/check-clean-branch.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Exits if any uncommitted changes are found.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+git update-index --really-refresh >> /dev/null
+git diff-index --quiet HEAD

--- a/precompile/contract/mocks.go
+++ b/precompile/contract/mocks.go
@@ -9,7 +9,6 @@ import (
 	reflect "reflect"
 
 	snow "github.com/ava-labs/avalanchego/snow"
-	common "github.com/ethereum/go-ethereum/common"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -34,20 +33,6 @@ func NewMockBlockContext(ctrl *gomock.Controller) *MockBlockContext {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockBlockContext) EXPECT() *MockBlockContextMockRecorder {
 	return m.recorder
-}
-
-// GetPredicateResults mocks base method.
-func (m *MockBlockContext) GetPredicateResults(arg0 common.Hash, arg1 common.Address) []byte {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPredicateResults", arg0, arg1)
-	ret0, _ := ret[0].([]byte)
-	return ret0
-}
-
-// GetPredicateResults indicates an expected call of GetPredicateResults.
-func (mr *MockBlockContextMockRecorder) GetPredicateResults(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPredicateResults", reflect.TypeOf((*MockBlockContext)(nil).GetPredicateResults), arg0, arg1)
 }
 
 // Number mocks base method.

--- a/scripts/mock.gen.sh
+++ b/scripts/mock.gen.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if ! [[ "$0" =~ scripts/mock.gen.sh ]]; then
+  echo "must be run from repository root"
+  exit 255
+fi
+
+if ! command -v mockgen &>/dev/null; then
+  echo "mockgen not found, installing..."
+  # https://github.com/uber-go/mock
+  go install -v go.uber.org/mock/mockgen@v0.2.0
+fi
+
+if ! command -v go-license &>/dev/null; then
+  echo "go-license not found, installing..."
+  # https://github.com/palantir/go-license
+  go install -v github.com/palantir/go-license@v1.25.0
+fi
+
+# tuples of (source interface import path, comma-separated interface names, output file path)
+input="scripts/mocks.mockgen.txt"
+while IFS= read -r line; do
+  IFS='=' read src_import_path interface_name output_path <<<"${line}"
+  package_name=$(basename $(dirname $output_path))
+  echo "Generating ${output_path}..."
+  mockgen -package=${package_name} -destination=${output_path} ${src_import_path} ${interface_name}
+
+  go-license \
+    --config=./header.yml \
+    "${output_path}"
+done <"$input"
+
+echo "SUCCESS"

--- a/scripts/mocks.mockgen.txt
+++ b/scripts/mocks.mockgen.txt
@@ -1,0 +1,2 @@
+github.com/ava-labs/subnet-evm/precompile/precompileconfig=Config,ChainConfig,Accepter=precompile/precompileconfig/mocks.go
+github.com/ava-labs/subnet-evm/precompile/contract=BlockContext,AccessibleState=precompile/contract/mocks.go


### PR DESCRIPTION
## Why this should be merged

We have added mock.gen.sh in the PR https://github.com/ava-labs/subnet-evm/pull/801. This one adds a CI job to ensure we're applying it correctly (as we do in avalanchego)

https://github.com/ava-labs/subnet-evm/pull/801#discussion_r1314280082

## How this was tested

CI

