### PR TITLE
Add Unit Test for Test Aggregate Signatures

### DIFF
--- a/warp/aggregator/aggregator_test.go
+++ b/warp/aggregator/aggregator_test.go
@@ -76,20 +76,22 @@ func TestAggregateSignatures(t *testing.T) {
 	}
 
 	type test struct {
-		name            string
-		contextFunc     func() context.Context
-		aggregatorFunc  func(*gomock.Controller) *Aggregator
-		unsignedMsg     *avalancheWarp.UnsignedMessage
-		quorumNum       uint64
-		expectedSigners []*avalancheWarp.Validator
-		expectedErr     error
+		name                  string
+		contextWithCancelFunc func() (context.Context, context.CancelFunc)
+		aggregatorFunc        func(*gomock.Controller, context.CancelFunc) *Aggregator
+		unsignedMsg           *avalancheWarp.UnsignedMessage
+		quorumNum             uint64
+		expectedSigners       []*avalancheWarp.Validator
+		expectedErr           error
 	}
 
 	tests := []test{
 		{
-			name:        "can't get height",
-			contextFunc: context.Background,
-			aggregatorFunc: func(ctrl *gomock.Controller) *Aggregator {
+			name: "can't get height",
+			contextWithCancelFunc: func() (context.Context, context.CancelFunc) {
+				return context.Background(), nil
+			},
+			aggregatorFunc: func(ctrl *gomock.Controller, _ context.CancelFunc) *Aggregator {
 				state := validators.NewMockState(ctrl)
 				state.EXPECT().GetCurrentHeight(gomock.Any()).Return(uint64(0), errTest)
 				return New(subnetID, state, nil)
@@ -99,9 +101,11 @@ func TestAggregateSignatures(t *testing.T) {
 			expectedErr: errTest,
 		},
 		{
-			name:        "can't get validator set",
-			contextFunc: context.Background,
-			aggregatorFunc: func(ctrl *gomock.Controller) *Aggregator {
+			name: "can't get validator set",
+			contextWithCancelFunc: func() (context.Context, context.CancelFunc) {
+				return context.Background(), nil
+			},
+			aggregatorFunc: func(ctrl *gomock.Controller, _ context.CancelFunc) *Aggregator {
 				state := validators.NewMockState(ctrl)
 				state.EXPECT().GetCurrentHeight(gomock.Any()).Return(pChainHeight, nil)
 				state.EXPECT().GetValidatorSet(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errTest)
@@ -111,9 +115,11 @@ func TestAggregateSignatures(t *testing.T) {
 			expectedErr: errTest,
 		},
 		{
-			name:        "no validators exist",
-			contextFunc: context.Background,
-			aggregatorFunc: func(ctrl *gomock.Controller) *Aggregator {
+			name: "no validators exist",
+			contextWithCancelFunc: func() (context.Context, context.CancelFunc) {
+				return context.Background(), nil
+			},
+			aggregatorFunc: func(ctrl *gomock.Controller, _ context.CancelFunc) *Aggregator {
 				state := validators.NewMockState(ctrl)
 				state.EXPECT().GetCurrentHeight(gomock.Any()).Return(pChainHeight, nil)
 				state.EXPECT().GetValidatorSet(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
@@ -124,9 +130,11 @@ func TestAggregateSignatures(t *testing.T) {
 			expectedErr: errNoValidators,
 		},
 		{
-			name:        "0/3 validators reply with signature",
-			contextFunc: context.Background,
-			aggregatorFunc: func(ctrl *gomock.Controller) *Aggregator {
+			name: "0/3 validators reply with signature",
+			contextWithCancelFunc: func() (context.Context, context.CancelFunc) {
+				return context.Background(), nil
+			},
+			aggregatorFunc: func(ctrl *gomock.Controller, _ context.CancelFunc) *Aggregator {
 				state := validators.NewMockState(ctrl)
 				state.EXPECT().GetCurrentHeight(gomock.Any()).Return(pChainHeight, nil)
 				state.EXPECT().GetValidatorSet(gomock.Any(), gomock.Any(), gomock.Any()).Return(
@@ -142,9 +150,11 @@ func TestAggregateSignatures(t *testing.T) {
 			expectedErr: avalancheWarp.ErrInsufficientWeight,
 		},
 		{
-			name:        "1/3 validators reply with signature; insufficient weight",
-			contextFunc: context.Background,
-			aggregatorFunc: func(ctrl *gomock.Controller) *Aggregator {
+			name: "1/3 validators reply with signature; insufficient weight",
+			contextWithCancelFunc: func() (context.Context, context.CancelFunc) {
+				return context.Background(), nil
+			},
+			aggregatorFunc: func(ctrl *gomock.Controller, _ context.CancelFunc) *Aggregator {
 				state := validators.NewMockState(ctrl)
 				state.EXPECT().GetCurrentHeight(gomock.Any()).Return(pChainHeight, nil)
 				state.EXPECT().GetValidatorSet(gomock.Any(), gomock.Any(), gomock.Any()).Return(
@@ -162,9 +172,11 @@ func TestAggregateSignatures(t *testing.T) {
 			expectedErr: avalancheWarp.ErrInsufficientWeight,
 		},
 		{
-			name:        "2/3 validators reply with signature; insufficient weight",
-			contextFunc: context.Background,
-			aggregatorFunc: func(ctrl *gomock.Controller) *Aggregator {
+			name: "2/3 validators reply with signature; insufficient weight",
+			contextWithCancelFunc: func() (context.Context, context.CancelFunc) {
+				return context.Background(), nil
+			},
+			aggregatorFunc: func(ctrl *gomock.Controller, _ context.CancelFunc) *Aggregator {
 				state := validators.NewMockState(ctrl)
 				state.EXPECT().GetCurrentHeight(gomock.Any()).Return(pChainHeight, nil)
 				state.EXPECT().GetValidatorSet(gomock.Any(), gomock.Any(), gomock.Any()).Return(
@@ -182,9 +194,11 @@ func TestAggregateSignatures(t *testing.T) {
 			expectedErr: avalancheWarp.ErrInsufficientWeight,
 		},
 		{
-			name:        "2/3 validators reply with signature; sufficient weight",
-			contextFunc: context.Background,
-			aggregatorFunc: func(ctrl *gomock.Controller) *Aggregator {
+			name: "2/3 validators reply with signature; sufficient weight",
+			contextWithCancelFunc: func() (context.Context, context.CancelFunc) {
+				return context.Background(), nil
+			},
+			aggregatorFunc: func(ctrl *gomock.Controller, _ context.CancelFunc) *Aggregator {
 				state := validators.NewMockState(ctrl)
 				state.EXPECT().GetCurrentHeight(gomock.Any()).Return(pChainHeight, nil)
 				state.EXPECT().GetValidatorSet(gomock.Any(), gomock.Any(), gomock.Any()).Return(
@@ -203,9 +217,11 @@ func TestAggregateSignatures(t *testing.T) {
 			expectedErr:     nil,
 		},
 		{
-			name:        "3/3 validators reply with signature; sufficient weight",
-			contextFunc: context.Background,
-			aggregatorFunc: func(ctrl *gomock.Controller) *Aggregator {
+			name: "3/3 validators reply with signature; sufficient weight",
+			contextWithCancelFunc: func() (context.Context, context.CancelFunc) {
+				return context.Background(), nil
+			},
+			aggregatorFunc: func(ctrl *gomock.Controller, _ context.CancelFunc) *Aggregator {
 				state := validators.NewMockState(ctrl)
 				state.EXPECT().GetCurrentHeight(gomock.Any()).Return(pChainHeight, nil)
 				state.EXPECT().GetValidatorSet(gomock.Any(), gomock.Any(), gomock.Any()).Return(
@@ -224,9 +240,11 @@ func TestAggregateSignatures(t *testing.T) {
 			expectedErr:     nil,
 		},
 		{
-			name:        "3/3 validators reply with signature; 1 invalid signature; sufficient weight",
-			contextFunc: context.Background,
-			aggregatorFunc: func(ctrl *gomock.Controller) *Aggregator {
+			name: "3/3 validators reply with signature; 1 invalid signature; sufficient weight",
+			contextWithCancelFunc: func() (context.Context, context.CancelFunc) {
+				return context.Background(), nil
+			},
+			aggregatorFunc: func(ctrl *gomock.Controller, _ context.CancelFunc) *Aggregator {
 				state := validators.NewMockState(ctrl)
 				state.EXPECT().GetCurrentHeight(gomock.Any()).Return(pChainHeight, nil)
 				state.EXPECT().GetValidatorSet(gomock.Any(), gomock.Any(), gomock.Any()).Return(
@@ -245,9 +263,11 @@ func TestAggregateSignatures(t *testing.T) {
 			expectedErr:     nil,
 		},
 		{
-			name:        "3/3 validators reply with signature; 3 invalid signatures; insufficient weight",
-			contextFunc: context.Background,
-			aggregatorFunc: func(ctrl *gomock.Controller) *Aggregator {
+			name: "3/3 validators reply with signature; 3 invalid signatures; insufficient weight",
+			contextWithCancelFunc: func() (context.Context, context.CancelFunc) {
+				return context.Background(), nil
+			},
+			aggregatorFunc: func(ctrl *gomock.Controller, _ context.CancelFunc) *Aggregator {
 				state := validators.NewMockState(ctrl)
 				state.EXPECT().GetCurrentHeight(gomock.Any()).Return(pChainHeight, nil)
 				state.EXPECT().GetValidatorSet(gomock.Any(), gomock.Any(), gomock.Any()).Return(
@@ -265,9 +285,11 @@ func TestAggregateSignatures(t *testing.T) {
 			expectedErr: avalancheWarp.ErrInsufficientWeight,
 		},
 		{
-			name:        "3/3 validators reply with signature; 2 invalid signatures; insufficient weight",
-			contextFunc: context.Background,
-			aggregatorFunc: func(ctrl *gomock.Controller) *Aggregator {
+			name: "3/3 validators reply with signature; 2 invalid signatures; insufficient weight",
+			contextWithCancelFunc: func() (context.Context, context.CancelFunc) {
+				return context.Background(), nil
+			},
+			aggregatorFunc: func(ctrl *gomock.Controller, _ context.CancelFunc) *Aggregator {
 				state := validators.NewMockState(ctrl)
 				state.EXPECT().GetCurrentHeight(gomock.Any()).Return(pChainHeight, nil)
 				state.EXPECT().GetValidatorSet(gomock.Any(), gomock.Any(), gomock.Any()).Return(
@@ -285,9 +307,11 @@ func TestAggregateSignatures(t *testing.T) {
 			expectedErr: avalancheWarp.ErrInsufficientWeight,
 		},
 		{
-			name:        "2/3 validators reply with signature; 1 invalid signature; sufficient weight",
-			contextFunc: context.Background,
-			aggregatorFunc: func(ctrl *gomock.Controller) *Aggregator {
+			name: "2/3 validators reply with signature; 1 invalid signature; sufficient weight",
+			contextWithCancelFunc: func() (context.Context, context.CancelFunc) {
+				return context.Background(), nil
+			},
+			aggregatorFunc: func(ctrl *gomock.Controller, _ context.CancelFunc) *Aggregator {
 				state := validators.NewMockState(ctrl)
 				state.EXPECT().GetCurrentHeight(gomock.Any()).Return(pChainHeight, nil)
 				state.EXPECT().GetValidatorSet(gomock.Any(), gomock.Any(), gomock.Any()).Return(
@@ -307,12 +331,12 @@ func TestAggregateSignatures(t *testing.T) {
 		},
 		{
 			name: "early termination of signature fetching on parent context cancelation",
-			contextFunc: func() context.Context {
+			contextWithCancelFunc: func() (context.Context, context.CancelFunc) {
 				ctx, cancel := context.WithCancel(context.Background())
 				cancel()
-				return ctx
+				return ctx, cancel
 			},
-			aggregatorFunc: func(ctrl *gomock.Controller) *Aggregator {
+			aggregatorFunc: func(ctrl *gomock.Controller, _ context.CancelFunc) *Aggregator {
 				state := validators.NewMockState(ctrl)
 				state.EXPECT().GetCurrentHeight(gomock.Any()).Return(pChainHeight, nil)
 				state.EXPECT().GetValidatorSet(gomock.Any(), gomock.Any(), gomock.Any()).Return(
@@ -354,9 +378,73 @@ func TestAggregateSignatures(t *testing.T) {
 			expectedErr:     avalancheWarp.ErrInsufficientWeight,
 		},
 		{
-			name:        "early termination of signature fetching on passing threshold",
-			contextFunc: context.Background,
-			aggregatorFunc: func(ctrl *gomock.Controller) *Aggregator {
+			name: "context cancels halfway through signature fetching",
+			contextWithCancelFunc: func() (context.Context, context.CancelFunc) {
+				ctx, cancel := context.WithCancel(context.Background())
+				return ctx, cancel
+			},
+			aggregatorFunc: func(ctrl *gomock.Controller, cancel context.CancelFunc) *Aggregator {
+				// defer cancel()
+				state := validators.NewMockState(ctrl)
+				state.EXPECT().GetCurrentHeight(gomock.Any()).Return(pChainHeight, nil)
+				state.EXPECT().GetValidatorSet(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					vdrSet, nil,
+				)
+
+				client := NewMockSignatureGetter(ctrl)
+				client.EXPECT().GetSignature(gomock.Any(), nodeID1, gomock.Any()).DoAndReturn(
+					func(ctx context.Context, _ ids.NodeID, _ *avalancheWarp.UnsignedMessage) (*bls.Signature, error) {
+						select {
+						case <-ctx.Done():
+							err := ctx.Err()
+							require.ErrorIs(t, err, context.Canceled)
+							return nil, err
+						default:
+							// cancel the context and return the signature
+							cancel()
+							return sig1, nil
+						}
+					},
+				)
+				client.EXPECT().GetSignature(gomock.Any(), nodeID2, gomock.Any()).DoAndReturn(
+					func(ctx context.Context, _ ids.NodeID, _ *avalancheWarp.UnsignedMessage) (*bls.Signature, error) {
+						select {
+						case <-ctx.Done():
+							err := ctx.Err()
+							require.ErrorIs(t, err, context.Canceled)
+							return nil, err
+						default:
+							// We should not be able to get this signature since context cancelled in another go routine
+							return sig2, nil
+						}
+					},
+				)
+				client.EXPECT().GetSignature(gomock.Any(), nodeID3, gomock.Any()).DoAndReturn(
+					func(ctx context.Context, _ ids.NodeID, _ *avalancheWarp.UnsignedMessage) (*bls.Signature, error) {
+						select {
+						case <-ctx.Done():
+							err := ctx.Err()
+							require.ErrorIs(t, err, context.Canceled)
+							return nil, err
+						default:
+							// We should not be able to get this signature since context cancelled in another go routine
+							return sig3, nil
+						}
+					},
+				)
+				return New(subnetID, state, client)
+			},
+			unsignedMsg:     unsignedMsg,
+			quorumNum:       33, // 1/3 Should have gotten one signature before cancellation
+			expectedSigners: []*avalancheWarp.Validator{vdr1},
+			expectedErr:     nil,
+		},
+		{
+			name: "early termination of signature fetching on passing threshold",
+			contextWithCancelFunc: func() (context.Context, context.CancelFunc) {
+				return context.Background(), nil
+			},
+			aggregatorFunc: func(ctrl *gomock.Controller, _ context.CancelFunc) *Aggregator {
 				state := validators.NewMockState(ctrl)
 				state.EXPECT().GetCurrentHeight(gomock.Any()).Return(pChainHeight, nil)
 				state.EXPECT().GetValidatorSet(gomock.Any(), gomock.Any(), gomock.Any()).Return(
@@ -390,9 +478,10 @@ func TestAggregateSignatures(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			require := require.New(t)
 
-			a := tt.aggregatorFunc(ctrl)
+			ctx, cancel := tt.contextWithCancelFunc()
+			a := tt.aggregatorFunc(ctrl, cancel)
 
-			res, err := a.AggregateSignatures(tt.contextFunc(), tt.unsignedMsg, tt.quorumNum)
+			res, err := a.AggregateSignatures(ctx, tt.unsignedMsg, tt.quorumNum)
 			require.ErrorIs(err, tt.expectedErr)
 			if err != nil {
 				return

--- a/warp/aggregator/aggregator_test.go
+++ b/warp/aggregator/aggregator_test.go
@@ -470,7 +470,7 @@ func TestAggregateSignatures(t *testing.T) {
 			require := require.New(t)
 
 			ctx, cancel := tt.contextWithCancelFunc()
-			// Guarantees that cancel is called preventing memory leak
+			// Guarantees that cancel is called preventing goroutine leak
 			if cancel != nil {
 				defer cancel()
 			}

--- a/warp/aggregator/aggregator_test.go
+++ b/warp/aggregator/aggregator_test.go
@@ -384,7 +384,6 @@ func TestAggregateSignatures(t *testing.T) {
 				return ctx, cancel
 			},
 			aggregatorFunc: func(ctrl *gomock.Controller, cancel context.CancelFunc) *Aggregator {
-				// defer cancel()
 				state := validators.NewMockState(ctrl)
 				state.EXPECT().GetCurrentHeight(gomock.Any()).Return(pChainHeight, nil)
 				state.EXPECT().GetValidatorSet(gomock.Any(), gomock.Any(), gomock.Any()).Return(

--- a/warp/aggregator/aggregator_test.go
+++ b/warp/aggregator/aggregator_test.go
@@ -393,16 +393,9 @@ func TestAggregateSignatures(t *testing.T) {
 				client := NewMockSignatureGetter(ctrl)
 				client.EXPECT().GetSignature(gomock.Any(), nodeID1, gomock.Any()).DoAndReturn(
 					func(ctx context.Context, _ ids.NodeID, _ *avalancheWarp.UnsignedMessage) (*bls.Signature, error) {
-						select {
-						case <-ctx.Done():
-							err := ctx.Err()
-							require.ErrorIs(t, err, context.Canceled)
-							return nil, err
-						default:
-							// cancel the context and return the signature
-							cancel()
-							return sig1, nil
-						}
+						// cancel the context and return the signature
+						cancel()
+						return sig1, nil
 					},
 				)
 				client.EXPECT().GetSignature(gomock.Any(), nodeID2, gomock.Any()).DoAndReturn(


### PR DESCRIPTION
## Why this should be merged

This unit test simulates the scenario where the context is canceled midway through signature fetching. 

All signature fetching go routines prior to cancellation should be able to get a signature. 

All signature fetching go routines after cancellation should return with context cancelled error and no signature. 

## How this works
The result should have an aggregate signature from only one validator.
## How this was tested
Only adds a UT. No actual change to any prod code. 
## How is this documented
UT is commented. 