### PR TITLE
core/bloombits: fix deadlock when matcher session hits an error

### DIFF
--- a/core/bloombits/matcher.go
+++ b/core/bloombits/matcher.go
@@ -640,13 +640,16 @@ func (s *MatcherSession) Multiplex(batch int, wait time.Duration, mux chan chan 
 			request <- &Retrieval{Bit: bit, Sections: sections, Context: s.ctx}
 
 			result := <-request
+
+			// Deliver a result before s.Close() to avoid a deadlock
+			s.deliverSections(result.Bit, result.Sections, result.Bitsets)
+
 			if result.Error != nil {
 				s.errLock.Lock()
 				s.err = result.Error
 				s.errLock.Unlock()
 				s.Close()
 			}
-			s.deliverSections(result.Bit, result.Sections, result.Bitsets)
 		}
 	}
 }


### PR DESCRIPTION
## Why this should be merged

A block-pruned node encounters deadlock if a node receives `eth_getLogs` for a pruned block.  The node will eventually be killed because deadlocked goroutines do not release system resources.

With this patch, such `eth_getLogs` immediately returns a jsonrpc error.

## How this works

This patch has been merged in the upstream and will be included in the next version v1.13.2.  More technical details are described in the original PR https://github.com/ethereum/go-ethereum/pull/28184.

## How this was tested

We had this deadlock in our DFK Chain node.  This patch fixed it.

## How is this documented

No change is needed.
