### PR TITLE
Fixed some golang links.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -18,8 +18,8 @@ Please make sure your contributions adhere to our coding and documentation
 guidelines:
 
 - Code must adhere to the official Go
-  [formatting](https://golang.org/doc/effective_go.html#formatting) guidelines
-  (i.e. uses [gofmt](https://golang.org/cmd/gofmt/)).
+  [formatting](https://go.dev/doc/effective_go#formatting) guidelines
+  (i.e. uses [gofmt](https://pkg.go.dev/cmd/gofmt)).
 - Pull requests need to be based on and opened against the `master` branch.
 - Pull reuqests should include a detailed description
 - Commits are required to be signed. See [here](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
@@ -32,7 +32,7 @@ guidelines:
 - Code should be well commented, so it is easier to read and maintain.
  Any complex sections or invariants should be documented explicitly.
 - Code must be documented adhering to the official Go
-  [commentary](https://golang.org/doc/effective_go.html#commentary) guidelines.
+  [commentary](https://go.dev/doc/effective_go#commentary) guidelines.
 - Changes with user facing impact (e.g., addition or modification of flags and
  options) should be accompanied by a link to a pull request to the [avalanche-docs](https://github.com/ava-labs/avalanche-docs)
  repository. [example](https://github.com/ava-labs/avalanche-docs/pull/1119/files). 

--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ To support these changes, there have been a number of changes to the SubnetEVM b
 
 ### Clone Subnet-evm
 
-First install Go 1.20.8 or later. Follow the instructions [here](https://golang.org/doc/install). You can verify by running `go version`.
+First install Go 1.20.8 or later. Follow the instructions [here](https://go.dev/doc/install). You can verify by running `go version`.
 
-Set `$GOPATH` environment variable properly for Go to look for Go Workspaces. Please read [this](https://go.dev/doc/gopath_code) for details. You can verify by running `echo $GOPATH`.
+Set `$GOPATH` environment variable properly for Go to look for Go Workspaces. Please read [this](https://go.dev/doc/code) for details. You can verify by running `echo $GOPATH`.
 
 As a few software will be installed into `$GOPATH/bin`, please make sure that `$GOPATH/bin` is in your `$PATH`, otherwise, you may get error running the commands below.
 

--- a/core/txpool/list.go
+++ b/core/txpool/list.go
@@ -520,7 +520,7 @@ type pricedList struct {
 	// Number of stale price points to (re-heap trigger).
 	// This field is accessed atomically, and must be the first field
 	// to ensure it has correct alignment for atomic.AddInt64.
-	// See https://golang.org/pkg/sync/atomic/#pkg-note-BUG.
+	// See https://pkg.go.dev/sync/atomic#pkg-note-BUG.
 	stales int64
 
 	all              *lookup    // Pointer to the map of all transactions

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -5,7 +5,7 @@ go-metrics
 
 Go port of Coda Hale's Metrics library: <https://github.com/dropwizard/metrics>.
 
-Documentation: <https://godoc.org/github.com/rcrowley/go-metrics>.
+Documentation: <https://pkg.go.dev/github.com/rcrowley/go-metrics>.
 
 Usage
 -----


### PR DESCRIPTION
## Why this should be merged

Some links have been moved, updated to the latest version.

## How this works

Clicking on the current links used to go to the old links and then redirect to the new ones, now it will go directly to the new ones. 

## How this was tested

I clicked on the links and realized there was a redirection.

## How is this documented

There seemed to be no need to document it.
