### PR TITLE
cmd/simulator: refactor simulator to support warp load test

### DIFF
--- a/cmd/simulator/key/key.go
+++ b/cmd/simulator/key/key.go
@@ -19,7 +19,7 @@ type Key struct {
 	Address common.Address
 }
 
-func createKey(pk *ecdsa.PrivateKey) *Key {
+func CreateKey(pk *ecdsa.PrivateKey) *Key {
 	return &Key{pk, ethcrypto.PubkeyToAddress(pk.PublicKey)}
 }
 
@@ -29,7 +29,7 @@ func Load(file string) (*Key, error) {
 	if err != nil {
 		return nil, fmt.Errorf("problem loading private key from %s: %w", file, err)
 	}
-	return createKey(pk), nil
+	return CreateKey(pk), nil
 }
 
 // LoadAll loads all keys in [dir].
@@ -81,5 +81,5 @@ func Generate() (*Key, error) {
 	if err != nil {
 		return nil, fmt.Errorf("%w: cannot generate key", err)
 	}
-	return createKey(pk), nil
+	return CreateKey(pk), nil
 }

--- a/cmd/simulator/load/funder.go
+++ b/cmd/simulator/load/funder.go
@@ -103,7 +103,7 @@ func DistributeFunds(ctx context.Context, client ethclient.Client, keys []*key.K
 	}
 
 	numTxs := uint64(len(needFundsAddrs))
-	txSequence, err := txs.GenerateTxSequence(ctx, txGenerator, client, maxFundsKey.PrivKey, numTxs)
+	txSequence, err := txs.GenerateTxSequence(ctx, txGenerator, client, maxFundsKey.PrivKey, numTxs, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate fund distribution sequence from %s of length %d", maxFundsKey.Address, len(needFundsAddrs))
 	}

--- a/cmd/simulator/load/loader.go
+++ b/cmd/simulator/load/loader.go
@@ -31,6 +31,10 @@ const (
 	MetricsEndpoint = "/metrics" // Endpoint for the Prometheus Metrics Server
 )
 
+// Loader executes a series of worker/tx sequence pairs.
+// Each worker/txSequence pair issues [batchSize] transactions, confirms all
+// of them as accepted, and then moves to the next batch until the txSequence
+// is exhausted.
 type Loader[T txs.THash] struct {
 	clients     []txs.Worker[T]
 	txSequences []txs.TxSequence[T]

--- a/cmd/simulator/load/loader.go
+++ b/cmd/simulator/load/loader.go
@@ -6,16 +6,13 @@ package load
 import (
 	"context"
 	"crypto/ecdsa"
-	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/big"
-	"net/http"
 	"os"
 	"os/signal"
 	"strconv"
-	"strings"
 	"syscall"
+	"time"
 
 	"github.com/ava-labs/subnet-evm/cmd/simulator/config"
 	"github.com/ava-labs/subnet-evm/cmd/simulator/key"
@@ -27,14 +24,100 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"golang.org/x/sync/errgroup"
 )
 
 const (
 	MetricsEndpoint = "/metrics" // Endpoint for the Prometheus Metrics Server
 )
+
+type Loader[T txs.THash] struct {
+	clients     []txs.Worker[T]
+	txSequences []txs.TxSequence[T]
+	batchSize   uint64
+	metrics     *metrics.Metrics
+}
+
+func New[T txs.THash](
+	clients []txs.Worker[T],
+	txSequences []txs.TxSequence[T],
+	batchSize uint64,
+	metrics *metrics.Metrics,
+) *Loader[T] {
+	return &Loader[T]{
+		clients:     clients,
+		txSequences: txSequences,
+		batchSize:   batchSize,
+		metrics:     metrics,
+	}
+}
+
+func (l *Loader[T]) Execute(ctx context.Context) error {
+	log.Info("Constructing tx agents...", "numAgents", len(l.txSequences))
+	agents := make([]txs.Agent[T], 0, len(l.txSequences))
+	for i := 0; i < len(l.txSequences); i++ {
+		agents = append(agents, txs.NewIssueNAgent(l.txSequences[i], l.clients[i], l.batchSize, l.metrics))
+	}
+
+	log.Info("Starting tx agents...")
+	eg := errgroup.Group{}
+	for _, agent := range agents {
+		agent := agent
+		eg.Go(func() error {
+			return agent.Execute(ctx)
+		})
+	}
+
+	log.Info("Waiting for tx agents...")
+	if err := eg.Wait(); err != nil {
+		return err
+	}
+	log.Info("Tx agents completed successfully.")
+	return nil
+}
+
+// ConfirmReachedTip finds the max height any client has reached and then ensures every client
+// reaches at least that height.
+//
+// This allows the network to continue to roll forward and creates a synchronization point to ensure
+// that every client in the loader has reached at least the max height observed of any client at
+// the time this function was called.
+func (l *Loader[T]) ConfirmReachedTip(ctx context.Context) error {
+	maxHeight := uint64(0)
+	for i, client := range l.clients {
+		latestHeight, err := client.LatestHeight(ctx)
+		if err != nil {
+			return fmt.Errorf("client %d failed to get latest height: %w", i, err)
+		}
+		if latestHeight > maxHeight {
+			maxHeight = latestHeight
+		}
+	}
+
+	eg := errgroup.Group{}
+	for i, client := range l.clients {
+		i := i
+		client := client
+		eg.Go(func() error {
+			for {
+				latestHeight, err := client.LatestHeight(ctx)
+				if err != nil {
+					return fmt.Errorf("failed to get latest height from client %d: %w", i, err)
+				}
+				if latestHeight >= maxHeight {
+					return nil
+				}
+				select {
+				case <-ctx.Done():
+					return fmt.Errorf("failed to get latest height from client %d: %w", i, ctx.Err())
+				case <-time.After(time.Second):
+				}
+			}
+		})
+	}
+
+	return eg.Wait()
+}
 
 // ExecuteLoader creates txSequences from [config] and has txAgents execute the specified simulation.
 func ExecuteLoader(ctx context.Context, config config.Config) error {
@@ -61,6 +144,9 @@ func ExecuteLoader(ctx context.Context, config config.Config) error {
 		// Cancel the child context and end all processes
 		cancel()
 	}()
+
+	m := metrics.NewDefaultMetrics()
+	ms := m.Serve(ctx, strconv.Itoa(int(config.MetricsPort)), MetricsEndpoint)
 
 	// Construct the arguments for the load simulator
 	clients := make([]ethclient.Client, 0, len(config.Endpoints))
@@ -96,11 +182,6 @@ func ExecuteLoader(ctx context.Context, config config.Config) error {
 	maxFeeCap := new(big.Int).Mul(big.NewInt(params.GWei), big.NewInt(config.MaxFeeCap))
 	minFundsPerAddr := new(big.Int).Mul(maxFeeCap, big.NewInt(int64(config.TxsPerWorker*params.TxGas)))
 
-	// Create metrics
-	reg := prometheus.NewRegistry()
-	m := metrics.NewMetrics(reg)
-	metricsPort := strconv.Itoa(int(config.MetricsPort))
-
 	log.Info("Distributing funds", "numTxsPerWorker", config.TxsPerWorker, "minFunds", minFundsPerAddr)
 	keys, err = DistributeFunds(ctx, clients[0], keys, config.Workers, minFundsPerAddr, m)
 	if err != nil {
@@ -128,7 +209,7 @@ func ExecuteLoader(ctx context.Context, config config.Config) error {
 	log.Info("Creating transaction sequences...")
 	txGenerator := func(key *ecdsa.PrivateKey, nonce uint64) (*types.Transaction, error) {
 		addr := ethcrypto.PubkeyToAddress(key.PublicKey)
-		tx, err := types.SignNewTx(key, signer, &types.DynamicFeeTx{
+		return types.SignNewTx(key, signer, &types.DynamicFeeTx{
 			ChainID:   chainID,
 			Nonce:     nonce,
 			GasTipCap: gasTipCap,
@@ -138,84 +219,19 @@ func ExecuteLoader(ctx context.Context, config config.Config) error {
 			Data:      nil,
 			Value:     common.Big0,
 		})
-		if err != nil {
-			return nil, err
-		}
-		return tx, nil
 	}
-	txSequences, err := txs.GenerateTxSequences(ctx, txGenerator, clients[0], pks, config.TxsPerWorker)
+
+	txSequences, err := txs.GenerateTxSequences(ctx, txGenerator, clients[0], pks, config.TxsPerWorker, false)
 	if err != nil {
 		return err
 	}
 
-	log.Info("Constructing tx agents...", "numAgents", config.Workers)
-	agents := make([]txs.Agent[*types.Transaction], 0, config.Workers)
-	for i := 0; i < config.Workers; i++ {
-		agents = append(agents, txs.NewIssueNAgent[*types.Transaction](txSequences[i], NewSingleAddressTxWorker(ctx, clients[i], senders[i]), config.BatchSize, m))
+	workers := make([]txs.Worker[*types.Transaction], 0, len(clients))
+	for i, client := range clients {
+		workers = append(workers, NewSingleAddressTxWorker(ctx, client, ethcrypto.PubkeyToAddress(pks[i].PublicKey)))
 	}
-
-	log.Info("Starting tx agents...")
-	eg := errgroup.Group{}
-	for _, agent := range agents {
-		agent := agent
-		eg.Go(func() error {
-			return agent.Execute(ctx)
-		})
-	}
-
-	go startMetricsServer(ctx, metricsPort, reg)
-
-	log.Info("Waiting for tx agents...")
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	log.Info("Tx agents completed successfully.")
-
-	printOutputFromMetricsServer(metricsPort)
-	return nil
-}
-
-func startMetricsServer(ctx context.Context, metricsPort string, reg *prometheus.Registry) {
-	// Create a prometheus server to expose individual tx metrics
-	server := &http.Server{
-		Addr: fmt.Sprintf(":%s", metricsPort),
-	}
-
-	// Start up go routine to listen for SIGINT notifications to gracefully shut down server
-	go func() {
-		// Blocks until signal is received
-		<-ctx.Done()
-
-		if err := server.Shutdown(ctx); err != nil {
-			log.Error("Metrics server error: %v", err)
-		}
-		log.Info("Received a SIGINT signal: Gracefully shutting down metrics server")
-	}()
-
-	// Start metrics server
-	http.Handle(MetricsEndpoint, promhttp.HandlerFor(reg, promhttp.HandlerOpts{Registry: reg}))
-	log.Info(fmt.Sprintf("Metrics Server: localhost:%s%s", metricsPort, MetricsEndpoint))
-	if err := server.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
-		log.Error("Metrics server error: %v", err)
-	}
-}
-
-func printOutputFromMetricsServer(metricsPort string) {
-	// Get response from server
-	resp, err := http.Get(fmt.Sprintf("http://localhost:%s%s", metricsPort, MetricsEndpoint))
-	if err != nil {
-		log.Error("cannot get response from metrics servers", "err", err)
-		return
-	}
-	// Read response body
-	respBody, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		log.Error("cannot read response body", "err", err)
-		return
-	}
-	// Print out formatted individual metrics
-	parts := strings.Split(string(respBody), "\n")
-	for _, s := range parts {
-		fmt.Printf("       \t\t\t%s\n", s)
-	}
+	loader := New(workers, txSequences, config.BatchSize, m)
+	err = loader.Execute(ctx)
+	ms.Print() // Print regardless of execution error
+	return err
 }

--- a/cmd/simulator/load/loader.go
+++ b/cmd/simulator/load/loader.go
@@ -147,6 +147,7 @@ func ExecuteLoader(ctx context.Context, config config.Config) error {
 
 	m := metrics.NewDefaultMetrics()
 	ms := m.Serve(ctx, strconv.Itoa(int(config.MetricsPort)), MetricsEndpoint)
+	defer ms.Shutdown()
 
 	// Construct the arguments for the load simulator
 	clients := make([]ethclient.Client, 0, len(config.Endpoints))

--- a/cmd/simulator/load/worker.go
+++ b/cmd/simulator/load/worker.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-type singleAddressTxWorker struct {
+type ethereumTxWorker struct {
 	client ethclient.Client
 
 	acceptedNonce uint64
@@ -25,10 +25,11 @@ type singleAddressTxWorker struct {
 	newHeads chan *types.Header
 }
 
-// NewSingleAddressTxWorker creates and returns a singleAddressTxWorker
-func NewSingleAddressTxWorker(ctx context.Context, client ethclient.Client, address common.Address) *singleAddressTxWorker {
+// NewSingleAddressTxWorker creates and returns a new ethereumTxWorker that confirms transactions by checking the latest
+// nonce of [address] and assuming any transaction with a lower nonce was already accepted.
+func NewSingleAddressTxWorker(ctx context.Context, client ethclient.Client, address common.Address) *ethereumTxWorker {
 	newHeads := make(chan *types.Header)
-	tw := &singleAddressTxWorker{
+	tw := &ethereumTxWorker{
 		client:   client,
 		address:  address,
 		newHeads: newHeads,
@@ -44,14 +45,49 @@ func NewSingleAddressTxWorker(ctx context.Context, client ethclient.Client, addr
 	return tw
 }
 
-func (tw *singleAddressTxWorker) IssueTx(ctx context.Context, tx *types.Transaction) error {
+// NewTxReceiptWorker creates and returns a new ethereumTxWorker that confirms transactions by checking for the
+// corresponding transaction receipt.
+func NewTxReceiptWorker(ctx context.Context, client ethclient.Client) *ethereumTxWorker {
+	newHeads := make(chan *types.Header)
+	tw := &ethereumTxWorker{
+		client:   client,
+		newHeads: newHeads,
+	}
+
+	sub, err := client.SubscribeNewHead(ctx, newHeads)
+	if err != nil {
+		log.Debug("failed to subscribe new heads, falling back to polling", "err", err)
+	} else {
+		tw.sub = sub
+	}
+
+	return tw
+}
+
+func (tw *ethereumTxWorker) IssueTx(ctx context.Context, tx *types.Transaction) error {
 	return tw.client.SendTransaction(ctx, tx)
 }
 
-func (tw *singleAddressTxWorker) ConfirmTx(ctx context.Context, tx *types.Transaction) error {
+func (tw *ethereumTxWorker) ConfirmTx(ctx context.Context, tx *types.Transaction) error {
+	if tw.address == (common.Address{}) {
+		return tw.confirmTxByReceipt(ctx, tx)
+	}
+	return tw.confirmTxByNonce(ctx, tx)
+}
+
+func (tw *ethereumTxWorker) confirmTxByNonce(ctx context.Context, tx *types.Transaction) error {
 	txNonce := tx.Nonce()
 
 	for {
+		// Update the worker's accepted nonce, so we can check on the next iteration
+		// if the transaction has been accepted.
+		acceptedNonce, err := tw.client.NonceAt(ctx, tw.address, nil)
+		if err != nil {
+			return fmt.Errorf("failed to await tx %s nonce %d: %w", tx.Hash(), txNonce, err)
+		}
+		tw.acceptedNonce = acceptedNonce
+
+		log.Info("trying to confirm tx", "txHash", tx.Hash(), "txNonce", txNonce, "acceptedNonce", tw.acceptedNonce)
 		// If the is less than what has already been accepted, the transaction is confirmed
 		if txNonce < tw.acceptedNonce {
 			return nil
@@ -63,18 +99,31 @@ func (tw *singleAddressTxWorker) ConfirmTx(ctx context.Context, tx *types.Transa
 		case <-ctx.Done():
 			return fmt.Errorf("failed to await tx %s nonce %d: %w", tx.Hash(), txNonce, ctx.Err())
 		}
-
-		// Update the worker's accepted nonce, so we can check on the next iteration
-		// if the transaction has been accepted.
-		acceptedNonce, err := tw.client.NonceAt(ctx, tw.address, nil)
-		if err != nil {
-			return fmt.Errorf("failed to await tx %s nonce %d: %w", tx.Hash(), txNonce, err)
-		}
-		tw.acceptedNonce = acceptedNonce
 	}
 }
 
-func (tw *singleAddressTxWorker) Close(ctx context.Context) error {
+func (tw *ethereumTxWorker) confirmTxByReceipt(ctx context.Context, tx *types.Transaction) error {
+	for {
+		_, err := tw.client.TransactionReceipt(ctx, tx.Hash())
+		if err == nil {
+			return nil
+		}
+		log.Debug("no tx receipt", "txHash", tx.Hash(), "nonce", tx.Nonce(), "err", err)
+
+		select {
+		case <-tw.newHeads:
+		case <-time.After(time.Second):
+		case <-ctx.Done():
+			return fmt.Errorf("failed to await tx %s nonce %d: %w", tx.Hash(), tx.Nonce(), ctx.Err())
+		}
+	}
+}
+
+func (tw *ethereumTxWorker) LatestHeight(ctx context.Context) (uint64, error) {
+	return tw.client.BlockNumber(ctx)
+}
+
+func (tw *ethereumTxWorker) Close(ctx context.Context) error {
 	if tw.sub != nil {
 		tw.sub.Unsubscribe()
 	}

--- a/cmd/simulator/load/worker.go
+++ b/cmd/simulator/load/worker.go
@@ -120,11 +120,3 @@ func (tw *ethereumTxWorker) confirmTxByReceipt(ctx context.Context, tx *types.Tr
 func (tw *ethereumTxWorker) LatestHeight(ctx context.Context) (uint64, error) {
 	return tw.client.BlockNumber(ctx)
 }
-
-func (tw *ethereumTxWorker) Close(ctx context.Context) error {
-	if tw.sub != nil {
-		tw.sub.Unsubscribe()
-	}
-	close(tw.newHeads)
-	return nil
-}

--- a/cmd/simulator/load/worker.go
+++ b/cmd/simulator/load/worker.go
@@ -79,15 +79,13 @@ func (tw *ethereumTxWorker) confirmTxByNonce(ctx context.Context, tx *types.Tran
 	txNonce := tx.Nonce()
 
 	for {
-		// Update the worker's accepted nonce, so we can check on the next iteration
-		// if the transaction has been accepted.
 		acceptedNonce, err := tw.client.NonceAt(ctx, tw.address, nil)
 		if err != nil {
 			return fmt.Errorf("failed to await tx %s nonce %d: %w", tx.Hash(), txNonce, err)
 		}
 		tw.acceptedNonce = acceptedNonce
 
-		log.Info("trying to confirm tx", "txHash", tx.Hash(), "txNonce", txNonce, "acceptedNonce", tw.acceptedNonce)
+		log.Debug("confirming tx", "txHash", tx.Hash(), "txNonce", txNonce, "acceptedNonce", tw.acceptedNonce)
 		// If the is less than what has already been accepted, the transaction is confirmed
 		if txNonce < tw.acceptedNonce {
 			return nil

--- a/cmd/simulator/metrics/metrics.go
+++ b/cmd/simulator/metrics/metrics.go
@@ -4,10 +4,20 @@
 package metrics
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 type Metrics struct {
+	reg *prometheus.Registry
 	// Summary of the quantiles of Individual Issuance Tx Times
 	IssuanceTxTimes prometheus.Summary
 	// Summary of the quantiles of Individual Confirmation Tx Times
@@ -16,9 +26,15 @@ type Metrics struct {
 	IssuanceToConfirmationTxTimes prometheus.Summary
 }
 
+func NewDefaultMetrics() *Metrics {
+	registry := prometheus.NewRegistry()
+	return NewMetrics(registry)
+}
+
 // NewMetrics creates and returns a Metrics and registers it with a Collector
-func NewMetrics(reg prometheus.Registerer) *Metrics {
+func NewMetrics(reg *prometheus.Registry) *Metrics {
 	m := &Metrics{
+		reg: reg,
 		IssuanceTxTimes: prometheus.NewSummary(prometheus.SummaryOpts{
 			Name:       "tx_issuance_time",
 			Help:       "Individual Tx Issuance Times for a Load Test",
@@ -39,4 +55,59 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 	reg.MustRegister(m.ConfirmationTxTimes)
 	reg.MustRegister(m.IssuanceToConfirmationTxTimes)
 	return m
+}
+
+type MetricsServer struct {
+	metricsPort     string
+	metricsEndpoint string
+}
+
+func (m *Metrics) Serve(ctx context.Context, metricsPort string, metricsEndpoint string) *MetricsServer {
+	// Create a prometheus server to expose individual tx metrics
+	server := &http.Server{
+		Addr: fmt.Sprintf(":%s", metricsPort),
+	}
+
+	// Start up go routine to listen for SIGINT notifications to gracefully shut down server
+	go func() {
+		// Blocks until signal is received
+		<-ctx.Done()
+
+		if err := server.Shutdown(ctx); err != nil {
+			log.Error("Metrics server error: %v", err)
+		}
+		log.Info("Received a SIGINT signal: Gracefully shutting down metrics server")
+	}()
+
+	// Start metrics server
+	http.Handle(metricsEndpoint, promhttp.HandlerFor(m.reg, promhttp.HandlerOpts{Registry: m.reg}))
+	log.Info(fmt.Sprintf("Metrics Server: localhost:%s%s", metricsPort, metricsEndpoint))
+	if err := server.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
+		log.Error("Metrics server error: %v", err)
+	}
+
+	return &MetricsServer{
+		metricsPort:     metricsPort,
+		metricsEndpoint: metricsEndpoint,
+	}
+}
+
+func (ms *MetricsServer) Print() {
+	// Get response from server
+	resp, err := http.Get(fmt.Sprintf("http://localhost:%s%s", ms.metricsPort, ms.metricsEndpoint))
+	if err != nil {
+		log.Error("cannot get response from metrics servers", "err", err)
+		return
+	}
+	// Read response body
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Error("cannot read response body", "err", err)
+		return
+	}
+	// Print out formatted individual metrics
+	parts := strings.Split(string(respBody), "\n")
+	for _, s := range parts {
+		fmt.Printf("       \t\t\t%s\n", s)
+	}
 }

--- a/cmd/simulator/metrics/metrics.go
+++ b/cmd/simulator/metrics/metrics.go
@@ -10,7 +10,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
-	"sync"
 
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/prometheus/client_golang/prometheus"
@@ -62,9 +61,8 @@ type MetricsServer struct {
 	metricsPort     string
 	metricsEndpoint string
 
-	cancel   context.CancelFunc
-	stopOnce sync.Once
-	stopCh   chan struct{}
+	cancel context.CancelFunc
+	stopCh chan struct{}
 }
 
 func (m *Metrics) Serve(ctx context.Context, metricsPort string, metricsEndpoint string) *MetricsServer {
@@ -106,10 +104,8 @@ func (m *Metrics) Serve(ctx context.Context, metricsPort string, metricsEndpoint
 }
 
 func (ms *MetricsServer) Shutdown() {
-	ms.stopOnce.Do(func() {
-		ms.cancel()
-		<-ms.stopCh
-	})
+	ms.cancel()
+	<-ms.stopCh
 }
 
 func (ms *MetricsServer) Print() {

--- a/cmd/simulator/txs/agent.go
+++ b/cmd/simulator/txs/agent.go
@@ -31,6 +31,7 @@ type TxSequence[T THash] interface {
 type Worker[T THash] interface {
 	IssueTx(ctx context.Context, tx T) error
 	ConfirmTx(ctx context.Context, tx T) error
+	LatestHeight(ctx context.Context) (uint64, error)
 	Close(ctx context.Context) error
 }
 
@@ -74,12 +75,6 @@ func (a issueNAgent[T]) Execute(ctx context.Context) error {
 		totalIssuedTime    time.Duration
 		totalConfirmedTime time.Duration
 	)
-
-	defer func() {
-		if err := a.worker.Close(ctx); err != nil {
-			log.Error("error trying to close worker: %w", "err", err)
-		}
-	}()
 
 	// Start time for execution
 	start := time.Now()

--- a/cmd/simulator/txs/agent.go
+++ b/cmd/simulator/txs/agent.go
@@ -32,7 +32,6 @@ type Worker[T THash] interface {
 	IssueTx(ctx context.Context, tx T) error
 	ConfirmTx(ctx context.Context, tx T) error
 	LatestHeight(ctx context.Context) (uint64, error)
-	Close(ctx context.Context) error
 }
 
 // Execute the work of the given agent.


### PR DESCRIPTION
This PR refactors the load simulator to better support async tx sequence generation for warp load testing.

It also better separates some of the load simulator code (still significant room for improvement).

Specific changes:
- add tx worker version that confirms transactions by receipt instead of nonce
- add confirm reached tip helper function to confirm all workers have observed the latest tip (as of calling the function)