### PR TITLE
warp/handlers: update duration greater than assertion to pass on windows

### DIFF
--- a/warp/handlers/signature_request_test.go
+++ b/warp/handlers/signature_request_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/ava-labs/avalanchego/database/memdb"
 	"github.com/ava-labs/avalanchego/ids"
@@ -57,11 +56,11 @@ func TestMessageSignatureHandler(t *testing.T) {
 				require.EqualValues(t, 1, stats.messageSignatureRequest.Count())
 				require.EqualValues(t, 1, stats.messageSignatureHit.Count())
 				require.EqualValues(t, 0, stats.messageSignatureMiss.Count())
-				require.Greater(t, stats.messageSignatureRequestDuration.Value(), time.Duration(0))
+				require.Greater(t, stats.messageSignatureRequestDuration.Value(), int64(0))
 				require.EqualValues(t, 0, stats.blockSignatureRequest.Count())
 				require.EqualValues(t, 0, stats.blockSignatureHit.Count())
 				require.EqualValues(t, 0, stats.blockSignatureMiss.Count())
-				require.EqualValues(t, stats.blockSignatureRequestDuration.Value(), time.Duration(0))
+				require.EqualValues(t, stats.blockSignatureRequestDuration.Value(), int64(0))
 			},
 		},
 		"unknown message": {
@@ -74,11 +73,11 @@ func TestMessageSignatureHandler(t *testing.T) {
 				require.EqualValues(t, 1, stats.messageSignatureRequest.Count())
 				require.EqualValues(t, 0, stats.messageSignatureHit.Count())
 				require.EqualValues(t, 1, stats.messageSignatureMiss.Count())
-				require.Greater(t, stats.messageSignatureRequestDuration.Value(), time.Duration(0))
+				require.Greater(t, stats.messageSignatureRequestDuration.Value(), int64(0))
 				require.EqualValues(t, 0, stats.blockSignatureRequest.Count())
 				require.EqualValues(t, 0, stats.blockSignatureHit.Count())
 				require.EqualValues(t, 0, stats.blockSignatureMiss.Count())
-				require.EqualValues(t, stats.blockSignatureRequestDuration.Value(), time.Duration(0))
+				require.EqualValues(t, stats.blockSignatureRequestDuration.Value(), int64(0))
 			},
 		},
 	}
@@ -159,11 +158,11 @@ func TestBlockSignatureHandler(t *testing.T) {
 				require.EqualValues(t, 0, stats.messageSignatureRequest.Count())
 				require.EqualValues(t, 0, stats.messageSignatureHit.Count())
 				require.EqualValues(t, 0, stats.messageSignatureMiss.Count())
-				require.EqualValues(t, stats.messageSignatureRequestDuration.Value(), time.Duration(0))
+				require.EqualValues(t, stats.messageSignatureRequestDuration.Value(), int64(0))
 				require.EqualValues(t, 1, stats.blockSignatureRequest.Count())
 				require.EqualValues(t, 1, stats.blockSignatureHit.Count())
 				require.EqualValues(t, 0, stats.blockSignatureMiss.Count())
-				require.Greater(t, stats.blockSignatureRequestDuration.Value(), time.Duration(0))
+				require.Greater(t, stats.blockSignatureRequestDuration.Value(), int64(0))
 			},
 		},
 		"unknown block": {
@@ -176,11 +175,11 @@ func TestBlockSignatureHandler(t *testing.T) {
 				require.EqualValues(t, 0, stats.messageSignatureRequest.Count())
 				require.EqualValues(t, 0, stats.messageSignatureHit.Count())
 				require.EqualValues(t, 0, stats.messageSignatureMiss.Count())
-				require.EqualValues(t, stats.messageSignatureRequestDuration.Value(), time.Duration(0))
+				require.EqualValues(t, stats.messageSignatureRequestDuration.Value(), int64(0))
 				require.EqualValues(t, 1, stats.blockSignatureRequest.Count())
 				require.EqualValues(t, 0, stats.blockSignatureHit.Count())
 				require.EqualValues(t, 1, stats.blockSignatureMiss.Count())
-				require.Greater(t, stats.blockSignatureRequestDuration.Value(), time.Duration(0))
+				require.Greater(t, stats.blockSignatureRequestDuration.Value(), int64(0))
 			},
 		},
 	}


### PR DESCRIPTION
This PR updates an assertion on the amount of time spent serving a request from using a duration to int64 value to match the value reported by the metric.

This fixes an error when running on Windows migrating this code to Coreth: https://github.com/ava-labs/coreth/actions/runs/6852336438/job/18630638235?pr=387
<img width="942" alt="Screenshot 2023-11-13 at 16 10 56" src="https://github.com/ava-labs/subnet-evm/assets/24684335/9fd4ca10-b99c-4cd1-86b9-c545ff88ccc3">
