### PR TITLE
Fix tracer precompile upgrade

### DIFF
--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -254,6 +254,11 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 		b := &BlockGen{i: i, chain: blocks, parent: parent, statedb: statedb, config: config, engine: engine}
 		b.header = makeHeader(chainreader, config, parent, gap, statedb, b.engine)
 
+		err := ApplyUpgrades(config, &parent.Header().Time, b, statedb)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to configure precompiles %v", err)
+		}
+
 		// Execute any user modifications to the block
 		if gen != nil {
 			gen(i, b)

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -656,6 +656,11 @@ func (api *baseAPI) traceBlock(ctx context.Context, block *types.Block, config *
 	}
 	defer release()
 
+	err = core.ApplyUpgrades(api.backend.ChainConfig(), &parent.Header().Time, block, statedb)
+	if err != nil {
+		return nil, fmt.Errorf("failed to configure precompiles in block tracing %v", err)
+	}
+
 	// JS tracers have high overhead. In this case run a parallel
 	// process that generates states in one thread and traces txes
 	// in separate worker threads.

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -230,7 +230,7 @@ func TestTraceCall(t *testing.T) {
 	})
 	defer backend.teardown()
 	api := NewAPI(backend)
-	var testSuite = []struct {
+	testSuite := []struct {
 		blockNumber rpc.BlockNumber
 		call        ethapi.TransactionArgs
 		config      *TraceCallConfig
@@ -271,7 +271,7 @@ func TestTraceCall(t *testing.T) {
 			},
 			config:    nil,
 			expectErr: fmt.Errorf("block #%d not found", genBlocks+1),
-			//expect:    nil,
+			// expect:    nil,
 		},
 		// Standard JSON trace upon the latest block
 		{
@@ -415,7 +415,7 @@ func TestTraceBlock(t *testing.T) {
 	defer backend.chain.Stop()
 	api := NewAPI(backend)
 
-	var testSuite = []struct {
+	testSuite := []struct {
 		blockNumber rpc.BlockNumber
 		config      *TraceConfig
 		want        string
@@ -509,7 +509,7 @@ func TestTracingWithOverrides(t *testing.T) {
 		Failed      bool
 		ReturnValue string
 	}
-	var testSuite = []struct {
+	testSuite := []struct {
 		blockNumber rpc.BlockNumber
 		call        ethapi.TransactionArgs
 		config      *TraceCallConfig
@@ -566,7 +566,7 @@ func TestTracingWithOverrides(t *testing.T) {
 				Data: newRPCBytes(common.Hex2Bytes("8381f58a")), // call number()
 			},
 			config: &TraceCallConfig{
-				//Tracer: &tracer,
+				// Tracer: &tracer,
 				StateOverrides: &ethapi.StateOverride{
 					randomAccounts[2].addr: ethapi.OverrideAccount{
 						Code:      newRPCBytes(common.Hex2Bytes("6080604052348015600f57600080fd5b506004361060285760003560e01c80638381f58a14602d575b600080fd5b60336049565b6040518082815260200191505060405180910390f35b6000548156fea2646970667358221220eab35ffa6ab2adfe380772a48b8ba78e82a1b820a18fcb6f59aa4efb20a5f60064736f6c63430007040033")),
@@ -658,7 +658,7 @@ func TestTracingWithOverrides(t *testing.T) {
 					},
 				},
 			},
-			//want: `{"gas":46900,"failed":false,"returnValue":"0000000000000000000000000000000000000000000000000000000000000539"}`,
+			// want: `{"gas":46900,"failed":false,"returnValue":"0000000000000000000000000000000000000000000000000000000000000539"}`,
 			want: `{"gas":44100,"failed":false,"returnValue":"0000000000000000000000000000000000000000000000000000000000000001"}`,
 		},
 		{ // No state override
@@ -683,7 +683,7 @@ func TestTracingWithOverrides(t *testing.T) {
 							byte(vm.MSTORE),
 							// RETURN (0, 32)
 							byte(vm.PUSH1), 32,
-							byte(vm.PUSH1), 00,
+							byte(vm.PUSH1), 0o0,
 							byte(vm.RETURN),
 						}),
 					},
@@ -718,7 +718,7 @@ func TestTracingWithOverrides(t *testing.T) {
 							byte(vm.MSTORE),
 							// RETURN (0, 32)
 							byte(vm.PUSH1), 32,
-							byte(vm.PUSH1), 00,
+							byte(vm.PUSH1), 0o0,
 							byte(vm.RETURN),
 						}),
 						State: newStates(
@@ -756,7 +756,7 @@ func TestTracingWithOverrides(t *testing.T) {
 							byte(vm.MSTORE),
 							// RETURN (0, 32)
 							byte(vm.PUSH1), 32,
-							byte(vm.PUSH1), 00,
+							byte(vm.PUSH1), 0o0,
 							byte(vm.RETURN),
 						}),
 						StateDiff: &map[common.Hash]common.Hash{
@@ -876,7 +876,7 @@ func TestTraceChain(t *testing.T) {
 	api := NewAPI(backend)
 
 	single := `{"result":{"gas":21000,"failed":false,"returnValue":"","structLogs":[]}}`
-	var cases = []struct {
+	cases := []struct {
 		start  uint64
 		end    uint64
 		config *TraceConfig
@@ -921,8 +921,9 @@ func TestTraceBlockPrecompileActivation(t *testing.T) {
 
 	// Initialize test accounts
 	accounts := newAccounts(3)
+	copyConfig := *params.TestChainConfig
 	genesis := &core.Genesis{
-		Config: params.TestChainConfig,
+		Config: &copyConfig,
 		Alloc: core.GenesisAlloc{
 			accounts[0].addr: {Balance: big.NewInt(params.Ether)},
 			accounts[1].addr: {Balance: big.NewInt(params.Ether)},

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/ava-labs/subnet-evm/ethdb"
 	"github.com/ava-labs/subnet-evm/internal/ethapi"
 	"github.com/ava-labs/subnet-evm/params"
+	"github.com/ava-labs/subnet-evm/precompile/contracts/txallowlist"
 	"github.com/ava-labs/subnet-evm/rpc"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -911,6 +912,109 @@ func TestTraceChain(t *testing.T) {
 		}
 		if ref != rel {
 			t.Errorf("Ref and deref actions are not equal, ref %d rel %d", ref, rel)
+		}
+	}
+}
+
+func TestTraceBlockPrecompileActivation(t *testing.T) {
+	t.Parallel()
+
+	// Initialize test accounts
+	accounts := newAccounts(3)
+	genesis := &core.Genesis{
+		Config: params.TestChainConfig,
+		Alloc: core.GenesisAlloc{
+			accounts[0].addr: {Balance: big.NewInt(params.Ether)},
+			accounts[1].addr: {Balance: big.NewInt(params.Ether)},
+			accounts[2].addr: {Balance: big.NewInt(params.Ether)},
+		},
+	}
+	// assumes gap is 10 sec, means 3 block away
+	activateAllowlistBlock := 3
+	activateAllowListTime := uint64(activateAllowlistBlock * 10)
+	activateTxAllowListConfig := params.PrecompileUpgrade{
+		Config: txallowlist.NewConfig(&activateAllowListTime, []common.Address{accounts[0].addr}, nil, nil),
+	}
+
+	deactivateAllowlistBlock := activateAllowlistBlock + 3
+	deactivateAllowListTime := uint64(deactivateAllowlistBlock) * 10
+	deactivateTxAllowListConfig := params.PrecompileUpgrade{
+		Config: txallowlist.NewDisableConfig(&deactivateAllowListTime),
+	}
+
+	genesis.Config.PrecompileUpgrades = []params.PrecompileUpgrade{
+		activateTxAllowListConfig,
+		deactivateTxAllowListConfig,
+	}
+	genBlocks := 10
+	signer := types.HomesteadSigner{}
+	backend := newTestBackend(t, genBlocks, genesis, func(i int, b *core.BlockGen) {
+		// Transfer from account[0] to account[1]
+		//    value: 1000 wei
+		//    fee:   0 wei
+		tx, _ := types.SignTx(types.NewTransaction(uint64(i), accounts[1].addr, big.NewInt(1000), params.TxGas, b.BaseFee(), nil), signer, accounts[0].key)
+		b.AddTx(tx)
+	})
+	defer backend.chain.Stop()
+	api := NewAPI(backend)
+
+	testSuite := []struct {
+		blockNumber rpc.BlockNumber
+		config      *TraceConfig
+		want        string
+		expectErr   error
+	}{
+		// Trace head block
+		{
+			blockNumber: rpc.BlockNumber(genBlocks),
+			want:        `[{"result":{"gas":21000,"failed":false,"returnValue":"","structLogs":[]}}]`,
+		},
+		// Trace block before activation
+		{
+			blockNumber: rpc.BlockNumber(activateAllowlistBlock - 1),
+			want:        `[{"result":{"gas":21000,"failed":false,"returnValue":"","structLogs":[]}}]`,
+		},
+		// Trace block activation
+		{
+			blockNumber: rpc.BlockNumber(activateAllowlistBlock),
+			want:        `[{"result":{"gas":21000,"failed":false,"returnValue":"","structLogs":[]}}]`,
+		},
+		// Trace block after activation
+		{
+			blockNumber: rpc.BlockNumber(activateAllowlistBlock + 1),
+			want:        `[{"result":{"gas":21000,"failed":false,"returnValue":"","structLogs":[]}}]`,
+		},
+		// Trace block deactivation
+		{
+			blockNumber: rpc.BlockNumber(deactivateAllowlistBlock),
+			want:        `[{"result":{"gas":21000,"failed":false,"returnValue":"","structLogs":[]}}]`,
+		},
+		// Trace block after deactivation
+		{
+			blockNumber: rpc.BlockNumber(deactivateAllowlistBlock + 1),
+			want:        `[{"result":{"gas":21000,"failed":false,"returnValue":"","structLogs":[]}}]`,
+		},
+	}
+	for i, tc := range testSuite {
+		result, err := api.TraceBlockByNumber(context.Background(), tc.blockNumber, tc.config)
+		if tc.expectErr != nil {
+			if err == nil {
+				t.Errorf("test %d, want error %v", i, tc.expectErr)
+				continue
+			}
+			if !reflect.DeepEqual(err, tc.expectErr) {
+				t.Errorf("test %d: error mismatch, want %v, get %v", i, tc.expectErr, err)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("test %d, want no error, have %v", i, err)
+			continue
+		}
+		have, _ := json.Marshal(result)
+		want := tc.want
+		if string(have) != want {
+			t.Errorf("test %d, result mismatch, have\n%v\n, want\n%v\n", i, string(have), want)
 		}
 	}
 }

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -230,7 +230,7 @@ func TestTraceCall(t *testing.T) {
 	})
 	defer backend.teardown()
 	api := NewAPI(backend)
-	testSuite := []struct {
+	var testSuite = []struct {
 		blockNumber rpc.BlockNumber
 		call        ethapi.TransactionArgs
 		config      *TraceCallConfig
@@ -271,7 +271,7 @@ func TestTraceCall(t *testing.T) {
 			},
 			config:    nil,
 			expectErr: fmt.Errorf("block #%d not found", genBlocks+1),
-			// expect:    nil,
+			//expect:    nil,
 		},
 		// Standard JSON trace upon the latest block
 		{
@@ -415,7 +415,7 @@ func TestTraceBlock(t *testing.T) {
 	defer backend.chain.Stop()
 	api := NewAPI(backend)
 
-	testSuite := []struct {
+	var testSuite = []struct {
 		blockNumber rpc.BlockNumber
 		config      *TraceConfig
 		want        string
@@ -509,7 +509,7 @@ func TestTracingWithOverrides(t *testing.T) {
 		Failed      bool
 		ReturnValue string
 	}
-	testSuite := []struct {
+	var testSuite = []struct {
 		blockNumber rpc.BlockNumber
 		call        ethapi.TransactionArgs
 		config      *TraceCallConfig
@@ -566,7 +566,7 @@ func TestTracingWithOverrides(t *testing.T) {
 				Data: newRPCBytes(common.Hex2Bytes("8381f58a")), // call number()
 			},
 			config: &TraceCallConfig{
-				// Tracer: &tracer,
+				//Tracer: &tracer,
 				StateOverrides: &ethapi.StateOverride{
 					randomAccounts[2].addr: ethapi.OverrideAccount{
 						Code:      newRPCBytes(common.Hex2Bytes("6080604052348015600f57600080fd5b506004361060285760003560e01c80638381f58a14602d575b600080fd5b60336049565b6040518082815260200191505060405180910390f35b6000548156fea2646970667358221220eab35ffa6ab2adfe380772a48b8ba78e82a1b820a18fcb6f59aa4efb20a5f60064736f6c63430007040033")),
@@ -658,7 +658,7 @@ func TestTracingWithOverrides(t *testing.T) {
 					},
 				},
 			},
-			// want: `{"gas":46900,"failed":false,"returnValue":"0000000000000000000000000000000000000000000000000000000000000539"}`,
+			//want: `{"gas":46900,"failed":false,"returnValue":"0000000000000000000000000000000000000000000000000000000000000539"}`,
 			want: `{"gas":44100,"failed":false,"returnValue":"0000000000000000000000000000000000000000000000000000000000000001"}`,
 		},
 		{ // No state override
@@ -683,7 +683,7 @@ func TestTracingWithOverrides(t *testing.T) {
 							byte(vm.MSTORE),
 							// RETURN (0, 32)
 							byte(vm.PUSH1), 32,
-							byte(vm.PUSH1), 0o0,
+							byte(vm.PUSH1), 00,
 							byte(vm.RETURN),
 						}),
 					},
@@ -718,7 +718,7 @@ func TestTracingWithOverrides(t *testing.T) {
 							byte(vm.MSTORE),
 							// RETURN (0, 32)
 							byte(vm.PUSH1), 32,
-							byte(vm.PUSH1), 0o0,
+							byte(vm.PUSH1), 00,
 							byte(vm.RETURN),
 						}),
 						State: newStates(
@@ -756,7 +756,7 @@ func TestTracingWithOverrides(t *testing.T) {
 							byte(vm.MSTORE),
 							// RETURN (0, 32)
 							byte(vm.PUSH1), 32,
-							byte(vm.PUSH1), 0o0,
+							byte(vm.PUSH1), 00,
 							byte(vm.RETURN),
 						}),
 						StateDiff: &map[common.Hash]common.Hash{
@@ -876,7 +876,7 @@ func TestTraceChain(t *testing.T) {
 	api := NewAPI(backend)
 
 	single := `{"result":{"gas":21000,"failed":false,"returnValue":"","structLogs":[]}}`
-	cases := []struct {
+	var cases = []struct {
 		start  uint64
 		end    uint64
 		config *TraceConfig


### PR DESCRIPTION
## Why this should be merged

Currently we don't apply upgrades in tracing. This PR adds regression test + fix.

Closes: #976 

## How this works

Call ApplyUpgrades before applying transactions in the tracer.

## How this was tested

added regression test

## How is this documented
