### PR TITLE
SetTxPredicateResults: Consistent overwriting

### DIFF
--- a/precompile/results/predicate_results.go
+++ b/precompile/results/predicate_results.go
@@ -81,8 +81,9 @@ func (p *PredicateResults) GetPredicateResults(txHash common.Hash, address commo
 
 // SetTxPredicateResults sets the predicate results for the given [txHash]. Overrides results if present.
 func (p *PredicateResults) SetTxPredicateResults(txHash common.Hash, txResults TxPredicateResults) {
-	// If there are no tx results, omit them.
+	// If there are no tx results, don't store an entry in the map
 	if len(txResults) == 0 {
+		delete(p.Results, txHash)
 		return
 	}
 	p.Results[txHash] = txResults

--- a/precompile/results/predicate_results_test.go
+++ b/precompile/results/predicate_results_test.go
@@ -119,4 +119,10 @@ func TestPredicateResultsAccessors(t *testing.T) {
 	require.Equal(predicateResult, predicateResults.GetPredicateResults(txHash, addr))
 	predicateResults.DeleteTxPredicateResults(txHash)
 	require.Empty(predicateResults.GetPredicateResults(txHash, addr))
+
+	// Ensure setting empty tx predicate results removes the entry
+	predicateResults.SetTxPredicateResults(txHash, txPredicateResults)
+	require.Equal(predicateResult, predicateResults.GetPredicateResults(txHash, addr))
+	predicateResults.SetTxPredicateResults(txHash, map[common.Address][]byte{})
+	require.Empty(predicateResults.GetPredicateResults(txHash, addr))
 }


### PR DESCRIPTION
## Why this should be merged
More consistent behavior for SetTxPredicateResults. This also matches the existing comment which suggests present results will be overrided.

## How this works
Removes an previous entries from the map if an empty entry is provided for the same Tx hash.

## How this was tested
CI

## How is this documented
Updated comments