### PR TITLE
Consolidate predicate prepare storage slots function

### DIFF
--- a/core/predicate_check.go
+++ b/core/predicate_check.go
@@ -31,6 +31,8 @@ func CheckPredicates(rules params.Rules, predicateContext *precompileconfig.Pred
 	if len(rules.Predicates) == 0 {
 		return predicateResults, nil
 	}
+
+	// Prepare the predicate storage slots from the transaction's access list
 	predicateArguments := predicateutils.PreparePredicateStorageSlots(rules, tx.AccessList())
 
 	for address, predicates := range predicateArguments {

--- a/core/predicate_check.go
+++ b/core/predicate_check.go
@@ -31,16 +31,7 @@ func CheckPredicates(rules params.Rules, predicateContext *precompileconfig.Pred
 	if len(rules.Predicates) == 0 {
 		return predicateResults, nil
 	}
-	predicateArguments := make(map[common.Address][][]byte)
-	for _, accessTuple := range tx.AccessList() {
-		address := accessTuple.Address
-		_, ok := rules.Predicates[address]
-		if !ok {
-			continue
-		}
-
-		predicateArguments[address] = append(predicateArguments[address], predicateutils.HashSliceToBytes(accessTuple.StorageKeys))
-	}
+	predicateArguments := predicateutils.PreparePredicateStorageSlots(rules, tx.AccessList())
 
 	for address, predicates := range predicateArguments {
 		// Since [address] is only added to [predicateArguments] when there's a valid predicate in the ruleset

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1190,24 +1190,10 @@ func (s *StateDB) Prepare(rules params.Rules, sender, coinbase common.Address, d
 			al.AddAddress(coinbase)
 		}
 
-		s.preparePredicateStorageSlots(rules, list)
+		s.predicateStorageSlots = predicateutils.PreparePredicateStorageSlots(rules, list)
 	}
 	// Reset transient storage at the beginning of transaction execution
 	s.transientStorage = newTransientStorage()
-}
-
-// preparePredicateStorageSlots populates the predicateStorageSlots field from the transaction's access list
-// Note: if an address is specified multiple times in the access list, each storage slot for that address is
-// appended to a slice of byte slices. Each byte slice represents a predicate, making it a slice of predicates
-// for each access list address, and every predicate in the slice goes through verification.
-func (s *StateDB) preparePredicateStorageSlots(rules params.Rules, list types.AccessList) {
-	s.predicateStorageSlots = make(map[common.Address][][]byte)
-	for _, el := range list {
-		if !rules.PredicateExists(el.Address) {
-			continue
-		}
-		s.predicateStorageSlots[el.Address] = append(s.predicateStorageSlots[el.Address], predicateutils.HashSliceToBytes(el.StorageKeys))
-	}
 }
 
 // AddAddressToAccessList adds the given address to the access list

--- a/utils/predicate/predicate_slots.go
+++ b/utils/predicate/predicate_slots.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-// PreparePredicateStorageSlots populates the predicateStorageSlots field from the transaction's access list
+// PreparePredicateStorageSlots populates the the predicate storage slots of a transaction's access list
 // Note: if an address is specified multiple times in the access list, each storage slot for that address is
 // appended to a slice of byte slices. Each byte slice represents a predicate, making it a slice of predicates
 // for each access list address, and every predicate in the slice goes through verification.

--- a/utils/predicate/predicate_slots.go
+++ b/utils/predicate/predicate_slots.go
@@ -1,0 +1,26 @@
+// (c) 2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package predicate
+
+import (
+	"github.com/ava-labs/subnet-evm/core/types"
+	"github.com/ava-labs/subnet-evm/params"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// PreparePredicateStorageSlots populates the predicateStorageSlots field from the transaction's access list
+// Note: if an address is specified multiple times in the access list, each storage slot for that address is
+// appended to a slice of byte slices. Each byte slice represents a predicate, making it a slice of predicates
+// for each access list address, and every predicate in the slice goes through verification.
+func PreparePredicateStorageSlots(rules params.Rules, list types.AccessList) map[common.Address][][]byte {
+	predicateStorageSlots := make(map[common.Address][][]byte)
+	for _, el := range list {
+		if !rules.PredicateExists(el.Address) {
+			continue
+		}
+		predicateStorageSlots[el.Address] = append(predicateStorageSlots[el.Address], HashSliceToBytes(el.StorageKeys))
+	}
+
+	return predicateStorageSlots
+}


### PR DESCRIPTION
## Why this should be merged
In `predicate_check` and `state_db` we were duplicating code for preparing the predicate storage slots from a transaction's access list. This PR consolidates them to a `util` function to make sure they're in sync and reduces duplication.

## How this works
- Creates separate file in utils `predicate_slots.go`
- Create utils `PreparePredicateStorageSlots` function
- Use util function for previous places.

## How this was tested
n/a

## How is this documented
comments in code
