### PR TITLE
return []byte instead of hexutil.Bytes

### DIFF
--- a/warp/warp_client.go
+++ b/warp/warp_client.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/subnet-evm/rpc"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
 var _ WarpClient = (*warpClient)(nil)
@@ -37,20 +36,18 @@ func NewWarpClient(uri, chain string) (WarpClient, error) {
 
 // GetSignature requests the BLS signature associated with a messageID
 func (c *warpClient) GetSignature(ctx context.Context, messageID ids.ID) ([]byte, error) {
-	var res hexutil.Bytes
-	err := c.client.CallContext(ctx, &res, "warp_getSignature", messageID)
-	if err != nil {
+	var res []byte
+	if err := c.client.CallContext(ctx, &res, "warp_getSignature", messageID); err != nil {
 		return nil, fmt.Errorf("call to warp_getSignature failed. err: %w", err)
 	}
-	return res, err
+	return res, nil
 }
 
 // GetAggregateSignature requests the aggregate signature associated with messageID
 func (c *warpClient) GetAggregateSignature(ctx context.Context, messageID ids.ID, quorumNum uint64) ([]byte, error) {
-	var res hexutil.Bytes
-	err := c.client.CallContext(ctx, &res, "warp_getAggregateSignature", messageID, quorumNum)
-	if err != nil {
+	var res []byte
+	if err := c.client.CallContext(ctx, &res, "warp_getAggregateSignature", messageID, quorumNum); err != nil {
 		return nil, fmt.Errorf("call to warp_getAggregateSignature failed. err: %w", err)
 	}
-	return res, err
+	return res, nil
 }

--- a/warp/warp_service.go
+++ b/warp/warp_service.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/subnet-evm/warp/aggregator"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
 // WarpAPI introduces snowman specific functionality to the evm
@@ -26,7 +25,7 @@ func NewWarpAPI(backend WarpBackend, aggregator *aggregator.Aggregator) *WarpAPI
 }
 
 // GetSignature returns the BLS signature associated with a messageID.
-func (api *WarpAPI) GetSignature(ctx context.Context, messageID ids.ID) (hexutil.Bytes, error) {
+func (api *WarpAPI) GetSignature(ctx context.Context, messageID ids.ID) ([]byte, error) {
 	signature, err := api.backend.GetSignature(messageID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get signature for with error %w", err)
@@ -35,7 +34,7 @@ func (api *WarpAPI) GetSignature(ctx context.Context, messageID ids.ID) (hexutil
 }
 
 // GetAggregateSignature fetches the aggregate signature for the requested [messageID]
-func (api *WarpAPI) GetAggregateSignature(ctx context.Context, messageID ids.ID, quorumNum uint64) (signedMessageBytes hexutil.Bytes, err error) {
+func (api *WarpAPI) GetAggregateSignature(ctx context.Context, messageID ids.ID, quorumNum uint64) ([]byte, error) {
 	unsignedMessage, err := api.backend.GetMessage(messageID)
 	if err != nil {
 		return nil, err
@@ -48,5 +47,5 @@ func (api *WarpAPI) GetAggregateSignature(ctx context.Context, messageID ids.ID,
 	// TODO: return the signature and total weight as well to the caller for more complete details
 	// Need to decide on the best UI for this and write up documentation with the potential
 	// gotchas that could impact signed messages becoming invalid.
-	return hexutil.Bytes(signatureResult.Message.Bytes()), nil
+	return signatureResult.Message.Bytes(), nil
 }


### PR DESCRIPTION
## Why this should be merged

I think it makes more sense for the caller to decide whether they want to use the returned value as a `hexutil.Bytes` or not.

## How this works

Rename.

## How this was tested

N/A

## How is this documented

N/A