### PR TITLE
remove flaky flag from golangbindings test

### DIFF
--- a/accounts/abi/bind/bind_test.go
+++ b/accounts/abi/bind/bind_test.go
@@ -2063,7 +2063,6 @@ func TestGolangBindingsOverload(t *testing.T) {
 }
 
 func TestGolangBindings(t *testing.T) {
-	t.Skip("FLAKY")
 	golangBindings(t, false)
 }
 

--- a/accounts/abi/bind/precompilebind/precompile_bind_test.go
+++ b/accounts/abi/bind/precompilebind/precompile_bind_test.go
@@ -514,7 +514,7 @@ func TestPrecompileBind(t *testing.T) {
 	// Create a temporary workspace for the test suite
 	ws := t.TempDir()
 
-	pkg := filepath.Join(ws, "bindtest")
+	pkg := filepath.Join(ws, "precompilebindtest")
 	if err := os.MkdirAll(pkg, 0o700); err != nil {
 		t.Fatalf("failed to create package: %v", err)
 	}
@@ -581,7 +581,7 @@ func TestPrecompileBind(t *testing.T) {
 		})
 	}
 
-	moder := exec.Command(gocmd, "mod", "init", "bindtest")
+	moder := exec.Command(gocmd, "mod", "init", "precompilebindtest")
 	moder.Dir = pkg
 	if out, err := moder.CombinedOutput(); err != nil {
 		t.Fatalf("failed to convert binding test to modules: %v\n%s", err, out)


### PR DESCRIPTION
I've run this few hundreds (even thousands) of times and got no flakiness. I wonder if this was because in some very rare cases we were overwriting the temp dir with the precompilebind tests. I changed the path for precompile bind tests and removed flaky flag.
Closes #828 