### PR TITLE
Add subnetID arg to warp APIs

### DIFF
--- a/tests/warp/warp_test.go
+++ b/tests/warp/warp_test.go
@@ -329,7 +329,7 @@ var _ = ginkgo.Describe("[Warp]", ginkgo.Ordered, func() {
 		gomega.Expect(err).Should(gomega.BeNil())
 
 		// Specify WarpQuorumDenominator to retrieve signatures from every validator
-		signedWarpMessageBytes, err := client.GetMessageAggregateSignature(ctx, unsignedWarpMessageID, params.WarpQuorumDenominator)
+		signedWarpMessageBytes, err := client.GetMessageAggregateSignature(ctx, unsignedWarpMessageID, params.WarpQuorumDenominator, "")
 		gomega.Expect(err).Should(gomega.BeNil())
 		gomega.Expect(signedWarpMessageBytes).Should(gomega.Equal(signedWarpMsg.Bytes()))
 	})
@@ -344,7 +344,7 @@ var _ = ginkgo.Describe("[Warp]", ginkgo.Ordered, func() {
 		gomega.Expect(err).Should(gomega.BeNil())
 
 		// Specify WarpQuorumDenominator to retrieve signatures from every validator
-		signedWarpBlockBytes, err := client.GetBlockAggregateSignature(ctx, warpBlockID, params.WarpQuorumDenominator)
+		signedWarpBlockBytes, err := client.GetBlockAggregateSignature(ctx, warpBlockID, params.WarpQuorumDenominator, "")
 		gomega.Expect(err).Should(gomega.BeNil())
 		gomega.Expect(signedWarpBlockBytes).Should(gomega.Equal(warpBlockHashSignedMsg.Bytes()))
 	})

--- a/warp/backend.go
+++ b/warp/backend.go
@@ -109,7 +109,7 @@ func (b *backend) GetMessageSignature(messageID ids.ID) ([bls.SignatureLen]byte,
 
 	unsignedMessage, err := b.GetMessage(messageID)
 	if err != nil {
-		return [bls.SignatureLen]byte{}, fmt.Errorf("failed to get warp message %s from db: %w", messageID.String(), err)
+		return [bls.SignatureLen]byte{}, err
 	}
 
 	var signature [bls.SignatureLen]byte

--- a/warp/client.go
+++ b/warp/client.go
@@ -16,9 +16,9 @@ var _ Client = (*client)(nil)
 
 type Client interface {
 	GetMessageSignature(ctx context.Context, messageID ids.ID) ([]byte, error)
-	GetMessageAggregateSignature(ctx context.Context, messageID ids.ID, quorumNum uint64) ([]byte, error)
+	GetMessageAggregateSignature(ctx context.Context, messageID ids.ID, quorumNum uint64, subnetIDStr string) ([]byte, error)
 	GetBlockSignature(ctx context.Context, blockID ids.ID) ([]byte, error)
-	GetBlockAggregateSignature(ctx context.Context, blockID ids.ID, quorumNum uint64) ([]byte, error)
+	GetBlockAggregateSignature(ctx context.Context, blockID ids.ID, quorumNum uint64, subnetIDStr string) ([]byte, error)
 }
 
 // client implementation for interacting with EVM [chain]
@@ -45,9 +45,9 @@ func (c *client) GetMessageSignature(ctx context.Context, messageID ids.ID) ([]b
 	return res, nil
 }
 
-func (c *client) GetMessageAggregateSignature(ctx context.Context, messageID ids.ID, quorumNum uint64) ([]byte, error) {
+func (c *client) GetMessageAggregateSignature(ctx context.Context, messageID ids.ID, quorumNum uint64, subnetIDStr string) ([]byte, error) {
 	var res hexutil.Bytes
-	if err := c.client.CallContext(ctx, &res, "warp_getMessageAggregateSignature", messageID, quorumNum); err != nil {
+	if err := c.client.CallContext(ctx, &res, "warp_getMessageAggregateSignature", messageID, quorumNum, subnetIDStr); err != nil {
 		return nil, fmt.Errorf("call to warp_getMessageAggregateSignature failed. err: %w", err)
 	}
 	return res, nil
@@ -61,9 +61,9 @@ func (c *client) GetBlockSignature(ctx context.Context, blockID ids.ID) ([]byte,
 	return res, nil
 }
 
-func (c *client) GetBlockAggregateSignature(ctx context.Context, blockID ids.ID, quorumNum uint64) ([]byte, error) {
+func (c *client) GetBlockAggregateSignature(ctx context.Context, blockID ids.ID, quorumNum uint64, subnetIDStr string) ([]byte, error) {
 	var res hexutil.Bytes
-	if err := c.client.CallContext(ctx, &res, "warp_getBlockAggregateSignature", blockID, quorumNum); err != nil {
+	if err := c.client.CallContext(ctx, &res, "warp_getBlockAggregateSignature", blockID, quorumNum, subnetIDStr); err != nil {
 		return nil, fmt.Errorf("call to warp_getBlockAggregateSignature failed. err: %w", err)
 	}
 	return res, nil


### PR DESCRIPTION
This PR adds a `subnetIDStr` argument to the Warp APIs, so that the caller can specify what subnetID's validator set the API should attempt to fetch validator signatures from.

This is used in the case of the C-Chain, so that signatures from subnetA can be fetched when aggregating signatures for a message that needs to be sent to subnetA.