### PR TITLE
Add Contexts Continued 

### DIFF
--- a/peer/client.go
+++ b/peer/client.go
@@ -24,7 +24,7 @@ type NetworkClient interface {
 	// node version greater than or equal to minVersion.
 	// Returns response bytes, the ID of the chosen peer, and ErrRequestFailed if
 	// the request should be retried.
-	SendAppRequestAny(ctx context.Context, cominVersion *version.Application, request []byte) ([]byte, ids.NodeID, error)
+	SendAppRequestAny(ctx context.Context, minVersion *version.Application, request []byte) ([]byte, ids.NodeID, error)
 
 	// SendAppRequest synchronously sends request to the selected nodeID
 	// Returns response bytes, and ErrRequestFailed if the request should be retried.

--- a/peer/client.go
+++ b/peer/client.go
@@ -24,7 +24,7 @@ type NetworkClient interface {
 	// node version greater than or equal to minVersion.
 	// Returns response bytes, the ID of the chosen peer, and ErrRequestFailed if
 	// the request should be retried.
-	SendAppRequestAny(minVersion *version.Application, request []byte) ([]byte, ids.NodeID, error)
+	SendAppRequestAny(ctx context.Context, cominVersion *version.Application, request []byte) ([]byte, ids.NodeID, error)
 
 	// SendAppRequest synchronously sends request to the selected nodeID
 	// Returns response bytes, and ErrRequestFailed if the request should be retried.
@@ -32,7 +32,7 @@ type NetworkClient interface {
 
 	// SendCrossChainRequest sends a request to a specific blockchain running on this node.
 	// Returns response bytes, and ErrRequestFailed if the request failed.
-	SendCrossChainRequest(chainID ids.ID, request []byte) ([]byte, error)
+	SendCrossChainRequest(ctx context.Context, chainID ids.ID, request []byte) ([]byte, error)
 
 	// Gossip sends given gossip message to peers
 	Gossip(gossip []byte) error
@@ -60,24 +60,29 @@ func NewNetworkClient(network Network) NetworkClient {
 // node version greater than or equal to minVersion.
 // Returns response bytes, the ID of the chosen peer, and ErrRequestFailed if
 // the request should be retried.
-func (c *client) SendAppRequestAny(minVersion *version.Application, request []byte) ([]byte, ids.NodeID, error) {
+func (c *client) SendAppRequestAny(ctx context.Context, minVersion *version.Application, request []byte) ([]byte, ids.NodeID, error) {
 	waitingHandler := newWaitingResponseHandler()
-	nodeID, err := c.network.SendAppRequestAny(minVersion, request, waitingHandler)
+	nodeID, err := c.network.SendAppRequestAny(ctx, minVersion, request, waitingHandler)
 	if err != nil {
 		return nil, nodeID, err
 	}
-	response := <-waitingHandler.responseChan
-	if waitingHandler.failed {
-		return nil, nodeID, ErrRequestFailed
+
+	select {
+	case <-ctx.Done():
+		return nil, nodeID, ctx.Err()
+	case response := <-waitingHandler.responseChan:
+		if waitingHandler.failed {
+			return nil, nodeID, ErrRequestFailed
+		}
+		return response, nodeID, nil
 	}
-	return response, nodeID, nil
 }
 
 // SendAppRequest synchronously sends request to the specified nodeID
 // Returns response bytes and ErrRequestFailed if the request should be retried.
 func (c *client) SendAppRequest(ctx context.Context, nodeID ids.NodeID, request []byte) ([]byte, error) {
 	waitingHandler := newWaitingResponseHandler()
-	if err := c.network.SendAppRequest(nodeID, request, waitingHandler); err != nil {
+	if err := c.network.SendAppRequest(ctx, nodeID, request, waitingHandler); err != nil {
 		return nil, err
 	}
 
@@ -94,16 +99,20 @@ func (c *client) SendAppRequest(ctx context.Context, nodeID ids.NodeID, request 
 
 // SendCrossChainRequest synchronously sends request to the specified chainID
 // Returns response bytes and ErrRequestFailed if the request should be retried.
-func (c *client) SendCrossChainRequest(chainID ids.ID, request []byte) ([]byte, error) {
+func (c *client) SendCrossChainRequest(ctx context.Context, chainID ids.ID, request []byte) ([]byte, error) {
 	waitingHandler := newWaitingResponseHandler()
-	if err := c.network.SendCrossChainRequest(chainID, request, waitingHandler); err != nil {
+	if err := c.network.SendCrossChainRequest(ctx, chainID, request, waitingHandler); err != nil {
 		return nil, err
 	}
-	response := <-waitingHandler.responseChan
-	if waitingHandler.failed {
-		return nil, ErrRequestFailed
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case response := <-waitingHandler.responseChan:
+		if waitingHandler.failed {
+			return nil, ErrRequestFailed
+		}
+		return response, nil
 	}
-	return response, nil
 }
 
 func (c *client) Gossip(gossip []byte) error {

--- a/peer/network.go
+++ b/peer/network.go
@@ -190,6 +190,7 @@ func (n *network) sendAppRequest(ctx context.Context, nodeID ids.NodeID, request
 
 	// Send app request to [nodeID].
 	// On failure, release the slot from [activeAppRequests] and delete request from [outstandingRequestHandlers]
+	// TODO: treat error from  n.appSender.SendAppRequest as fatal
 	if err := n.appSender.SendAppRequest(ctx, nodeIDs, requestID, request); err != nil {
 		n.activeAppRequests.Release(1)
 		delete(n.outstandingRequestHandlers, requestID)
@@ -222,6 +223,7 @@ func (n *network) SendCrossChainRequest(ctx context.Context, chainID ids.ID, req
 
 	// Send cross chain request to [chainID].
 	// On failure, release the slot from [activeCrossChainRequests] and delete request from [outstandingRequestHandlers].
+	// TODO: treat error from  n.appSender.SendCrossChainAppRequest as fatal
 	if err := n.appSender.SendCrossChainAppRequest(ctx, chainID, requestID, request); err != nil {
 		n.activeCrossChainRequests.Release(1)
 		delete(n.outstandingRequestHandlers, requestID)

--- a/peer/network.go
+++ b/peer/network.go
@@ -46,16 +46,16 @@ type Network interface {
 	// node version greater than or equal to minVersion.
 	// Returns the ID of the chosen peer, and an error if the request could not
 	// be sent to a peer with the desired [minVersion].
-	SendAppRequestAny(minVersion *version.Application, message []byte, handler message.ResponseHandler) (ids.NodeID, error)
+	SendAppRequestAny(ctx context.Context, minVersion *version.Application, message []byte, handler message.ResponseHandler) (ids.NodeID, error)
 
 	// SendAppRequest sends message to given nodeID, notifying handler when there's a response or timeout
-	SendAppRequest(nodeID ids.NodeID, message []byte, handler message.ResponseHandler) error
+	SendAppRequest(ctx context.Context, nodeID ids.NodeID, message []byte, handler message.ResponseHandler) error
 
 	// Gossip sends given gossip message to peers
 	Gossip(gossip []byte) error
 
 	// SendCrossChainRequest sends a message to given chainID notifying handler when there's a response or timeout
-	SendCrossChainRequest(chainID ids.ID, message []byte, handler message.ResponseHandler) error
+	SendCrossChainRequest(ctx context.Context, chainID ids.ID, message []byte, handler message.ResponseHandler) error
 
 	// Shutdown stops all peer channel listeners and marks the node to have stopped
 	// n.Start() can be called again but the peers will have to be reconnected
@@ -134,7 +134,7 @@ func NewNetwork(router *p2p.Router, appSender common.AppSender, codec codec.Mana
 // the request will be sent to any peer regardless of their version.
 // Returns the ID of the chosen peer, and an error if the request could not
 // be sent to a peer with the desired [minVersion].
-func (n *network) SendAppRequestAny(minVersion *version.Application, request []byte, handler message.ResponseHandler) (ids.NodeID, error) {
+func (n *network) SendAppRequestAny(ctx context.Context, minVersion *version.Application, request []byte, handler message.ResponseHandler) (ids.NodeID, error) {
 	// Take a slot from total [activeAppRequests] and block until a slot becomes available.
 	if err := n.activeAppRequests.Acquire(context.Background(), 1); err != nil {
 		return ids.EmptyNodeID, errAcquiringSemaphore
@@ -143,7 +143,7 @@ func (n *network) SendAppRequestAny(minVersion *version.Application, request []b
 	n.lock.Lock()
 	defer n.lock.Unlock()
 	if nodeID, ok := n.peers.GetAnyPeer(minVersion); ok {
-		return nodeID, n.sendAppRequest(nodeID, request, handler)
+		return nodeID, n.sendAppRequest(ctx, nodeID, request, handler)
 	}
 
 	n.activeAppRequests.Release(1)
@@ -151,7 +151,7 @@ func (n *network) SendAppRequestAny(minVersion *version.Application, request []b
 }
 
 // SendAppRequest sends request message bytes to specified nodeID, notifying the responseHandler on response or failure
-func (n *network) SendAppRequest(nodeID ids.NodeID, request []byte, responseHandler message.ResponseHandler) error {
+func (n *network) SendAppRequest(ctx context.Context, nodeID ids.NodeID, request []byte, responseHandler message.ResponseHandler) error {
 	if nodeID == ids.EmptyNodeID {
 		return fmt.Errorf("cannot send request to empty nodeID, nodeID=%s, requestLen=%d", nodeID, len(request))
 	}
@@ -164,7 +164,7 @@ func (n *network) SendAppRequest(nodeID ids.NodeID, request []byte, responseHand
 	n.lock.Lock()
 	defer n.lock.Unlock()
 
-	return n.sendAppRequest(nodeID, request, responseHandler)
+	return n.sendAppRequest(ctx, nodeID, request, responseHandler)
 }
 
 // sendAppRequest sends request message bytes to specified nodeID and adds [responseHandler] to [outstandingRequestHandlers]
@@ -173,7 +173,7 @@ func (n *network) SendAppRequest(nodeID ids.NodeID, request []byte, responseHand
 // Releases active requests semaphore if there was an error in sending the request
 // Returns an error if [appSender] is unable to make the request.
 // Assumes write lock is held
-func (n *network) sendAppRequest(nodeID ids.NodeID, request []byte, responseHandler message.ResponseHandler) error {
+func (n *network) sendAppRequest(ctx context.Context, nodeID ids.NodeID, request []byte, responseHandler message.ResponseHandler) error {
 	if n.closed.Get() {
 		n.activeAppRequests.Release(1)
 		return nil
@@ -190,7 +190,7 @@ func (n *network) sendAppRequest(nodeID ids.NodeID, request []byte, responseHand
 
 	// Send app request to [nodeID].
 	// On failure, release the slot from [activeAppRequests] and delete request from [outstandingRequestHandlers]
-	if err := n.appSender.SendAppRequest(context.TODO(), nodeIDs, requestID, request); err != nil {
+	if err := n.appSender.SendAppRequest(ctx, nodeIDs, requestID, request); err != nil {
 		n.activeAppRequests.Release(1)
 		delete(n.outstandingRequestHandlers, requestID)
 		return err
@@ -203,7 +203,7 @@ func (n *network) sendAppRequest(nodeID ids.NodeID, request []byte, responseHand
 // SendCrossChainRequest sends request message bytes to specified chainID and adds [handler] to [outstandingRequestHandlers]
 // so that it can be invoked when the network receives either a response or failure message.
 // Returns an error if [appSender] is unable to make the request.
-func (n *network) SendCrossChainRequest(chainID ids.ID, request []byte, handler message.ResponseHandler) error {
+func (n *network) SendCrossChainRequest(ctx context.Context, chainID ids.ID, request []byte, handler message.ResponseHandler) error {
 	// Take a slot from total [activeCrossChainRequests] and block until a slot becomes available.
 	if err := n.activeCrossChainRequests.Acquire(context.Background(), 1); err != nil {
 		return errAcquiringSemaphore
@@ -222,7 +222,7 @@ func (n *network) SendCrossChainRequest(chainID ids.ID, request []byte, handler 
 
 	// Send cross chain request to [chainID].
 	// On failure, release the slot from [activeCrossChainRequests] and delete request from [outstandingRequestHandlers].
-	if err := n.appSender.SendCrossChainAppRequest(context.TODO(), chainID, requestID, request); err != nil {
+	if err := n.appSender.SendCrossChainAppRequest(ctx, chainID, requestID, request); err != nil {
 		n.activeCrossChainRequests.Release(1)
 		delete(n.outstandingRequestHandlers, requestID)
 		return err

--- a/peer/network.go
+++ b/peer/network.go
@@ -136,7 +136,7 @@ func NewNetwork(router *p2p.Router, appSender common.AppSender, codec codec.Mana
 // be sent to a peer with the desired [minVersion].
 func (n *network) SendAppRequestAny(ctx context.Context, minVersion *version.Application, request []byte, handler message.ResponseHandler) (ids.NodeID, error) {
 	// Take a slot from total [activeAppRequests] and block until a slot becomes available.
-	if err := n.activeAppRequests.Acquire(context.Background(), 1); err != nil {
+	if err := n.activeAppRequests.Acquire(ctx, 1); err != nil {
 		return ids.EmptyNodeID, errAcquiringSemaphore
 	}
 
@@ -157,7 +157,7 @@ func (n *network) SendAppRequest(ctx context.Context, nodeID ids.NodeID, request
 	}
 
 	// Take a slot from total [activeAppRequests] and block until a slot becomes available.
-	if err := n.activeAppRequests.Acquire(context.Background(), 1); err != nil {
+	if err := n.activeAppRequests.Acquire(ctx, 1); err != nil {
 		return errAcquiringSemaphore
 	}
 
@@ -205,7 +205,7 @@ func (n *network) sendAppRequest(ctx context.Context, nodeID ids.NodeID, request
 // Returns an error if [appSender] is unable to make the request.
 func (n *network) SendCrossChainRequest(ctx context.Context, chainID ids.ID, request []byte, handler message.ResponseHandler) error {
 	// Take a slot from total [activeCrossChainRequests] and block until a slot becomes available.
-	if err := n.activeCrossChainRequests.Acquire(context.Background(), 1); err != nil {
+	if err := n.activeCrossChainRequests.Acquire(ctx, 1); err != nil {
 		return errAcquiringSemaphore
 	}
 

--- a/peer/network_test.go
+++ b/peer/network_test.go
@@ -177,7 +177,7 @@ func TestAppRequestOnCtxCancellation(t *testing.T) {
 	// cancel context prior to sending
 	cancel()
 	_, err = client.SendAppRequest(ctx, nodeID, requestBytes)
-	assert.ErrorContains(t, err, "context canceled")
+	assert.ErrorIs(t, err, context.Canceled)
 }
 
 func TestRequestRequestsRoutingAndResponse(t *testing.T) {
@@ -374,7 +374,7 @@ func TestAppRequestAnyOnCtxCancellation(t *testing.T) {
 	// cancel context prior to sending
 	cancel()
 	_, _, err = client.SendAppRequestAny(ctx, defaultPeerVersion, requestBytes)
-	assert.ErrorContains(t, err, "context canceled")
+	assert.ErrorIs(t, err, context.Canceled)
 }
 
 func TestRequestMinVersion(t *testing.T) {
@@ -687,7 +687,7 @@ func TestCrossChainAppRequestOnCtxCancellation(t *testing.T) {
 	// cancel context prior to sending
 	cancel()
 	_, err = client.SendCrossChainRequest(ctx, chainID, crossChainRequest)
-	assert.ErrorContains(t, err, "context canceled")
+	assert.ErrorIs(t, err, context.Canceled)
 }
 
 func TestCrossChainRequestRequestsRoutingAndResponse(t *testing.T) {

--- a/peer/network_test.go
+++ b/peer/network_test.go
@@ -132,6 +132,54 @@ func TestRequestAnyRequestsRoutingAndResponse(t *testing.T) {
 	assert.Equal(t, totalCalls, int(atomic.LoadUint32(&callNum)))
 }
 
+func TestAppRequestOnCtxCancellation(t *testing.T) {
+	var net Network
+	codecManager := buildCodec(t, HelloRequest{}, HelloResponse{})
+	crossChainCodecManager := buildCodec(t, ExampleCrossChainRequest{}, ExampleCrossChainResponse{})
+
+	callNum := uint32(0)
+	senderWg := &sync.WaitGroup{}
+	sender := testAppSender{
+		sendAppRequestFn: func(nodes set.Set[ids.NodeID], requestID uint32, requestBytes []byte) error {
+			nodeID, _ := nodes.Pop()
+			senderWg.Add(1)
+			go func() {
+				defer senderWg.Done()
+				if err := net.AppRequest(context.Background(), nodeID, requestID, time.Now().Add(5*time.Second), requestBytes); err != nil {
+					panic(err)
+				}
+			}()
+			return nil
+		},
+		sendAppResponseFn: func(nodeID ids.NodeID, requestID uint32, responseBytes []byte) error {
+			senderWg.Add(1)
+			go func() {
+				defer senderWg.Done()
+				if err := net.AppResponse(context.Background(), nodeID, requestID, responseBytes); err != nil {
+					panic(err)
+				}
+				atomic.AddUint32(&callNum, 1)
+			}()
+			return nil
+		},
+	}
+
+	net = NewNetwork(p2p.NewRouter(logging.NoLog{}, nil, prometheus.NewRegistry(), ""), sender, codecManager, crossChainCodecManager, ids.EmptyNodeID, 1, 1)
+	net.SetRequestHandler(&HelloGreetingRequestHandler{codec: codecManager})
+	client := NewNetworkClient(net)
+
+	requestMessage := HelloRequest{Message: "this is a request"}
+	requestBytes, err := message.RequestToBytes(codecManager, requestMessage)
+	assert.NoError(t, err)
+
+	nodeID := ids.GenerateTestNodeID()
+	ctx, cancel := context.WithCancel(context.Background())
+	// cancel context prior to sending
+	cancel()
+	_, err = client.SendAppRequest(ctx, nodeID, requestBytes)
+	assert.ErrorContains(t, err, "context canceled")
+}
+
 func TestRequestRequestsRoutingAndResponse(t *testing.T) {
 	callNum := uint32(0)
 	senderWg := &sync.WaitGroup{}

--- a/peer/network_test.go
+++ b/peer/network_test.go
@@ -133,7 +133,6 @@ func TestRequestAnyRequestsRoutingAndResponse(t *testing.T) {
 }
 
 func TestAppRequestOnCtxCancellation(t *testing.T) {
-	var net Network
 	codecManager := buildCodec(t, HelloRequest{}, HelloResponse{})
 	crossChainCodecManager := buildCodec(t, ExampleCrossChainRequest{}, ExampleCrossChainResponse{})
 
@@ -146,9 +145,8 @@ func TestAppRequestOnCtxCancellation(t *testing.T) {
 		},
 	}
 
-	net = NewNetwork(p2p.NewRouter(logging.NoLog{}, nil, prometheus.NewRegistry(), ""), sender, codecManager, crossChainCodecManager, ids.EmptyNodeID, 1, 1)
+	net := NewNetwork(p2p.NewRouter(logging.NoLog{}, nil, prometheus.NewRegistry(), ""), sender, codecManager, crossChainCodecManager, ids.EmptyNodeID, 1, 1)
 	net.SetRequestHandler(&HelloGreetingRequestHandler{codec: codecManager})
-	client := NewNetworkClient(net)
 
 	requestMessage := HelloRequest{Message: "this is a request"}
 	requestBytes, err := message.RequestToBytes(codecManager, requestMessage)
@@ -158,6 +156,7 @@ func TestAppRequestOnCtxCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	// cancel context prior to sending
 	cancel()
+	client := NewNetworkClient(net)
 	_, err = client.SendAppRequest(ctx, nodeID, requestBytes)
 	assert.ErrorIs(t, err, context.Canceled)
 }
@@ -300,7 +299,6 @@ func TestAppRequestOnShutdown(t *testing.T) {
 }
 
 func TestAppRequestAnyOnCtxCancellation(t *testing.T) {
-	var net Network
 	codecManager := buildCodec(t, HelloRequest{}, HelloResponse{})
 	crossChainCodecManager := buildCodec(t, ExampleCrossChainRequest{}, ExampleCrossChainResponse{})
 
@@ -313,9 +311,8 @@ func TestAppRequestAnyOnCtxCancellation(t *testing.T) {
 		},
 	}
 
-	net = NewNetwork(p2p.NewRouter(logging.NoLog{}, nil, prometheus.NewRegistry(), ""), sender, codecManager, crossChainCodecManager, ids.EmptyNodeID, 1, 1)
+	net := NewNetwork(p2p.NewRouter(logging.NoLog{}, nil, prometheus.NewRegistry(), ""), sender, codecManager, crossChainCodecManager, ids.EmptyNodeID, 1, 1)
 	net.SetRequestHandler(&HelloGreetingRequestHandler{codec: codecManager})
-	client := NewNetworkClient(net)
 	assert.NoError(t,
 		net.Connected(
 			context.Background(),
@@ -331,6 +328,7 @@ func TestAppRequestAnyOnCtxCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	// cancel context prior to sending
 	cancel()
+	client := NewNetworkClient(net)
 	_, _, err = client.SendAppRequestAny(ctx, defaultPeerVersion, requestBytes)
 	assert.ErrorIs(t, err, context.Canceled)
 }
@@ -606,7 +604,6 @@ func TestCrossChainAppRequest(t *testing.T) {
 }
 
 func TestCrossChainAppRequestOnCtxCancellation(t *testing.T) {
-	var net Network
 	codecManager := buildCodec(t, TestMessage{})
 	crossChainCodecManager := buildCodec(t, ExampleCrossChainRequest{}, ExampleCrossChainResponse{})
 
@@ -619,9 +616,8 @@ func TestCrossChainAppRequestOnCtxCancellation(t *testing.T) {
 		},
 	}
 
-	net = NewNetwork(p2p.NewRouter(logging.NoLog{}, nil, prometheus.NewRegistry(), ""), sender, codecManager, crossChainCodecManager, ids.EmptyNodeID, 1, 1)
+	net := NewNetwork(p2p.NewRouter(logging.NoLog{}, nil, prometheus.NewRegistry(), ""), sender, codecManager, crossChainCodecManager, ids.EmptyNodeID, 1, 1)
 	net.SetCrossChainRequestHandler(&testCrossChainHandler{codec: crossChainCodecManager})
-	client := NewNetworkClient(net)
 
 	exampleCrossChainRequest := ExampleCrossChainRequest{
 		Message: "hello this is an example request",
@@ -634,6 +630,7 @@ func TestCrossChainAppRequestOnCtxCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	// cancel context prior to sending
 	cancel()
+	client := NewNetworkClient(net)
 	_, err = client.SendCrossChainRequest(ctx, chainID, crossChainRequest)
 	assert.ErrorIs(t, err, context.Canceled)
 }

--- a/peer/network_test.go
+++ b/peer/network_test.go
@@ -115,7 +115,7 @@ func TestRequestAnyRequestsRoutingAndResponse(t *testing.T) {
 			defer wg.Done()
 			requestBytes, err := message.RequestToBytes(codecManager, requestMessage)
 			assert.NoError(t, err)
-			responseBytes, _, err := client.SendAppRequestAny(defaultPeerVersion, requestBytes)
+			responseBytes, _, err := client.SendAppRequestAny(context.Background(), defaultPeerVersion, requestBytes)
 			assert.NoError(t, err)
 			assert.NotNil(t, responseBytes)
 
@@ -261,7 +261,7 @@ func TestAppRequestOnShutdown(t *testing.T) {
 		defer wg.Done()
 		requestBytes, err := message.RequestToBytes(codecManager, requestMessage)
 		require.NoError(t, err)
-		responseBytes, _, err := client.SendAppRequestAny(defaultPeerVersion, requestBytes)
+		responseBytes, _, err := client.SendAppRequestAny(context.Background(), defaultPeerVersion, requestBytes)
 		require.Error(t, err, ErrRequestFailed)
 		require.Nil(t, responseBytes)
 	}()
@@ -316,6 +316,7 @@ func TestRequestMinVersion(t *testing.T) {
 
 	// ensure version does not match
 	responseBytes, _, err := client.SendAppRequestAny(
+		context.Background(),
 		&version.Application{
 			Major: 2,
 			Minor: 0,
@@ -327,7 +328,7 @@ func TestRequestMinVersion(t *testing.T) {
 	assert.Nil(t, responseBytes)
 
 	// ensure version matches and the request goes through
-	responseBytes, _, err = client.SendAppRequestAny(defaultPeerVersion, requestBytes)
+	responseBytes, _, err = client.SendAppRequestAny(context.Background(), defaultPeerVersion, requestBytes)
 	assert.NoError(t, err)
 
 	var response TestMessage
@@ -528,7 +529,7 @@ func TestCrossChainAppRequest(t *testing.T) {
 	assert.NoError(t, err)
 
 	chainID := ids.ID(ethcommon.BytesToHash([]byte{1, 2, 3, 4, 5}))
-	responseBytes, err := client.SendCrossChainRequest(chainID, crossChainRequest)
+	responseBytes, err := client.SendCrossChainRequest(context.Background(), chainID, crossChainRequest)
 	assert.NoError(t, err)
 
 	var response ExampleCrossChainResponse
@@ -594,7 +595,7 @@ func TestCrossChainRequestRequestsRoutingAndResponse(t *testing.T) {
 			defer requestWg.Done()
 			crossChainRequest, err := buildCrossChainRequest(crossChainCodecManager, exampleCrossChainRequest)
 			assert.NoError(t, err)
-			responseBytes, err := client.SendCrossChainRequest(chainID, crossChainRequest)
+			responseBytes, err := client.SendCrossChainRequest(context.Background(), chainID, crossChainRequest)
 			assert.NoError(t, err)
 			assert.NotNil(t, responseBytes)
 
@@ -644,7 +645,7 @@ func TestCrossChainRequestOnShutdown(t *testing.T) {
 		defer wg.Done()
 		crossChainRequest, err := buildCrossChainRequest(crossChainCodecManager, exampleCrossChainRequest)
 		require.NoError(t, err)
-		responseBytes, err := client.SendCrossChainRequest(chainID, crossChainRequest)
+		responseBytes, err := client.SendCrossChainRequest(context.Background(), chainID, crossChainRequest)
 		require.ErrorIs(t, err, ErrRequestFailed)
 		require.Nil(t, responseBytes)
 	}()
@@ -658,8 +659,8 @@ func TestNetworkAppRequestAfterShutdown(t *testing.T) {
 	net := NewNetwork(nil, nil, nil, nil, ids.EmptyNodeID, 1, 0)
 	net.Shutdown()
 
-	require.NoError(net.SendAppRequest(ids.GenerateTestNodeID(), nil, nil))
-	require.NoError(net.SendAppRequest(ids.GenerateTestNodeID(), nil, nil))
+	require.NoError(net.SendAppRequest(context.Background(), ids.GenerateTestNodeID(), nil, nil))
+	require.NoError(net.SendAppRequest(context.Background(), ids.GenerateTestNodeID(), nil, nil))
 }
 
 func TestNetworkCrossChainAppRequestAfterShutdown(t *testing.T) {
@@ -668,8 +669,8 @@ func TestNetworkCrossChainAppRequestAfterShutdown(t *testing.T) {
 	net := NewNetwork(nil, nil, nil, nil, ids.EmptyNodeID, 0, 1)
 	net.Shutdown()
 
-	require.NoError(net.SendCrossChainRequest(ids.GenerateTestID(), nil, nil))
-	require.NoError(net.SendCrossChainRequest(ids.GenerateTestID(), nil, nil))
+	require.NoError(net.SendCrossChainRequest(context.Background(), ids.GenerateTestID(), nil, nil))
+	require.NoError(net.SendCrossChainRequest(context.Background(), ids.GenerateTestID(), nil, nil))
 }
 
 func TestSDKRouting(t *testing.T) {

--- a/sync/client/client.go
+++ b/sync/client/client.go
@@ -325,14 +325,14 @@ func (c *client) get(ctx context.Context, request message.Request, parseFn parse
 			start    time.Time = time.Now()
 		)
 		if len(c.stateSyncNodes) == 0 {
-			response, nodeID, err = c.networkClient.SendAppRequestAny(StateSyncVersion, requestBytes)
+			response, nodeID, err = c.networkClient.SendAppRequestAny(ctx, StateSyncVersion, requestBytes)
 		} else {
 			// get the next nodeID using the nodeIdx offset. If we're out of nodes, loop back to 0
 			// we do this every attempt to ensure we get a different node each time if possible.
 			nodeIdx := atomic.AddUint32(&c.stateSyncNodeIdx, 1)
 			nodeID = c.stateSyncNodes[nodeIdx%uint32(len(c.stateSyncNodes))]
 
-			response, err = c.networkClient.SendAppRequest(context.TODO(), nodeID, requestBytes)
+			response, err = c.networkClient.SendAppRequest(ctx, nodeID, requestBytes)
 		}
 		metric.UpdateRequestLatency(time.Since(start))
 

--- a/sync/client/mock_network.go
+++ b/sync/client/mock_network.go
@@ -29,7 +29,7 @@ type mockNetwork struct {
 	nodesRequested []ids.NodeID
 }
 
-func (t *mockNetwork) SendAppRequestAny(minVersion *version.Application, request []byte) ([]byte, ids.NodeID, error) {
+func (t *mockNetwork) SendAppRequestAny(ctx context.Context, minVersion *version.Application, request []byte) ([]byte, ids.NodeID, error) {
 	if len(t.response) == 0 {
 		return nil, ids.EmptyNodeID, errors.New("no mocked response to return in mockNetwork")
 	}
@@ -78,7 +78,7 @@ func (t *mockNetwork) Gossip([]byte) error {
 	panic("not implemented") // we don't care about this function for this test
 }
 
-func (t *mockNetwork) SendCrossChainRequest(chainID ids.ID, request []byte) ([]byte, error) {
+func (t *mockNetwork) SendCrossChainRequest(ctx context.Context, chainID ids.ID, request []byte) ([]byte, error) {
 	panic("not implemented") // we don't care about this function for this test
 }
 


### PR DESCRIPTION
## Why this should be merged
This is an additional supplement to Dan's PR on the `add-contexts` branch. 
All Send functions in Networking now take in a context. 
If contexed cancelled prior to being called, we should return a ctx cancelled err. We also don't generate a new context on sends and instead pass the existing one through. 
## How this works

## How this was tested
UT
## How is this documented
