### PR TITLE
clear messageCache on backend.Clear

### DIFF
--- a/warp/backend.go
+++ b/warp/backend.go
@@ -55,6 +55,7 @@ func NewBackend(warpSigner avalancheWarp.Signer, db database.Database, cacheSize
 
 func (b *backend) Clear() error {
 	b.signatureCache.Flush()
+	b.messageCache.Flush()
 	return database.Clear(b.db, batchSize)
 }
 


### PR DESCRIPTION
## Why this should be merged

We should be clearing all of the state from the `backend`.

## How this works

Clears cache on `Clear`.

## How this was tested

New UT

## How is this documented

N/A