### PR TITLE
warp: add details to accepted message log

### DIFF
--- a/plugin/evm/block.go
+++ b/plugin/evm/block.go
@@ -121,7 +121,7 @@ func (b *Block) handlePrecompileAccept(rules *params.Rules, sharedMemoryWriter *
 			if !ok {
 				continue
 			}
-			if err := accepter.Accept(acceptCtx, log.TxHash, logIdx, log.Topics, log.Data); err != nil {
+			if err := accepter.Accept(acceptCtx, log.BlockHash, log.BlockNumber, log.TxHash, logIdx, log.Topics, log.Data); err != nil {
 				return err
 			}
 		}

--- a/plugin/evm/block_test.go
+++ b/plugin/evm/block_test.go
@@ -69,6 +69,8 @@ func TestHandlePrecompileAccept(t *testing.T) {
 	gomock.InOrder(
 		mockAccepter.EXPECT().Accept(
 			gomock.Not(gomock.Nil()),                // acceptCtx
+			ethBlock.Hash(),                         // blockHash
+			ethBlock.NumberU64(),                    // blockNumber
 			ethBlock.Transactions()[txIndex].Hash(), // txHash
 			0,                                       // logIndex
 			receipt.Logs[0].Topics,                  // topics
@@ -76,6 +78,8 @@ func TestHandlePrecompileAccept(t *testing.T) {
 		),
 		mockAccepter.EXPECT().Accept(
 			gomock.Not(gomock.Nil()),                // acceptCtx
+			ethBlock.Hash(),                         // blockHash
+			ethBlock.NumberU64(),                    // blockNumber
 			ethBlock.Transactions()[txIndex].Hash(), // txHash
 			2,                                       // logIndex
 			receipt.Logs[2].Topics,                  // topics

--- a/precompile/precompileconfig/config.go
+++ b/precompile/precompileconfig/config.go
@@ -75,7 +75,7 @@ type AcceptContext struct {
 // will not maintain backwards compatibility of this interface and your code should not
 // rely on this. Designed for use only by precompiles that ship with subnet-evm.
 type Accepter interface {
-	Accept(acceptCtx *AcceptContext, txHash common.Hash, logIndex int, topics []common.Hash, logData []byte) error
+	Accept(acceptCtx *AcceptContext, blockHash common.Hash, blockNumber uint64, txHash common.Hash, logIndex int, topics []common.Hash, logData []byte) error
 }
 
 // ChainContext defines an interface that provides information to a stateful precompile

--- a/precompile/precompileconfig/mocks.go
+++ b/precompile/precompileconfig/mocks.go
@@ -246,15 +246,15 @@ func (m *MockAccepter) EXPECT() *MockAccepterMockRecorder {
 }
 
 // Accept mocks base method.
-func (m *MockAccepter) Accept(arg0 *AcceptContext, arg1 common.Hash, arg2 int, arg3 []common.Hash, arg4 []byte) error {
+func (m *MockAccepter) Accept(arg0 *AcceptContext, arg1 common.Hash, arg2 uint64, arg3 common.Hash, arg4 int, arg5 []common.Hash, arg6 []byte) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Accept", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "Accept", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Accept indicates an expected call of Accept.
-func (mr *MockAccepterMockRecorder) Accept(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockAccepterMockRecorder) Accept(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Accept", reflect.TypeOf((*MockAccepter)(nil).Accept), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Accept", reflect.TypeOf((*MockAccepter)(nil).Accept), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }

--- a/x/warp/config.go
+++ b/x/warp/config.go
@@ -105,12 +105,20 @@ func (c *Config) Equal(s precompileconfig.Config) bool {
 	return equals && c.QuorumNumerator == other.QuorumNumerator
 }
 
-func (c *Config) Accept(acceptCtx *precompileconfig.AcceptContext, txHash common.Hash, logIndex int, topics []common.Hash, logData []byte) error {
+func (c *Config) Accept(acceptCtx *precompileconfig.AcceptContext, blockHash common.Hash, blockNumber uint64, txHash common.Hash, logIndex int, topics []common.Hash, logData []byte) error {
 	unsignedMessage, err := UnpackSendWarpEventDataToMessage(logData)
 	if err != nil {
 		return fmt.Errorf("failed to parse warp log data into unsigned message (TxHash: %s, LogIndex: %d): %w", txHash, logIndex, err)
 	}
-	log.Info("Accepted warp unsigned message", "txHash", txHash, "logIndex", logIndex, "logData", common.Bytes2Hex(logData))
+	log.Info(
+		"Accepted warp unsigned message",
+		"blockHash", blockHash,
+		"blockNumber", blockNumber,
+		"txHash", txHash,
+		"logIndex", logIndex,
+		"logData", common.Bytes2Hex(logData),
+		"warpMessageID", unsignedMessage.ID(),
+	)
 	if err := acceptCtx.Warp.AddMessage(unsignedMessage); err != nil {
 		return fmt.Errorf("failed to add warp message during accept (TxHash: %s, LogIndex: %d): %w", txHash, logIndex, err)
 	}


### PR DESCRIPTION
## Why this should be merged
Adds more information to the log emitted when a block sending warp messages are accepted.

## How this works
Passes through blockNumber, blockHash.

## How this was tested
CI

## How is this documented
N/A