### PR TITLE
x/warp: update PredicateGas to require warp message contains a valid payload

### DIFF
--- a/x/warp/config.go
+++ b/x/warp/config.go
@@ -30,7 +30,7 @@ var (
 	errOverflowSignersGasCost  = errors.New("overflow calculating warp signers gas cost")
 	errInvalidPredicateBytes   = errors.New("cannot unpack predicate bytes")
 	errInvalidWarpMsg          = errors.New("cannot unpack warp message")
-	errInvalidWarpMsgPayoad    = errors.New("cannot unpack warp message payload")
+	errInvalidWarpMsgPayload   = errors.New("cannot unpack warp message payload")
 	errInvalidAddressedPayload = errors.New("cannot unpack addressed payload")
 	errInvalidBlockHashPayload = errors.New("cannot unpack block hash payload")
 	errCannotGetNumSigners     = errors.New("cannot fetch num signers from warp message")
@@ -172,7 +172,7 @@ func (c *Config) PredicateGas(predicateBytes []byte) (uint64, error) {
 	}
 	_, err = payload.Parse(warpMessage.Payload)
 	if err != nil {
-		return 0, fmt.Errorf("%w: %s", errInvalidWarpMsgPayoad, err)
+		return 0, fmt.Errorf("%w: %s", errInvalidWarpMsgPayload, err)
 	}
 
 	numSigners, err := warpMessage.Signature.NumSigners()

--- a/x/warp/config.go
+++ b/x/warp/config.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/vms/platformvm/warp"
+	"github.com/ava-labs/avalanchego/vms/platformvm/warp/payload"
 	"github.com/ava-labs/subnet-evm/params"
 	"github.com/ava-labs/subnet-evm/precompile/precompileconfig"
 	"github.com/ava-labs/subnet-evm/predicate"
@@ -29,6 +30,7 @@ var (
 	errOverflowSignersGasCost  = errors.New("overflow calculating warp signers gas cost")
 	errInvalidPredicateBytes   = errors.New("cannot unpack predicate bytes")
 	errInvalidWarpMsg          = errors.New("cannot unpack warp message")
+	errInvalidWarpMsgPayoad    = errors.New("cannot unpack warp message payload")
 	errInvalidAddressedPayload = errors.New("cannot unpack addressed payload")
 	errInvalidBlockHashPayload = errors.New("cannot unpack block hash payload")
 	errCannotGetNumSigners     = errors.New("cannot fetch num signers from warp message")
@@ -147,6 +149,8 @@ func (c *Config) verifyWarpMessage(predicateContext *precompileconfig.PredicateC
 // 2. Size of the message
 // 3. Number of signers
 // 4. TODO: Lookup of the validator set
+//
+// If the payload of the warp message fails parsing, return a non-nil error invalidating the transaction.
 func (c *Config) PredicateGas(predicateBytes []byte) (uint64, error) {
 	totalGas := GasCostPerSignatureVerification
 	bytesGasCost, overflow := math.SafeMul(GasCostPerWarpMessageBytes, uint64(len(predicateBytes)))
@@ -165,6 +169,10 @@ func (c *Config) PredicateGas(predicateBytes []byte) (uint64, error) {
 	warpMessage, err := warp.ParseMessage(unpackedPredicateBytes)
 	if err != nil {
 		return 0, fmt.Errorf("%w: %s", errInvalidWarpMsg, err)
+	}
+	_, err = payload.Parse(warpMessage.Payload)
+	if err != nil {
+		return 0, fmt.Errorf("%w: %s", errInvalidWarpMsgPayoad, err)
 	}
 
 	numSigners, err := warpMessage.Signature.NumSigners()

--- a/x/warp/predicate_test.go
+++ b/x/warp/predicate_test.go
@@ -395,7 +395,7 @@ func TestInvalidAddressedPayload(t *testing.T) {
 		},
 		StorageSlots: [][]byte{predicateBytes},
 		Gas:          GasCostPerSignatureVerification + uint64(len(predicateBytes))*GasCostPerWarpMessageBytes + uint64(numKeys)*GasCostPerWarpSigner,
-		GasErr:       errInvalidWarpMsgPayoad,
+		GasErr:       errInvalidWarpMsgPayload,
 	}
 
 	test.Run(t)

--- a/x/warp/predicate_test.go
+++ b/x/warp/predicate_test.go
@@ -232,7 +232,9 @@ func TestWarpMessageFromPrimaryNetwork(t *testing.T) {
 	require := require.New(t)
 	numKeys := 10
 	cChainID := ids.GenerateTestID()
-	unsignedMsg, err := avalancheWarp.NewUnsignedMessage(networkID, cChainID, []byte{1, 2, 3})
+	addressedCall, err := payload.NewAddressedCall(utils.RandomBytes(20), utils.RandomBytes(100))
+	require.NoError(err)
+	unsignedMsg, err := avalancheWarp.NewUnsignedMessage(networkID, cChainID, addressedCall.Bytes())
 	require.NoError(err)
 
 	getValidatorsOutput := make(map[ids.NodeID]*validators.GetValidatorOutput)
@@ -393,18 +395,19 @@ func TestInvalidAddressedPayload(t *testing.T) {
 		},
 		StorageSlots: [][]byte{predicateBytes},
 		Gas:          GasCostPerSignatureVerification + uint64(len(predicateBytes))*GasCostPerWarpMessageBytes + uint64(numKeys)*GasCostPerWarpSigner,
-		GasErr:       nil,
-		PredicateRes: set.NewBits(0).Bytes(),
+		GasErr:       errInvalidWarpMsgPayoad,
 	}
 
 	test.Run(t)
 }
 
 func TestInvalidBitSet(t *testing.T) {
+	addressedCall, err := payload.NewAddressedCall(utils.RandomBytes(20), utils.RandomBytes(100))
+	require.NoError(t, err)
 	unsignedMsg, err := avalancheWarp.NewUnsignedMessage(
 		networkID,
 		sourceChainID,
-		[]byte{1, 2, 3},
+		addressedCall.Bytes(),
 	)
 	require.NoError(t, err)
 


### PR DESCRIPTION
This PR updates `PredicateGas` of the warp precompile to parse the payload included in a warp message and return an error if it does not match a valid payload format defined by AvalancheGo.