### PR TITLE
fix warp event packing

### DIFF
--- a/plugin/evm/vm_warp_test.go
+++ b/plugin/evm/vm_warp_test.go
@@ -96,7 +96,7 @@ func TestSendWarpMessage(t *testing.T) {
 	}
 	require.Equal(expectedTopics, receipts[0].Logs[0].Topics)
 	logData := receipts[0].Logs[0].Data
-	unsignedMessage, err := avalancheWarp.ParseUnsignedMessage(logData)
+	unsignedMessage, err := warp.UnpackSendWarpEventDataToMessage(logData)
 	require.NoError(err)
 	unsignedMessageID := unsignedMessage.ID()
 

--- a/tests/warp/warp_test.go
+++ b/tests/warp/warp_test.go
@@ -232,7 +232,7 @@ var _ = ginkgo.Describe("[Warp]", ginkgo.Ordered, func() {
 		// the log extracted from the last block.
 		txLog := logs[0]
 		log.Info("Parsing logData as unsigned warp message")
-		unsignedMsg, err := avalancheWarp.ParseUnsignedMessage(txLog.Data)
+		unsignedMsg, err := warp.UnpackSendWarpEventDataToMessage(txLog.Data)
 		gomega.Expect(err).Should(gomega.BeNil())
 
 		// Set local variables for the duration of the test

--- a/x/warp/config.go
+++ b/x/warp/config.go
@@ -104,7 +104,7 @@ func (c *Config) Equal(s precompileconfig.Config) bool {
 }
 
 func (c *Config) Accept(acceptCtx *precompileconfig.AcceptContext, txHash common.Hash, logIndex int, topics []common.Hash, logData []byte) error {
-	unsignedMessage, err := warp.ParseUnsignedMessage(logData)
+	unsignedMessage, err := UnpackSendWarpEventDataToMessage(logData)
 	if err != nil {
 		return fmt.Errorf("failed to parse warp log data into unsigned message (TxHash: %s, LogIndex: %d): %w", txHash, logIndex, err)
 	}


### PR DESCRIPTION
Replaces: #924 

## Why this should be merged

Fixes the event packing for data for `SendWarpMessage`.

Fixes: #894

## How this works

Uses `abi` package `PackEvent`/`UnpackIntoInterface` functions to properly pack/unpack messages for event data.

## How this was tested

Fixes failing e2e tests. adds new UT tests.