### PR TITLE
Add more unit tests for aggregator

### DIFF
--- a/warp/aggregator/aggregation_job_test.go
+++ b/warp/aggregator/aggregation_job_test.go
@@ -217,10 +217,16 @@ func TestAggregateThresholdSignaturesOverMaxNeeded(t *testing.T) {
 		&mockFetcher{
 			fetch: func(_ context.Context, nodeID ids.NodeID, _ *avalancheWarp.UnsignedMessage) (*bls.Signature, error) {
 				// Allow bls signatures from all nodes even though we only need 3/5
-				for i, matchingNodeID := range nodeIDs {
-					if matchingNodeID == nodeID {
-						return blsSignatures[i], nil
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				default:
+					for i, matchingNodeID := range nodeIDs {
+						if matchingNodeID == nodeID {
+							return blsSignatures[i], nil
+						}
 					}
+
 				}
 				return nil, errors.New("what do we say to the god of death")
 			},
@@ -261,6 +267,7 @@ func TestAggregateThresholdSignaturesOverMaxNeeded(t *testing.T) {
 		TotalWeight:     500,
 		Message:         signedMessage,
 	}
+	// Why does this test get 500/500 signature weight? Shouldn't it cancel the context after we hit 300/500 or 60/100?
 	executeSignatureAggregationTest(t, signatureAggregationTest{
 		ctx:         ctx,
 		job:         aggregationJob,

--- a/warp/aggregator/aggregation_job_test.go
+++ b/warp/aggregator/aggregation_job_test.go
@@ -34,8 +34,8 @@ func executeSignatureAggregationTest(t testing.TB, test signatureAggregationTest
 	t.Helper()
 
 	res, err := test.job.Execute(test.ctx)
+	require.ErrorIs(t, err, test.expectedErr)
 	if test.expectedErr != nil {
-		require.ErrorIs(t, err, test.expectedErr)
 		return
 	}
 
@@ -240,7 +240,7 @@ func TestAggregateThresholdSignaturesOverMaxNeeded(t *testing.T) {
 			GetCurrentHeightF: getCurrentHeightF,
 			GetValidatorSetF: func(ctx context.Context, height uint64, subnetID ids.ID) (map[ids.NodeID]*validators.GetValidatorOutput, error) {
 				res := make(map[ids.NodeID]*validators.GetValidatorOutput)
-				for i := 0; i < 5; i++ {
+				for i := 0; i < len(nodeIDs); i++ {
 					res[nodeIDs[i]] = &validators.GetValidatorOutput{
 						NodeID:    nodeIDs[i],
 						PublicKey: blsPublicKeys[i],
@@ -266,8 +266,6 @@ func TestAggregateThresholdSignaturesOverMaxNeeded(t *testing.T) {
 		TotalWeight:     500,
 		Message:         signedMessage,
 	}
-	// This test is failing even though it shoudn't be.
-	// Why does this test get 500/500 signature weight? Shouldn't the child context be canceled by VerifyWeight after we hit 300/500 or 60/100?
 	executeSignatureAggregationTest(t, signatureAggregationTest{
 		ctx:         ctx,
 		job:         aggregationJob,

--- a/warp/aggregator/aggregation_job_test.go
+++ b/warp/aggregator/aggregation_job_test.go
@@ -216,17 +216,16 @@ func TestAggregateThresholdSignaturesOverMaxNeeded(t *testing.T) {
 	aggregationJob := newSignatureAggregationJob(
 		&mockFetcher{
 			fetch: func(_ context.Context, nodeID ids.NodeID, _ *avalancheWarp.UnsignedMessage) (*bls.Signature, error) {
-				// Allow bls signatures from all nodes even though we only need 3/5
 				select {
 				case <-ctx.Done():
 					return nil, ctx.Err()
 				default:
+					// Allow bls signatures from all nodes even though we only need 3/5
 					for i, matchingNodeID := range nodeIDs {
 						if matchingNodeID == nodeID {
 							return blsSignatures[i], nil
 						}
 					}
-
 				}
 				return nil, errors.New("what do we say to the god of death")
 			},
@@ -267,7 +266,8 @@ func TestAggregateThresholdSignaturesOverMaxNeeded(t *testing.T) {
 		TotalWeight:     500,
 		Message:         signedMessage,
 	}
-	// Why does this test get 500/500 signature weight? Shouldn't it cancel the context after we hit 300/500 or 60/100?
+	// This test is failing even though it shoudn't be.
+	// Why does this test get 500/500 signature weight? Shouldn't it the child context be canceled by VerifyWeight after we hit 300/500 or 60/100?
 	executeSignatureAggregationTest(t, signatureAggregationTest{
 		ctx:         ctx,
 		job:         aggregationJob,

--- a/warp/aggregator/aggregation_job_test.go
+++ b/warp/aggregator/aggregation_job_test.go
@@ -267,7 +267,7 @@ func TestAggregateThresholdSignaturesOverMaxNeeded(t *testing.T) {
 		Message:         signedMessage,
 	}
 	// This test is failing even though it shoudn't be.
-	// Why does this test get 500/500 signature weight? Shouldn't it the child context be canceled by VerifyWeight after we hit 300/500 or 60/100?
+	// Why does this test get 500/500 signature weight? Shouldn't the child context be canceled by VerifyWeight after we hit 300/500 or 60/100?
 	executeSignatureAggregationTest(t, signatureAggregationTest{
 		ctx:         ctx,
 		job:         aggregationJob,

--- a/warp/aggregator/aggregation_job_test.go
+++ b/warp/aggregator/aggregation_job_test.go
@@ -215,7 +215,7 @@ func TestAggregateThresholdSignaturesOverMaxNeeded(t *testing.T) {
 	ctx := context.Background()
 	aggregationJob := newSignatureAggregationJob(
 		&mockFetcher{
-			fetch: func(_ context.Context, nodeID ids.NodeID, _ *avalancheWarp.UnsignedMessage) (*bls.Signature, error) {
+			fetch: func(ctx context.Context, nodeID ids.NodeID, _ *avalancheWarp.UnsignedMessage) (*bls.Signature, error) {
 				select {
 				case <-ctx.Done():
 					return nil, ctx.Err()


### PR DESCRIPTION
## Why this should be merged
This new unit test is failing even though it shouldn't be.
Why does this test get 500/500 signature weight? Shouldn't it the child context be canceled by VerifyWeight after we hit 300/500 or 60/100 and therefore we shouldn't be able to fetch more signatures?''


Edit: Spun up 100 go routines. `signatureFetchCancel()`, aka the child ctx gets called exactly right. cancel propagates down to `fetchSignature and gets BLS signatures for about 80 go routines and the rest get handled by ctx.Done(). This makes me think we will fetch signatures from every node, even if a cancel triggers. 

#881  this should help the overfetching
## How this works

## How this was tested

## How is this documented
