### PR TITLE
rename `WarpBackend` to `Backend`

### DIFF
--- a/plugin/evm/network_handler.go
+++ b/plugin/evm/network_handler.go
@@ -33,7 +33,7 @@ func newNetworkHandler(
 	provider syncHandlers.SyncDataProvider,
 	diskDB ethdb.KeyValueReader,
 	evmTrieDB *trie.Database,
-	warpBackend warp.WarpBackend,
+	warpBackend warp.Backend,
 	networkCodec codec.Manager,
 ) message.RequestHandler {
 	syncStats := syncStats.NewHandlerStats(metrics.Enabled)

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -218,7 +218,7 @@ type VM struct {
 
 	// Avalanche Warp Messaging backend
 	// Used to serve BLS signatures of warp messages over RPC
-	warpBackend warp.WarpBackend
+	warpBackend warp.Backend
 }
 
 // Initialize implements the snowman.ChainVM interface
@@ -437,7 +437,7 @@ func (vm *VM) Initialize(
 	vm.client = peer.NewNetworkClient(vm.Network)
 
 	// initialize warp backend
-	vm.warpBackend = warp.NewWarpBackend(vm.ctx, vm.warpDB, warpSignatureCacheSize)
+	vm.warpBackend = warp.NewBackend(vm.ctx, vm.warpDB, warpSignatureCacheSize)
 
 	// clear warpdb on initialization if config enabled
 	if vm.config.PruneWarpDB {

--- a/warp/backend.go
+++ b/warp/backend.go
@@ -78,25 +78,25 @@ func (b *backend) AddMessage(unsignedMessage *avalancheWarp.UnsignedMessage) err
 	return nil
 }
 
-func (w *backend) GetSignature(messageID ids.ID) ([bls.SignatureLen]byte, error) {
+func (b *backend) GetSignature(messageID ids.ID) ([bls.SignatureLen]byte, error) {
 	log.Debug("Getting warp message from backend", "messageID", messageID)
-	if sig, ok := w.signatureCache.Get(messageID); ok {
+	if sig, ok := b.signatureCache.Get(messageID); ok {
 		return sig, nil
 	}
 
-	unsignedMessage, err := w.GetMessage(messageID)
+	unsignedMessage, err := b.GetMessage(messageID)
 	if err != nil {
 		return [bls.SignatureLen]byte{}, fmt.Errorf("failed to get warp message %s from db: %w", messageID.String(), err)
 	}
 
 	var signature [bls.SignatureLen]byte
-	sig, err := w.snowCtx.WarpSigner.Sign(unsignedMessage)
+	sig, err := b.snowCtx.WarpSigner.Sign(unsignedMessage)
 	if err != nil {
 		return [bls.SignatureLen]byte{}, fmt.Errorf("failed to sign warp message: %w", err)
 	}
 
 	copy(signature[:], sig)
-	w.signatureCache.Put(messageID, signature)
+	b.signatureCache.Put(messageID, signature)
 	return signature, nil
 }
 

--- a/warp/backend_test.go
+++ b/warp/backend_test.go
@@ -28,7 +28,7 @@ func TestClearDB(t *testing.T) {
 	sk, err := bls.NewSecretKey()
 	require.NoError(t, err)
 	snowCtx.WarpSigner = avalancheWarp.NewSigner(sk, networkID, sourceChainID)
-	backend := NewWarpBackend(snowCtx, db, 500)
+	backend := NewBackend(snowCtx, db, 500)
 
 	// use multiple messages to test that all messages get cleared
 	payloads := [][]byte{[]byte("test1"), []byte("test2"), []byte("test3"), []byte("test4"), []byte("test5")}
@@ -64,7 +64,7 @@ func TestAddAndGetValidMessage(t *testing.T) {
 	sk, err := bls.NewSecretKey()
 	require.NoError(t, err)
 	snowCtx.WarpSigner = avalancheWarp.NewSigner(sk, networkID, sourceChainID)
-	backend := NewWarpBackend(snowCtx, db, 500)
+	backend := NewBackend(snowCtx, db, 500)
 
 	// Create a new unsigned message and add it to the warp backend.
 	unsignedMsg, err := avalancheWarp.NewUnsignedMessage(networkID, sourceChainID, payload)
@@ -85,7 +85,7 @@ func TestAddAndGetValidMessage(t *testing.T) {
 func TestAddAndGetUnknownMessage(t *testing.T) {
 	db := memdb.New()
 
-	backend := NewWarpBackend(snow.DefaultContextTest(), db, 500)
+	backend := NewBackend(snow.DefaultContextTest(), db, 500)
 	unsignedMsg, err := avalancheWarp.NewUnsignedMessage(networkID, sourceChainID, payload)
 	require.NoError(t, err)
 
@@ -104,7 +104,7 @@ func TestZeroSizedCache(t *testing.T) {
 	snowCtx.WarpSigner = avalancheWarp.NewSigner(sk, networkID, sourceChainID)
 
 	// Verify zero sized cache works normally, because the lru cache will be initialized to size 1 for any size parameter <= 0.
-	backend := NewWarpBackend(snowCtx, db, 0)
+	backend := NewBackend(snowCtx, db, 0)
 
 	// Create a new unsigned message and add it to the warp backend.
 	unsignedMsg, err := avalancheWarp.NewUnsignedMessage(networkID, sourceChainID, payload)

--- a/warp/handlers/signature_request.go
+++ b/warp/handlers/signature_request.go
@@ -24,12 +24,12 @@ type SignatureRequestHandler interface {
 
 // signatureRequestHandler implements the SignatureRequestHandler interface
 type signatureRequestHandler struct {
-	backend warp.WarpBackend
+	backend warp.Backend
 	codec   codec.Manager
 	stats   stats.SignatureRequestHandlerStats
 }
 
-func NewSignatureRequestHandler(backend warp.WarpBackend, codec codec.Manager, stats stats.SignatureRequestHandlerStats) SignatureRequestHandler {
+func NewSignatureRequestHandler(backend warp.Backend, codec codec.Manager, stats stats.SignatureRequestHandlerStats) SignatureRequestHandler {
 	return &signatureRequestHandler{
 		backend: backend,
 		codec:   codec,

--- a/warp/handlers/signature_request_test.go
+++ b/warp/handlers/signature_request_test.go
@@ -26,20 +26,20 @@ func TestSignatureHandler(t *testing.T) {
 	require.NoError(t, err)
 
 	snowCtx.WarpSigner = avalancheWarp.NewSigner(blsSecretKey, snowCtx.NetworkID, snowCtx.ChainID)
-	warpBackend := warp.NewWarpBackend(snowCtx, database, 100)
+	backend := warp.NewBackend(snowCtx, database, 100)
 
 	msg, err := avalancheWarp.NewUnsignedMessage(snowCtx.NetworkID, snowCtx.ChainID, []byte("test"))
 	require.NoError(t, err)
 
 	messageID := msg.ID()
-	require.NoError(t, warpBackend.AddMessage(msg))
-	signature, err := warpBackend.GetSignature(messageID)
+	require.NoError(t, backend.AddMessage(msg))
+	signature, err := backend.GetSignature(messageID)
 	require.NoError(t, err)
 	unknownMessageID := ids.GenerateTestID()
 
 	emptySignature := [bls.SignatureLen]byte{}
 	mockHandlerStats := &stats.MockSignatureRequestHandlerStats{}
-	signatureRequestHandler := NewSignatureRequestHandler(warpBackend, message.Codec, mockHandlerStats)
+	signatureRequestHandler := NewSignatureRequestHandler(backend, message.Codec, mockHandlerStats)
 
 	tests := map[string]struct {
 		setup       func() (request message.SignatureRequest, expectedResponse []byte)

--- a/warp/warp_service.go
+++ b/warp/warp_service.go
@@ -14,11 +14,11 @@ import (
 
 // WarpAPI introduces snowman specific functionality to the evm
 type WarpAPI struct {
-	backend    WarpBackend
+	backend    Backend
 	aggregator *aggregator.Aggregator
 }
 
-func NewWarpAPI(backend WarpBackend, aggregator *aggregator.Aggregator) *WarpAPI {
+func NewWarpAPI(backend Backend, aggregator *aggregator.Aggregator) *WarpAPI {
 	return &WarpAPI{
 		backend:    backend,
 		aggregator: aggregator,


### PR DESCRIPTION
## Why this should be merged

Removes stuttered name.

## How this works

N/A

## How this was tested

N/A

## How is this documented

N/A