### PR TITLE
bump versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/release_checklist.md
@@ -7,19 +7,23 @@ assignees: ''
 
 ---
 
-**Release**
+## Release
+
 The release version and a description of the planned changes to be included in the release.
 
-**Issues**
+## Issues
+
 Link the major issues planned to be included in the release.
 
-**Documentation**
+## Documentation
+
 Link the relevant documentation PRs for this release.
 
-**Checklist**
-- [ ] Update version in scripts/versions.sh and plugin/evm/version.go
-- [ ] Bump AvalancheGo dependency for RPCChainVM Compatibility
+## Checklist
+
+- [ ] Update version in plugin/evm/version.go
+- [ ] Bump AvalancheGo dependency in go.mod for RPCChainVM Compatibility
+- [ ] Update AvalancheGo dependency in scripts/versions.sh for e2e tests.
 - [ ] Add new entry in compatibility.json for RPCChainVM Compatibility
 - [ ] Update AvalancheGo compatibility in README
-- [ ] Bump cmd/simulator go mod (if needed)
 - [ ] Confirm goreleaser job has successfully generated binaries by checking the releases page

--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ The Subnet EVM runs in a separate process from the main AvalancheGo process and 
 [v0.5.1] AvalancheGo@v1.10.1-v1.10.4 (Protocol Version: 26)
 [v0.5.2] AvalancheGo@v1.10.1-v1.10.4 (Protocol Version: 26)
 [v0.5.3] AvalancheGo@v1.10.5-v1.10.6 (Protocol Version: 27)
-[v0.5.4] AvalancheGo@v1.10.9 (Protocol Version: 28)
-[v0.5.5] AvalancheGo@v1.10.9 (Protocol Version: 28)
+[v0.5.4] AvalancheGo@v1.10.9-v1.10.10 (Protocol Version: 28)
+[v0.5.5] AvalancheGo@v1.10.9-v1.10.10 (Protocol Version: 28)
+[v0.5.6] AvalancheGo@v1.10.9-v1.10.10 (Protocol Version: 28)
 ```
 
 ## API

--- a/compatibility.json
+++ b/compatibility.json
@@ -1,5 +1,6 @@
 {
   "rpcChainVMProtocolVersion": {
+    "v0.5.6": 28,
     "v0.5.5": 28,
     "v0.5.4": 28,
     "v0.5.3": 27,

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/VictoriaMetrics/fastcache v1.10.0
 	github.com/ava-labs/avalanche-network-runner v1.7.2-0.20230825150237-723bc7b31724
-	github.com/ava-labs/avalanchego v1.10.10-rc.4
+	github.com/ava-labs/avalanchego v1.10.10
 	github.com/cespare/cp v0.1.0
 	github.com/cockroachdb/pebble v0.0.0-20230209160836-829675f94811
 	github.com/davecgh/go-spew v1.1.1
@@ -55,7 +55,7 @@ require (
 	github.com/DataDog/zstd v1.5.2 // indirect
 	github.com/Microsoft/go-winio v0.5.2 // indirect
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
-	github.com/ava-labs/coreth v0.12.5-rc.3 // indirect
+	github.com/ava-labs/coreth v0.12.5-rc.6 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.7.0 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -61,10 +61,10 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/ava-labs/avalanche-network-runner v1.7.2-0.20230825150237-723bc7b31724 h1:ptqFgQtJ5DyLb2lvuvawLJNlvo1A1qv+JXYTneNeg14=
 github.com/ava-labs/avalanche-network-runner v1.7.2-0.20230825150237-723bc7b31724/go.mod h1:euKHwZ77sGvGfhVj4v9WPM4jD2b5N80ldE2XHqO7lwA=
-github.com/ava-labs/avalanchego v1.10.10-rc.4 h1:1oxQf1boQDliJspfGBqsYsqg91d4F3qiFTnwnp+EruY=
-github.com/ava-labs/avalanchego v1.10.10-rc.4/go.mod h1:BN97sZppDSvIMIfEjrLTjdPTFkGLkb0ISJHEcoxMMNk=
-github.com/ava-labs/coreth v0.12.5-rc.3 h1:cpmC+fSZMsO4gaFWqXHzAHrJACf05u5HPAYmwh7nmkU=
-github.com/ava-labs/coreth v0.12.5-rc.3/go.mod h1:HI+jTIflnDFBd0bledgkgid1Uurwr8q1h7zb3LsFsSo=
+github.com/ava-labs/avalanchego v1.10.10 h1:EYX4LVotcfdtIQ0nJSBTcoisubx/Bzk2tM1aP3yiYiw=
+github.com/ava-labs/avalanchego v1.10.10/go.mod h1:6UA0nxxTvvpyuCbP2DSzx9+7uWQfQx9DPApK8JptLiE=
+github.com/ava-labs/coreth v0.12.5-rc.6 h1:OajGUyKkO5Q82XSuMa8T5UD6QywtCHUiZ4Tv3RFmRBU=
+github.com/ava-labs/coreth v0.12.5-rc.6/go.mod h1:s5wVyy+5UCCk2m0Tq3jVmy0UqOpKBDYqRE13gInCJVs=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/plugin/evm/version.go
+++ b/plugin/evm/version.go
@@ -11,7 +11,7 @@ var (
 	// GitCommit is set by the build script
 	GitCommit string
 	// Version is the version of Subnet EVM
-	Version string = "v0.5.5"
+	Version string = "v0.5.6"
 )
 
 func init() {

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Don't export them as they're used in the context of other calls
-AVALANCHE_VERSION=${AVALANCHE_VERSION:-'v1.10.10-rc.4'}
+AVALANCHE_VERSION=${AVALANCHE_VERSION:-'v1.10.10'}
 AVALANCHEGO_VERSION=${AVALANCHEGO_VERSION:-$AVALANCHE_VERSION}
 GINKGO_VERSION=${GINKGO_VERSION:-'v2.2.0'}
 


### PR DESCRIPTION
## Why this should be merged

Bumps Subnet-EVM and AvalancheGo versions

Also updates release check list template.

Closes: #879 

## How this was tested

Existing tests cover.

## How is this documented

Allowlist Manager Role will be documented with DUpgrade docs.
