### PR TITLE
pass warpSigner instead of snow context into backend

### DIFF
--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -442,7 +442,7 @@ func (vm *VM) Initialize(
 	vm.client = peer.NewNetworkClient(vm.Network)
 
 	// initialize warp backend
-	vm.warpBackend = warp.NewBackend(vm.ctx, vm.warpDB, warpSignatureCacheSize)
+	vm.warpBackend = warp.NewBackend(vm.ctx.WarpSigner, vm.warpDB, warpSignatureCacheSize)
 
 	// clear warpdb on initialization if config enabled
 	if vm.config.PruneWarpDB {

--- a/warp/backend_test.go
+++ b/warp/backend_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/ava-labs/avalanchego/database/memdb"
 	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
 	"github.com/ava-labs/avalanchego/utils/hashing"
 	avalancheWarp "github.com/ava-labs/avalanchego/vms/platformvm/warp"
@@ -24,11 +23,10 @@ var (
 func TestClearDB(t *testing.T) {
 	db := memdb.New()
 
-	snowCtx := snow.DefaultContextTest()
 	sk, err := bls.NewSecretKey()
 	require.NoError(t, err)
-	snowCtx.WarpSigner = avalancheWarp.NewSigner(sk, networkID, sourceChainID)
-	backend := NewBackend(snowCtx, db, 500)
+	warpSigner := avalancheWarp.NewSigner(sk, networkID, sourceChainID)
+	backend := NewBackend(warpSigner, db, 500)
 
 	// use multiple messages to test that all messages get cleared
 	payloads := [][]byte{[]byte("test1"), []byte("test2"), []byte("test3"), []byte("test4"), []byte("test5")}
@@ -60,11 +58,10 @@ func TestClearDB(t *testing.T) {
 func TestAddAndGetValidMessage(t *testing.T) {
 	db := memdb.New()
 
-	snowCtx := snow.DefaultContextTest()
 	sk, err := bls.NewSecretKey()
 	require.NoError(t, err)
-	snowCtx.WarpSigner = avalancheWarp.NewSigner(sk, networkID, sourceChainID)
-	backend := NewBackend(snowCtx, db, 500)
+	warpSigner := avalancheWarp.NewSigner(sk, networkID, sourceChainID)
+	backend := NewBackend(warpSigner, db, 500)
 
 	// Create a new unsigned message and add it to the warp backend.
 	unsignedMsg, err := avalancheWarp.NewUnsignedMessage(networkID, sourceChainID, payload)
@@ -77,7 +74,7 @@ func TestAddAndGetValidMessage(t *testing.T) {
 	signature, err := backend.GetSignature(messageID)
 	require.NoError(t, err)
 
-	expectedSig, err := snowCtx.WarpSigner.Sign(unsignedMsg)
+	expectedSig, err := warpSigner.Sign(unsignedMsg)
 	require.NoError(t, err)
 	require.Equal(t, expectedSig, signature[:])
 }
@@ -85,7 +82,10 @@ func TestAddAndGetValidMessage(t *testing.T) {
 func TestAddAndGetUnknownMessage(t *testing.T) {
 	db := memdb.New()
 
-	backend := NewBackend(snow.DefaultContextTest(), db, 500)
+	sk, err := bls.NewSecretKey()
+	require.NoError(t, err)
+	warpSigner := avalancheWarp.NewSigner(sk, networkID, sourceChainID)
+	backend := NewBackend(warpSigner, db, 500)
 	unsignedMsg, err := avalancheWarp.NewUnsignedMessage(networkID, sourceChainID, payload)
 	require.NoError(t, err)
 
@@ -98,13 +98,12 @@ func TestAddAndGetUnknownMessage(t *testing.T) {
 func TestZeroSizedCache(t *testing.T) {
 	db := memdb.New()
 
-	snowCtx := snow.DefaultContextTest()
 	sk, err := bls.NewSecretKey()
 	require.NoError(t, err)
-	snowCtx.WarpSigner = avalancheWarp.NewSigner(sk, networkID, sourceChainID)
+	warpSigner := avalancheWarp.NewSigner(sk, networkID, sourceChainID)
 
 	// Verify zero sized cache works normally, because the lru cache will be initialized to size 1 for any size parameter <= 0.
-	backend := NewBackend(snowCtx, db, 0)
+	backend := NewBackend(warpSigner, db, 0)
 
 	// Create a new unsigned message and add it to the warp backend.
 	unsignedMsg, err := avalancheWarp.NewUnsignedMessage(networkID, sourceChainID, payload)
@@ -117,7 +116,7 @@ func TestZeroSizedCache(t *testing.T) {
 	signature, err := backend.GetSignature(messageID)
 	require.NoError(t, err)
 
-	expectedSig, err := snowCtx.WarpSigner.Sign(unsignedMsg)
+	expectedSig, err := warpSigner.Sign(unsignedMsg)
 	require.NoError(t, err)
 	require.Equal(t, expectedSig, signature[:])
 }

--- a/warp/handlers/signature_request_test.go
+++ b/warp/handlers/signature_request_test.go
@@ -25,8 +25,8 @@ func TestSignatureHandler(t *testing.T) {
 	blsSecretKey, err := bls.NewSecretKey()
 	require.NoError(t, err)
 
-	snowCtx.WarpSigner = avalancheWarp.NewSigner(blsSecretKey, snowCtx.NetworkID, snowCtx.ChainID)
-	backend := warp.NewBackend(snowCtx, database, 100)
+	warpSigner := avalancheWarp.NewSigner(blsSecretKey, snowCtx.NetworkID, snowCtx.ChainID)
+	backend := warp.NewBackend(warpSigner, database, 100)
 
 	msg, err := avalancheWarp.NewUnsignedMessage(snowCtx.NetworkID, snowCtx.ChainID, []byte("test"))
 	require.NoError(t, err)


### PR DESCRIPTION
## Why this should be merged

Reduces interface. We only need one field of the snow.Context, so let's just pass that in.

## How this works

Self-explanatory.

## How this was tested

Existing UT.

## How is this documented

New interface.