### PR TITLE
warp: use bitset in predicate results to encode indexes of failures instead of success

### DIFF
--- a/x/warp/config.go
+++ b/x/warp/config.go
@@ -197,12 +197,13 @@ func (c *Config) verifyPredicate(predicateContext *precompileconfig.PredicateCon
 	return c.verifyWarpMessage(predicateContext, warpMessage)
 }
 
-// VerifyPredicate verifies the predicate represents a valid signed and properly formatted Avalanche Warp Message.
+// VerifyPredicate computes indices of predicates that failed verification as a bitset then returns the result
+// as a byte slice.
 func (c *Config) VerifyPredicate(predicateContext *precompileconfig.PredicateContext, predicates [][]byte) []byte {
 	resultBitSet := set.NewBits()
 
 	for predicateIndex, predicateBytes := range predicates {
-		if c.verifyPredicate(predicateContext, predicateBytes) {
+		if !c.verifyPredicate(predicateContext, predicateBytes) {
 			resultBitSet.Add(predicateIndex)
 		}
 	}

--- a/x/warp/contract_test.go
+++ b/x/warp/contract_test.go
@@ -201,9 +201,7 @@ func TestGetVerifiedWarpMessage(t *testing.T) {
 			Caller: callerAddr,
 			InputFn: func(t testing.TB) []byte {
 				input, err := PackGetVerifiedWarpMessage(1)
-				if err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, err)
 				return input
 			},
 			BeforeHook: func(t testing.TB, state contract.StateDB) {
@@ -226,9 +224,7 @@ func TestGetVerifiedWarpMessage(t *testing.T) {
 			Caller: callerAddr,
 			InputFn: func(t testing.TB) []byte {
 				input, err := PackGetVerifiedWarpMessage(1)
-				if err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, err)
 				return input
 			},
 			BeforeHook: func(t testing.TB, state contract.StateDB) {
@@ -258,9 +254,7 @@ func TestGetVerifiedWarpMessage(t *testing.T) {
 			Caller: callerAddr,
 			InputFn: func(t testing.TB) []byte {
 				input, err := PackGetVerifiedWarpMessage(1)
-				if err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, err)
 				return input
 			},
 			BeforeHook: func(t testing.TB, state contract.StateDB) {
@@ -417,9 +411,7 @@ func TestGetVerifiedWarpMessage(t *testing.T) {
 			Caller: callerAddr,
 			InputFn: func(t testing.TB) []byte {
 				res, err := PackGetVerifiedWarpMessage(math.MaxInt32 + 1)
-				if err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, err)
 				return res
 			},
 			SuppliedGas: GetVerifiedWarpMessageBaseCost,
@@ -430,9 +422,7 @@ func TestGetVerifiedWarpMessage(t *testing.T) {
 			Caller: callerAddr,
 			InputFn: func(t testing.TB) []byte {
 				res, err := PackGetVerifiedWarpMessage(1)
-				if err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, err)
 				return res[:len(res)-2]
 			},
 			SuppliedGas: GetVerifiedWarpMessageBaseCost,
@@ -491,9 +481,7 @@ func TestGetVerifiedWarpBlockHash(t *testing.T) {
 			Caller: callerAddr,
 			InputFn: func(t testing.TB) []byte {
 				input, err := PackGetVerifiedWarpBlockHash(1)
-				if err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, err)
 				return input
 			},
 			BeforeHook: func(t testing.TB, state contract.StateDB) {
@@ -516,9 +504,7 @@ func TestGetVerifiedWarpBlockHash(t *testing.T) {
 			Caller: callerAddr,
 			InputFn: func(t testing.TB) []byte {
 				input, err := PackGetVerifiedWarpBlockHash(1)
-				if err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, err)
 				return input
 			},
 			BeforeHook: func(t testing.TB, state contract.StateDB) {
@@ -547,9 +533,7 @@ func TestGetVerifiedWarpBlockHash(t *testing.T) {
 			Caller: callerAddr,
 			InputFn: func(t testing.TB) []byte {
 				input, err := PackGetVerifiedWarpBlockHash(1)
-				if err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, err)
 				return input
 			},
 			BeforeHook: func(t testing.TB, state contract.StateDB) {
@@ -705,9 +689,7 @@ func TestGetVerifiedWarpBlockHash(t *testing.T) {
 			Caller: callerAddr,
 			InputFn: func(t testing.TB) []byte {
 				res, err := PackGetVerifiedWarpBlockHash(math.MaxInt32 + 1)
-				if err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, err)
 				return res
 			},
 			SuppliedGas: GetVerifiedWarpMessageBaseCost,
@@ -718,9 +700,7 @@ func TestGetVerifiedWarpBlockHash(t *testing.T) {
 			Caller: callerAddr,
 			InputFn: func(t testing.TB) []byte {
 				res, err := PackGetVerifiedWarpBlockHash(1)
-				if err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, err)
 				return res[:len(res)-2]
 			},
 			SuppliedGas: GetVerifiedWarpMessageBaseCost,

--- a/x/warp/contract_warp_handler.go
+++ b/x/warp/contract_warp_handler.go
@@ -62,7 +62,7 @@ func handleWarpMessage(accessibleState contract.AccessibleState, input []byte, s
 	state := accessibleState.GetStateDB()
 	predicateBytes, exists := state.GetPredicateStorageSlots(ContractAddress, warpIndex)
 	predicateResults := accessibleState.GetBlockContext().GetPredicateResults(state.GetTxHash(), ContractAddress)
-	valid := exists && set.BitsFromBytes(predicateResults).Contains(warpIndex)
+	valid := exists && !set.BitsFromBytes(predicateResults).Contains(warpIndex)
 	if !valid {
 		return handler.packFailed(), remainingGas, nil
 	}


### PR DESCRIPTION
## Why this should be merged
Warp messages are encoded in the transaction's access list as a predicate, and the result of verifying the predicate with calling VerifyPredicate (success, fail) is stored the header as an encoded bitset. If we expect most of the transactions to represent successes (as opposed to txs that pay gas but reference invalid warp messages in the predicate), we can use 0 to encode success and 1 to encode failure.
This change has the advantage of using the empty byte slice to represent a valid transaction that only specifies valid warp messages.

The current implementation does the opposite: 1 for success and 0 for failure, which adds one or more bytes in the header for valid txs that only specify valid warp messages.

## How this works
Changes the logic to add 1 to the bitset on error instead of success

## How this was tested
CI + additional UT

## How is this documented
N/A (implementation change)