### PR TITLE
override network upgrades

### DIFF
--- a/params/network_upgrades.go
+++ b/params/network_upgrades.go
@@ -4,7 +4,6 @@
 package params
 
 import (
-	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/subnet-evm/utils"
 )
 
@@ -50,17 +49,6 @@ func (m *MandatoryNetworkUpgrades) mandatoryForkOrder() []fork {
 	return []fork{
 		{name: "subnetEVMTimestamp", timestamp: m.SubnetEVMTimestamp},
 		{name: "dUpgradeTimestamp", timestamp: m.DUpgradeTimestamp},
-	}
-}
-
-func GetMandatoryNetworkUpgrades(networkID uint32) MandatoryNetworkUpgrades {
-	switch networkID {
-	case constants.FujiID:
-		return FujiNetworkUpgrades
-	case constants.MainnetID:
-		return MainnetNetworkUpgrades
-	default:
-		return LocalNetworkUpgrades
 	}
 }
 

--- a/params/network_upgrades.go
+++ b/params/network_upgrades.go
@@ -22,6 +22,11 @@ var (
 		SubnetEVMTimestamp: utils.NewUint64(0),
 		// DUpgradeTimestamp: utils.NewUint64(0), // TODO: Uncomment and set this to the correct value
 	}
+
+	UnitTestNetworkUpgrades = MandatoryNetworkUpgrades{
+		SubnetEVMTimestamp: utils.NewUint64(0),
+		DUpgradeTimestamp:  utils.NewUint64(0),
+	}
 )
 
 // MandatoryNetworkUpgrades contains timestamps that enable mandatory network upgrades.

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -992,10 +992,10 @@ func attachEthService(handler *rpc.Server, apis []rpc.API, names []string) error
 // along with a flag that indicates if returned upgrades should be strictly enforced.
 func getMandatoryNetworkUpgrades(networkID uint32) (params.MandatoryNetworkUpgrades, bool) {
 	switch networkID {
-	case avalanchegoConstants.FujiID:
-		return params.FujiNetworkUpgrades, true
 	case avalanchegoConstants.MainnetID:
 		return params.MainnetNetworkUpgrades, true
+	case avalanchegoConstants.FujiID:
+		return params.FujiNetworkUpgrades, true
 	case avalanchegoConstants.UnitTestID:
 		return params.UnitTestNetworkUpgrades, false
 	default:

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -303,6 +303,12 @@ func (vm *VM) Initialize(
 		// We enforce network upgrades here, regardless of the chain config
 		// provided in the genesis file
 		g.Config.MandatoryNetworkUpgrades = mandatoryNetworkUpgrades
+	} else {
+		// If we are not enforcing, then apply those only if they are not
+		// already set in the genesis file
+		if g.Config.MandatoryNetworkUpgrades == (params.MandatoryNetworkUpgrades{}) {
+			g.Config.MandatoryNetworkUpgrades = mandatoryNetworkUpgrades
+		}
 	}
 
 	// Load airdrop file if provided

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -2204,38 +2204,11 @@ func TestTxAllowListSuccessfulTx(t *testing.T) {
 	genesis.Config.GenesisPrecompiles = params.Precompiles{
 		txallowlist.ConfigKey: txallowlist.NewConfig(utils.NewUint64(0), testEthAddrs[0:1], nil),
 	}
-<<<<<<< HEAD
-=======
-	// set the DUpgradeTimestamp to be in the future
-	dUpgradeTime := time.Now().Add(10 * time.Hour)
-	genesis.Config.DUpgradeTimestamp = utils.TimeToNewUint64(dUpgradeTime)
->>>>>>> 7f1674a74 (override network upgrades)
 	genesisJSON, err := genesis.MarshalJSON()
 	if err != nil {
 		t.Fatal(err)
 	}
-<<<<<<< HEAD
 	issuer, vm, _, _ := GenesisVM(t, true, string(genesisJSON), "", "")
-=======
-
-	// prepare the new upgrade bytes to disable the TxAllowList
-	disableAllowListTime := dUpgradeTime.Add(10 * time.Hour)
-	reenableAllowlistTime := disableAllowListTime.Add(10 * time.Hour)
-	upgradeConfig := &params.UpgradeConfig{
-		PrecompileUpgrades: []params.PrecompileUpgrade{
-			{
-				Config: txallowlist.NewDisableConfig(utils.TimeToNewUint64(disableAllowListTime)),
-			},
-			// re-enable the tx allowlist after DUpgrade to set the manager role
-			{
-				Config: txallowlist.NewConfig(utils.TimeToNewUint64(reenableAllowlistTime), testEthAddrs[0:1], nil, []common.Address{managerAddress}),
-			},
-		},
-	}
-	upgradeBytesJSON, err := json.Marshal(upgradeConfig)
-	require.NoError(t, err)
-	issuer, vm, _, _ := GenesisVM(t, true, string(genesisJSON), "", string(upgradeBytesJSON))
->>>>>>> 7f1674a74 (override network upgrades)
 
 	defer func() {
 		if err := vm.Shutdown(context.Background()); err != nil {

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -2204,11 +2204,38 @@ func TestTxAllowListSuccessfulTx(t *testing.T) {
 	genesis.Config.GenesisPrecompiles = params.Precompiles{
 		txallowlist.ConfigKey: txallowlist.NewConfig(utils.NewUint64(0), testEthAddrs[0:1], nil),
 	}
+<<<<<<< HEAD
+=======
+	// set the DUpgradeTimestamp to be in the future
+	dUpgradeTime := time.Now().Add(10 * time.Hour)
+	genesis.Config.DUpgradeTimestamp = utils.TimeToNewUint64(dUpgradeTime)
+>>>>>>> 7f1674a74 (override network upgrades)
 	genesisJSON, err := genesis.MarshalJSON()
 	if err != nil {
 		t.Fatal(err)
 	}
+<<<<<<< HEAD
 	issuer, vm, _, _ := GenesisVM(t, true, string(genesisJSON), "", "")
+=======
+
+	// prepare the new upgrade bytes to disable the TxAllowList
+	disableAllowListTime := dUpgradeTime.Add(10 * time.Hour)
+	reenableAllowlistTime := disableAllowListTime.Add(10 * time.Hour)
+	upgradeConfig := &params.UpgradeConfig{
+		PrecompileUpgrades: []params.PrecompileUpgrade{
+			{
+				Config: txallowlist.NewDisableConfig(utils.TimeToNewUint64(disableAllowListTime)),
+			},
+			// re-enable the tx allowlist after DUpgrade to set the manager role
+			{
+				Config: txallowlist.NewConfig(utils.TimeToNewUint64(reenableAllowlistTime), testEthAddrs[0:1], nil, []common.Address{managerAddress}),
+			},
+		},
+	}
+	upgradeBytesJSON, err := json.Marshal(upgradeConfig)
+	require.NoError(t, err)
+	issuer, vm, _, _ := GenesisVM(t, true, string(genesisJSON), "", string(upgradeBytesJSON))
+>>>>>>> 7f1674a74 (override network upgrades)
 
 	defer func() {
 		if err := vm.Shutdown(context.Background()); err != nil {

--- a/plugin/evm/vm_upgrade_bytes_test.go
+++ b/plugin/evm/vm_upgrade_bytes_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/snow"
 	commonEng "github.com/ava-labs/avalanchego/snow/engine/common"
+	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/vms/components/chain"
 	"github.com/ava-labs/subnet-evm/core"
 	"github.com/ava-labs/subnet-evm/core/types"
@@ -245,16 +246,62 @@ func TestMandatoryUpgradesEnforced(t *testing.T) {
 	}
 
 	// initialize the VM with these upgrade bytes
-	_, vm, _, _ := GenesisVM(t, true, string(genesisBytes), "", "")
+	tests := []struct {
+		networkID uint32
+		expected  bool
+	}{
+		{
+			networkID: constants.MainnetID,
+			expected:  true,
+		},
+		{
+			networkID: constants.FujiID,
+			expected:  true,
+		},
+		{
+			networkID: constants.LocalID,
+			expected:  false,
+		},
+		{
+			networkID: constants.UnitTestID,
+			expected:  false,
+		},
+	}
 
-	defer func() {
-		if err := vm.Shutdown(context.Background()); err != nil {
-			t.Fatal(err)
-		}
-	}()
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("networkID %d", test.networkID), func(t *testing.T) {
+			vm := &VM{}
+			ctx, dbManager, genesisBytes, issuer, _ := setupGenesis(t, string(genesisBytes))
+			ctx.NetworkID = test.networkID
+			appSender := &commonEng.SenderTest{T: t}
+			appSender.CantSendAppGossip = true
+			appSender.SendAppGossipF = func(context.Context, []byte) error { return nil }
+			err := vm.Initialize(
+				context.Background(),
+				ctx,
+				dbManager,
+				genesisBytes,
+				nil,
+				nil,
+				issuer,
+				[]*commonEng.Fx{},
+				appSender,
+			)
+			require.NoError(t, err, "error initializing GenesisVM")
 
-	// verify upgrade is rescheduled
-	require.True(t, vm.chainConfig.IsSubnetEVM(0))
+			require.NoError(t, vm.SetState(context.Background(), snow.Bootstrapping))
+			require.NoError(t, vm.SetState(context.Background(), snow.NormalOp))
+
+			defer func() {
+				if err := vm.Shutdown(context.Background()); err != nil {
+					t.Fatal(err)
+				}
+			}()
+
+			// verify upgrade is rescheduled
+			require.Equal(t, test.expected, vm.chainConfig.IsSubnetEVM(0))
+		})
+	}
 }
 
 func mustMarshal(t *testing.T, v interface{}) string {

--- a/tests/precompile/genesis/contract_deployer_allow_list.json
+++ b/tests/precompile/genesis/contract_deployer_allow_list.json
@@ -11,7 +11,6 @@
     "petersburgBlock": 0,
     "istanbulBlock": 0,
     "muirGlacierBlock": 0,
-    "subnetEVMTimestamp": 0,
     "feeConfig": {
       "gasLimit": 20000000,
       "minBaseFee": 1000000000,

--- a/tests/precompile/genesis/contract_native_minter.json
+++ b/tests/precompile/genesis/contract_native_minter.json
@@ -11,7 +11,6 @@
     "petersburgBlock": 0,
     "istanbulBlock": 0,
     "muirGlacierBlock": 0,
-    "subnetEVMTimestamp": 0,
     "feeConfig": {
       "gasLimit": 20000000,
       "minBaseFee": 1000000000,

--- a/tests/precompile/genesis/fee_manager.json
+++ b/tests/precompile/genesis/fee_manager.json
@@ -11,7 +11,6 @@
     "petersburgBlock": 0,
     "istanbulBlock": 0,
     "muirGlacierBlock": 0,
-    "subnetEVMTimestamp": 0,
     "feeConfig": {
       "gasLimit": 20000000,
       "minBaseFee": 1000000000,

--- a/tests/precompile/genesis/reward_manager.json
+++ b/tests/precompile/genesis/reward_manager.json
@@ -11,7 +11,6 @@
     "petersburgBlock": 0,
     "istanbulBlock": 0,
     "muirGlacierBlock": 0,
-    "subnetEVMTimestamp": 0,
     "feeConfig": {
       "gasLimit": 20000000,
       "minBaseFee": 1000000000,

--- a/tests/precompile/genesis/tx_allow_list.json
+++ b/tests/precompile/genesis/tx_allow_list.json
@@ -11,7 +11,6 @@
     "petersburgBlock": 0,
     "istanbulBlock": 0,
     "muirGlacierBlock": 0,
-    "subnetEVMTimestamp": 0,
     "feeConfig": {
       "gasLimit": 20000000,
       "minBaseFee": 1000000000,

--- a/tests/precompile/genesis/warp.json
+++ b/tests/precompile/genesis/warp.json
@@ -11,7 +11,6 @@
       "petersburgBlock": 0,
       "istanbulBlock": 0,
       "muirGlacierBlock": 0,
-      "subnetEVMTimestamp": 0,
       "feeConfig": {
         "gasLimit": 20000000,
         "minBaseFee": 1000000000,


### PR DESCRIPTION
## Why this should be merged

From comment:https://github.com/ava-labs/subnet-evm/pull/801#discussion_r1314279711

Adds a way to override enforced mandatory upgrades. Mandatory upgrades are still enforced for mainnet and fuji, but rest of the networks (unit tests and local) can be overridden. 

## How this works

We conditionally enforce.

## How this was tested

Expanded the current unit tests

## How is this documented

No need.
