### PR TITLE
use timer instead of time.After

### DIFF
--- a/warp/aggregator/signature_getter.go
+++ b/warp/aggregator/signature_getter.go
@@ -51,16 +51,24 @@ func (s *NetworkSignatureGetter) GetSignature(ctx context.Context, nodeID ids.No
 	}
 
 	delay := initialRetryFetchSignatureDelay
-	for ctx.Err() == nil {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	for {
 		signatureRes, err := s.Client.SendAppRequest(nodeID, signatureReqBytes)
-		// If the client fails to retrieve a response perform an exponential backoff.
-		// Note: it is up to the caller to ensure that [ctx] is eventually cancelled
 		if err != nil {
+			// Wait until the retry delay has elapsed before retrying.
+			if !timer.Stop() {
+				<-timer.C
+			}
+			timer.Reset(delay)
+
 			select {
 			case <-ctx.Done():
-				break
-			case <-time.After(delay):
+				return nil, err
+			case <-timer.C:
 			}
+
+			// Exponential backoff.
 			delay *= retryBackoffFactor
 			continue
 		}
@@ -76,6 +84,4 @@ func (s *NetworkSignatureGetter) GetSignature(ctx context.Context, nodeID ids.No
 		}
 		return blsSignature, nil
 	}
-
-	return nil, fmt.Errorf("ctx expired fetching signature for message %s from %s: %w", unsignedWarpMessage.ID(), nodeID, ctx.Err())
 }

--- a/warp/aggregator/signature_getter.go
+++ b/warp/aggregator/signature_getter.go
@@ -64,7 +64,7 @@ func (s *NetworkSignatureGetter) GetSignature(ctx context.Context, nodeID ids.No
 
 			select {
 			case <-ctx.Done():
-				return nil, err
+				return nil, ctx.Err()
 			case <-timer.C:
 			}
 


### PR DESCRIPTION
## Why this should be merged

Using `time.After` can leave a hanging goroutine.

## How this works

Refactor loop.

## How this was tested

Existing UT

## How is this documented

Comments