### PR TITLE
use cgo in mockgen

### DIFF
--- a/scripts/build_image.sh
+++ b/scripts/build_image.sh
@@ -5,13 +5,18 @@ set -o nounset
 set -o pipefail
 
 # Avalanche root directory
-SUBNET_EVM_PATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
+SUBNET_EVM_PATH=$(
+  cd "$(dirname "${BASH_SOURCE[0]}")"
+  cd .. && pwd
+)
 
 # Load the versions
 source "$SUBNET_EVM_PATH"/scripts/versions.sh
 
 # Load the constants
 source "$SUBNET_EVM_PATH"/scripts/constants.sh
+
+BUILD_IMAGE_ID=${BUILD_IMAGE_ID:-"${AVALANCHEGO_VERSION}-Subnet-EVM-${CURRENT_BRANCH}"}
 
 echo "Building Docker Image: $DOCKERHUB_REPO:$BUILD_IMAGE_ID based of $AVALANCHEGO_VERSION"
 docker build -t "$DOCKERHUB_REPO:$BUILD_IMAGE_ID" "$SUBNET_EVM_PATH" -f "$SUBNET_EVM_PATH/Dockerfile" \

--- a/scripts/constants.sh
+++ b/scripts/constants.sh
@@ -25,8 +25,6 @@ fi
 
 echo "Using branch: ${CURRENT_BRANCH}"
 
-BUILD_IMAGE_ID=${BUILD_IMAGE_ID:-"${AVALANCHEGO_VERSION}-Subnet-EVM-${CURRENT_BRANCH}"}
-
 # Static compilation
 STATIC_LD_FLAGS=''
 if [ "${STATIC_COMPILATION:-}" = 1 ]; then

--- a/scripts/constants.sh
+++ b/scripts/constants.sh
@@ -7,14 +7,13 @@ GOPATH="$(go env GOPATH)"
 DOCKERHUB_REPO="avaplatform/avalanchego"
 
 # if this isn't a git repository (say building from a release), don't set our git constants.
-if [ ! -d .git ]
-then
+if [ ! -d .git ]; then
     CURRENT_BRANCH=""
     SUBNET_EVM_COMMIT=""
     SUBNET_EVM_COMMIT_ID=""
 else
     # Current branch
-    CURRENT_BRANCH=${CURRENT_BRANCH:-$(git describe --tags --exact-match 2> /dev/null || git symbolic-ref -q --short HEAD || git rev-parse --short HEAD || :)}
+    CURRENT_BRANCH=${CURRENT_BRANCH:-$(git describe --tags --exact-match 2>/dev/null || git symbolic-ref -q --short HEAD || git rev-parse --short HEAD || :)}
 
     # Image build id
     #
@@ -30,10 +29,9 @@ BUILD_IMAGE_ID=${BUILD_IMAGE_ID:-"${AVALANCHEGO_VERSION}-Subnet-EVM-${CURRENT_BR
 
 # Static compilation
 STATIC_LD_FLAGS=''
-if [ "${STATIC_COMPILATION:-}" = 1 ]
-then
+if [ "${STATIC_COMPILATION:-}" = 1 ]; then
     export CC=musl-gcc
-    command -v $CC || ( echo $CC must be available for static compilation && exit 1 )
+    command -v $CC || (echo $CC must be available for static compilation && exit 1)
     STATIC_LD_FLAGS=' -extldflags "-static" -linkmode external '
 fi
 
@@ -41,4 +39,4 @@ fi
 #
 # We use "export" here instead of just setting a bash variable because we need
 # to pass this flag to all child processes spawned by the shell.
-export CGO_CFLAGS="-O -D__BLST_PORTABLE__"
+export CGO_CFLAGS="-O2 -D__BLST_PORTABLE__"

--- a/scripts/mock.gen.sh
+++ b/scripts/mock.gen.sh
@@ -19,6 +19,8 @@ if ! command -v go-license &>/dev/null; then
   go install -v github.com/palantir/go-license@v1.25.0
 fi
 
+source ./scripts/constants.sh
+
 # tuples of (source interface import path, comma-separated interface names, output file path)
 input="scripts/mocks.mockgen.txt"
 while IFS= read -r line; do

--- a/scripts/mock.gen.sh
+++ b/scripts/mock.gen.sh
@@ -2,6 +2,12 @@
 
 set -euo pipefail
 
+# Root directory
+SUBNET_EVM_PATH=$(
+  cd "$(dirname "${BASH_SOURCE[0]}")"
+  cd .. && pwd
+)
+
 if ! [[ "$0" =~ scripts/mock.gen.sh ]]; then
   echo "must be run from repository root"
   exit 255
@@ -19,7 +25,8 @@ if ! command -v go-license &>/dev/null; then
   go install -v github.com/palantir/go-license@v1.25.0
 fi
 
-source ./scripts/constants.sh
+# Load the constants
+source "$SUBNET_EVM_PATH"/scripts/constants.sh
 
 # tuples of (source interface import path, comma-separated interface names, output file path)
 input="scripts/mocks.mockgen.txt"


### PR DESCRIPTION
## Why this should be merged

Ports changes from https://github.com/ava-labs/avalanchego/pull/2184 to fix flaky mockgen.

Closes: #972 

## How this works

Uses `-O2` flag for CGO flags and imports it in mockgen script.

## How this was tested

This should fix flaky tests.
