### PR TITLE
Update release checklist to include deploying to WAGMI

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/release_checklist.md
@@ -26,4 +26,5 @@ Link the relevant documentation PRs for this release.
 - [ ] Update AvalancheGo dependency in scripts/versions.sh for e2e tests.
 - [ ] Add new entry in compatibility.json for RPCChainVM Compatibility
 - [ ] Update AvalancheGo compatibility in README
+- [ ] Deploy to WAGMI
 - [ ] Confirm goreleaser job has successfully generated binaries by checking the releases page


### PR DESCRIPTION
This PR adds deploying to WAGMI to the Subnet-EVM release process checklist.