### PR TITLE
bump golangci-lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.51
+          version: v1.54
           working-directory: .
           args: --timeout 10m
 

--- a/core/state/snapshot/conversion.go
+++ b/core/state/snapshot/conversion.go
@@ -216,6 +216,7 @@ func (stat *generateStats) report() {
 		}
 	}
 	log.Info("Iterating state snapshot", ctx...)
+
 }
 
 // reportDone prints the last log when the whole generation is finished.

--- a/core/state/snapshot/conversion.go
+++ b/core/state/snapshot/conversion.go
@@ -216,7 +216,6 @@ func (stat *generateStats) report() {
 		}
 	}
 	log.Info("Iterating state snapshot", ctx...)
-
 }
 
 // reportDone prints the last log when the whole generation is finished.


### PR DESCRIPTION
## Why this should be merged
Newer version of golangci-lint includes better linters incl. the wspace linter

## How this works
Bumps the version

## How this was tested
First commit fails lint on this PR (expected)

## How is this documented
N/A