### PR TITLE
rename DUpgrade to Durango

### DIFF
--- a/accounts/abi/bind/precompilebind/precompile_config_test_template.go
+++ b/accounts/abi/bind/precompilebind/precompile_config_test_template.go
@@ -36,7 +36,7 @@ func TestVerify(t *testing.T) {
 			Config: NewConfig(utils.NewUint64(3){{- if .Contract.AllowList}}, admins, enableds, managers{{- end}}),
 			ChainConfig: func() precompileconfig.ChainConfig {
 				config := precompileconfig.NewMockChainConfig(gomock.NewController(t))
-				config.EXPECT().IsDUpgrade(gomock.Any()).Return(true).AnyTimes()
+				config.EXPECT().IsDurango(gomock.Any()).Return(true).AnyTimes()
 				return config
 			}(),
 			ExpectedError: "",

--- a/accounts/abi/bind/precompilebind/precompile_contract_template.go
+++ b/accounts/abi/bind/precompilebind/precompile_contract_template.go
@@ -143,7 +143,7 @@ func Set{{.Contract.Type}}AllowListStatus(stateDB contract.StateDB, address comm
 // assumes that [input] does not include selector (omits first 4 func signature bytes)
 func Unpack{{capitalise .Normalized.Name}}Input(input []byte) ({{capitalise .Normalized.Name}}Input, error) {
 	inputStruct := {{capitalise .Normalized.Name}}Input{}
-	// The strict mode in decoding is disabled after DUpgrade. You can re-enable by changing the last argument to true.
+	// The strict mode in decoding is disabled after Durango. You can re-enable by changing the last argument to true.
 	err := {{$contract.Type}}ABI.UnpackInputIntoInterface(&inputStruct, "{{.Original.Name}}", input, false)
 
 	return inputStruct, err
@@ -160,7 +160,7 @@ func Pack{{.Normalized.Name}}(inputStruct {{capitalise .Normalized.Name}}Input) 
 // Unpack{{capitalise .Normalized.Name}}Input attempts to unpack [input] into the {{$bindedType}} type argument
 // assumes that [input] does not include selector (omits first 4 func signature bytes)
 func Unpack{{capitalise .Normalized.Name}}Input(input []byte)({{$bindedType}}, error) {
-// The strict mode in decoding is disabled after DUpgrade. You can re-enable by changing the last argument to true.
+// The strict mode in decoding is disabled after Durango. You can re-enable by changing the last argument to true.
 res, err := {{$contract.Type}}ABI.UnpackInput("{{$method.Original.Name}}", input, false)
 if err != nil {
 	return {{bindtypenew $input.Type $structs}}, err

--- a/cmd/evm/internal/t8ntool/transaction.go
+++ b/cmd/evm/internal/t8ntool/transaction.go
@@ -182,7 +182,7 @@ func Transaction(ctx *cli.Context) error {
 			r.Error = errors.New("gas * maxFeePerGas exceeds 256 bits")
 		}
 		// Check whether the init code size has been exceeded.
-		if chainConfig.IsDUpgrade(0) && tx.To() == nil && len(tx.Data()) > params.MaxInitCodeSize {
+		if chainConfig.IsDurango(0) && tx.To() == nil && len(tx.Data()) > params.MaxInitCodeSize {
 			r.Error = errors.New("max initcode size exceeded")
 		}
 		results = append(results, r)

--- a/consensus/dummy/consensus.go
+++ b/consensus/dummy/consensus.go
@@ -198,7 +198,7 @@ func (self *DummyEngine) verifyHeader(chain consensus.ChainHeaderReader, header 
 		return errUnclesUnsupported
 	}
 	switch {
-	case config.IsDUpgrade(header.Time):
+	case config.IsDurango(header.Time):
 		if len(header.Extra) < params.DynamicFeeExtraDataSize {
 			return fmt.Errorf("expected extra-data field length >= %d, found %d", params.DynamicFeeExtraDataSize, len(header.Extra))
 		}

--- a/core/evm.go
+++ b/core/evm.go
@@ -54,8 +54,8 @@ func NewEVMBlockContext(header *types.Header, chain ChainContext, author *common
 	if !ok {
 		return newEVMBlockContext(header, chain, author, nil)
 	}
-	// Prior to the DUpgrade, the VM enforces the extra data is smaller than or
-	// equal to this size. After the DUpgrade, the VM pre-verifies the extra
+	// Prior to the Durango, the VM enforces the extra data is smaller than or
+	// equal to this size. After the Durango, the VM pre-verifies the extra
 	// data past the dynamic fee rollup window is valid.
 	predicateResults, err := predicate.ParseResults(predicateBytes)
 	if err != nil {

--- a/core/evm.go
+++ b/core/evm.go
@@ -54,8 +54,8 @@ func NewEVMBlockContext(header *types.Header, chain ChainContext, author *common
 	if !ok {
 		return newEVMBlockContext(header, chain, author, nil)
 	}
-	// Prior to the Durango, the VM enforces the extra data is smaller than or
-	// equal to this size. After the Durango, the VM pre-verifies the extra
+	// Prior to Durango, the VM enforces the extra data is smaller than or
+	// equal to this size. After Durango, the VM pre-verifies the extra
 	// data past the dynamic fee rollup window is valid.
 	predicateResults, err := predicate.ParseResults(predicateBytes)
 	if err != nil {

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1169,7 +1169,7 @@ func (s *StateDB) commit(deleteEmptyObjects bool, snaps *snapshot.Tree, blockHas
 //
 // Potential EIPs:
 // - Reset access list (Berlin)
-// - Add coinbase to access list (EIP-3651/DUpgrade)
+// - Add coinbase to access list (EIP-3651/Durango)
 // - Reset transient storage (EIP-1153)
 func (s *StateDB) Prepare(rules params.Rules, sender, coinbase common.Address, dst *common.Address, precompiles []common.Address, list types.AccessList) {
 	if rules.IsSubnetEVM {
@@ -1191,7 +1191,7 @@ func (s *StateDB) Prepare(rules params.Rules, sender, coinbase common.Address, d
 				al.AddSlot(el.Address, key)
 			}
 		}
-		if rules.IsDUpgrade { // EIP-3651: warm coinbase
+		if rules.IsDurango { // EIP-3651: warm coinbase
 			al.AddAddress(coinbase)
 		}
 

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -302,7 +302,7 @@ func TestStateProcessorErrors(t *testing.T) {
 		}
 	}
 
-	// ErrMaxInitCodeSizeExceeded, for this we need extra Shanghai (DUpgrade/EIP-3860) enabled.
+	// ErrMaxInitCodeSizeExceeded, for this we need extra Shanghai (Durango/EIP-3860) enabled.
 	{
 		var (
 			db    = rawdb.NewMemoryDatabase()
@@ -320,7 +320,7 @@ func TestStateProcessorErrors(t *testing.T) {
 					MuirGlacierBlock:    big.NewInt(0),
 					MandatoryNetworkUpgrades: params.MandatoryNetworkUpgrades{
 						SubnetEVMTimestamp: utils.NewUint64(0),
-						DUpgradeTimestamp:  utils.NewUint64(0),
+						DurangoTimestamp:   utils.NewUint64(0),
 					},
 					FeeConfig: params.DefaultFeeConfig,
 				},

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -111,7 +111,7 @@ func IntrinsicGas(data []byte, accessList types.AccessList, isContractCreation b
 		}
 		gas += z * params.TxDataZeroGas
 
-		if isContractCreation && rules.IsDUpgrade {
+		if isContractCreation && rules.IsDurango {
 			lenWords := toWordSize(dataLen)
 			if (math.MaxUint64-gas)/params.InitCodeWordGas < lenWords {
 				return 0, ErrGasUintOverflow
@@ -425,7 +425,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	}
 
 	// Check whether the init code size has been exceeded.
-	if rules.IsDUpgrade && contractCreation && len(msg.Data) > params.MaxInitCodeSize {
+	if rules.IsDurango && contractCreation && len(msg.Data) > params.MaxInitCodeSize {
 		return nil, fmt.Errorf("%w: code size %v limit %v", vmerrs.ErrMaxInitCodeSizeExceeded, len(msg.Data), params.MaxInitCodeSize)
 	}
 

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -1580,7 +1580,7 @@ func (pool *TxPool) reset(oldHead, newHead *types.Header) {
 	pool.rules.Store(&rules)
 	pool.eip2718.Store(rules.IsSubnetEVM)
 	pool.eip1559.Store(rules.IsSubnetEVM)
-	pool.eip3860.Store(rules.IsDUpgrade)
+	pool.eip3860.Store(rules.IsDurango)
 }
 
 // promoteExecutables moves transactions that have become processable from the

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -70,8 +70,8 @@ func NewEVMInterpreter(evm *EVM) *EVMInterpreter {
 	// If jump table was not initialised we set the default one.
 	var table *JumpTable
 	switch {
-	case evm.chainRules.IsDUpgrade:
-		table = &dUpgradeInstructionSet
+	case evm.chainRules.IsDurango:
+		table = &durangoInstructionSet
 	case evm.chainRules.IsSubnetEVM:
 		table = &subnetEVMInstructionSet
 	case evm.chainRules.IsIstanbul:

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -63,7 +63,7 @@ var (
 	constantinopleInstructionSet   = newConstantinopleInstructionSet()
 	istanbulInstructionSet         = newIstanbulInstructionSet()
 	subnetEVMInstructionSet        = newSubnetEVMInstructionSet()
-	dUpgradeInstructionSet         = newDUpgradeInstructionSet()
+	durangoInstructionSet          = newDurangoInstructionSet()
 )
 
 // JumpTable contains the EVM opcodes supported at a given fork.
@@ -87,9 +87,9 @@ func validate(jt JumpTable) JumpTable {
 	return jt
 }
 
-// newDUpgradeInstructionSet returns the frontier, homestead, byzantium,
-// constantinople, istanbul, petersburg, subnet-evm, d-upgrade instructions.
-func newDUpgradeInstructionSet() JumpTable {
+// newDurangoInstructionSet returns the frontier, homestead, byzantium,
+// constantinople, istanbul, petersburg, subnet-evm, durango instructions.
+func newDurangoInstructionSet() JumpTable {
 	instructionSet := newSubnetEVMInstructionSet()
 	enable3855(&instructionSet) // PUSH0 instruction
 	enable3860(&instructionSet) // Limit and meter initcode

--- a/core/vm/jump_table_export.go
+++ b/core/vm/jump_table_export.go
@@ -24,8 +24,8 @@ import (
 // the rules.
 func LookupInstructionSet(rules params.Rules) (JumpTable, error) {
 	switch {
-	case rules.IsDUpgrade:
-		return newDUpgradeInstructionSet(), nil
+	case rules.IsDurango:
+		return newDurangoInstructionSet(), nil
 	case rules.IsSubnetEVM:
 		return newSubnetEVMInstructionSet(), nil
 	case rules.IsIstanbul:

--- a/core/vm/jump_table_test.go
+++ b/core/vm/jump_table_test.go
@@ -34,7 +34,7 @@ import (
 
 // TestJumpTableCopy tests that deep copy is necessery to prevent modify shared jump table
 func TestJumpTableCopy(t *testing.T) {
-	tbl := newDUpgradeInstructionSet()
+	tbl := newDurangoInstructionSet()
 	require.Equal(t, uint64(0), tbl[SLOAD].constantGas)
 
 	// a deep copy won't modify the shared jump table

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -1052,8 +1052,8 @@ func overrideConfig(original *params.ChainConfig, override *params.ChainConfig) 
 		copy.SubnetEVMTimestamp = timestamp
 		canon = false
 	}
-	if timestamp := override.DUpgradeTimestamp; timestamp != nil {
-		copy.DUpgradeTimestamp = timestamp
+	if timestamp := override.DurangoTimestamp; timestamp != nil {
+		copy.DurangoTimestamp = timestamp
 		canon = false
 	}
 	if timestamp := override.CancunTime; timestamp != nil {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -252,7 +252,7 @@ func (w *worker) commitTransaction(env *environment, tx *types.Transaction, coin
 		blockContext vm.BlockContext
 	)
 
-	if env.rules.IsDUpgrade {
+	if env.rules.IsDurango {
 		results, err := core.CheckPredicates(env.rules, env.predicateContext, tx)
 		if err != nil {
 			log.Debug("Transaction predicate failed verification in miner", "tx", tx.Hash(), "err", err)
@@ -337,7 +337,7 @@ func (w *worker) commitTransactions(env *environment, txs *types.TransactionsByP
 // commit runs any post-transaction state modifications, assembles the final block
 // and commits new work if consensus engine is running.
 func (w *worker) commit(env *environment) (*types.Block, error) {
-	if env.rules.IsDUpgrade {
+	if env.rules.IsDurango {
 		predicateResultsBytes, err := env.predicateResults.Bytes()
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal predicate results: %w", err)

--- a/params/config.go
+++ b/params/config.go
@@ -106,7 +106,7 @@ var (
 		MuirGlacierBlock:    big.NewInt(0),
 		MandatoryNetworkUpgrades: MandatoryNetworkUpgrades{
 			SubnetEVMTimestamp: utils.NewUint64(0),
-			DUpgradeTimestamp:  utils.NewUint64(0),
+			DurangoTimestamp:   utils.NewUint64(0),
 		},
 		GenesisPrecompiles: Precompiles{},
 		UpgradeConfig:      UpgradeConfig{},
@@ -279,7 +279,7 @@ func (c *ChainConfig) Description() string {
 	}
 	banner += "Mandatory Upgrades:\n"
 	banner += fmt.Sprintf(" - SubnetEVM Timestamp:           @%-10v (https://github.com/ava-labs/avalanchego/releases/tag/v1.10.0)\n", ptrToString(c.SubnetEVMTimestamp))
-	banner += fmt.Sprintf(" - DUpgrade Timestamp:            @%-10v (https://github.com/ava-labs/avalanchego/releases/tag/v1.11.0)\n", ptrToString(c.DUpgradeTimestamp))
+	banner += fmt.Sprintf(" - Durango Timestamp:            @%-10v (https://github.com/ava-labs/avalanchego/releases/tag/v1.11.0)\n", ptrToString(c.DurangoTimestamp))
 	banner += fmt.Sprintf(" - Cancun Timestamp:              @%-10v (https://github.com/ava-labs/avalanchego/releases/tag/v1.11.0)\n", ptrToString(c.CancunTime))
 	banner += "\n"
 
@@ -370,10 +370,10 @@ func (c *ChainConfig) IsSubnetEVM(time uint64) bool {
 	return utils.IsTimestampForked(c.SubnetEVMTimestamp, time)
 }
 
-// IsDUpgrade returns whether [time] represents a block
-// with a timestamp after the DUpgrade upgrade time.
-func (c *ChainConfig) IsDUpgrade(time uint64) bool {
-	return utils.IsTimestampForked(c.DUpgradeTimestamp, time)
+// IsDurango returns whether [time] represents a block
+// with a timestamp after the Durango upgrade time.
+func (c *ChainConfig) IsDurango(time uint64) bool {
+	return utils.IsTimestampForked(c.DurangoTimestamp, time)
 }
 
 // IsCancun returns whether [time] represents a block
@@ -717,7 +717,7 @@ type Rules struct {
 
 	// Rules for Avalanche releases
 	IsSubnetEVM bool
-	IsDUpgrade  bool
+	IsDurango   bool
 
 	// ActivePrecompiles maps addresses to stateful precompiled contracts that are enabled
 	// for this rule set.
@@ -764,7 +764,7 @@ func (c *ChainConfig) AvalancheRules(blockNum *big.Int, timestamp uint64) Rules 
 	rules := c.rules(blockNum, timestamp)
 
 	rules.IsSubnetEVM = c.IsSubnetEVM(timestamp)
-	rules.IsDUpgrade = c.IsDUpgrade(timestamp)
+	rules.IsDurango = c.IsDurango(timestamp)
 
 	// Initialize the stateful precompiles that should be enabled at [blockTimestamp].
 	rules.ActivePrecompiles = make(map[common.Address]precompileconfig.Config)

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -274,7 +274,7 @@ func TestChainConfigMarshalWithUpgrades(t *testing.T) {
 			MuirGlacierBlock:    big.NewInt(0),
 			MandatoryNetworkUpgrades: MandatoryNetworkUpgrades{
 				SubnetEVMTimestamp: utils.NewUint64(0),
-				DUpgradeTimestamp:  utils.NewUint64(0),
+				DurangoTimestamp:   utils.NewUint64(0),
 			},
 			GenesisPrecompiles: Precompiles{},
 		},
@@ -310,7 +310,7 @@ func TestChainConfigMarshalWithUpgrades(t *testing.T) {
 		"istanbulBlock": 0,
 		"muirGlacierBlock": 0,
 		"subnetEVMTimestamp": 0,
-		"dUpgradeTimestamp": 0,
+		"durangoTimestamp": 0,
 		"upgrades": {
 			"precompileUpgrades": [
 				{

--- a/params/network_upgrades.go
+++ b/params/network_upgrades.go
@@ -10,22 +10,22 @@ import (
 var (
 	LocalNetworkUpgrades = MandatoryNetworkUpgrades{
 		SubnetEVMTimestamp: utils.NewUint64(0),
-		DUpgradeTimestamp:  utils.NewUint64(0),
+		DurangoTimestamp:   utils.NewUint64(0),
 	}
 
 	FujiNetworkUpgrades = MandatoryNetworkUpgrades{
 		SubnetEVMTimestamp: utils.NewUint64(0),
-		// DUpgradeTimestamp: utils.NewUint64(0), // TODO: Uncomment and set this to the correct value
+		// DurangoTimestamp: utils.NewUint64(0), // TODO: Uncomment and set this to the correct value
 	}
 
 	MainnetNetworkUpgrades = MandatoryNetworkUpgrades{
 		SubnetEVMTimestamp: utils.NewUint64(0),
-		// DUpgradeTimestamp: utils.NewUint64(0), // TODO: Uncomment and set this to the correct value
+		// DurangoTimestamp: utils.NewUint64(0), // TODO: Uncomment and set this to the correct value
 	}
 
 	UnitTestNetworkUpgrades = MandatoryNetworkUpgrades{
 		SubnetEVMTimestamp: utils.NewUint64(0),
-		DUpgradeTimestamp:  utils.NewUint64(0),
+		DurangoTimestamp:   utils.NewUint64(0),
 	}
 )
 
@@ -36,10 +36,10 @@ var (
 type MandatoryNetworkUpgrades struct {
 	// SubnetEVMTimestamp is a placeholder that activates Avalanche Upgrades prior to ApricotPhase6 (nil = no fork, 0 = already activated)
 	SubnetEVMTimestamp *uint64 `json:"subnetEVMTimestamp,omitempty"`
-	// DUpgrade activates the Shanghai Execution Spec Upgrade from Ethereum (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/shanghai.md#included-eips)
+	// Durango activates the Shanghai Execution Spec Upgrade from Ethereum (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/shanghai.md#included-eips)
 	// and Avalanche Warp Messaging. (nil = no fork, 0 = already activated)
 	// Note: EIP-4895 is excluded since withdrawals are not relevant to the Avalanche C-Chain or Subnets running the EVM.
-	DUpgradeTimestamp *uint64 `json:"dUpgradeTimestamp,omitempty"`
+	DurangoTimestamp *uint64 `json:"durangoTimestamp,omitempty"`
 	// Cancun activates the Cancun upgrade from Ethereum. (nil = no fork, 0 = already activated)
 	CancunTime *uint64 `json:"cancunTime,omitempty"`
 }
@@ -48,8 +48,8 @@ func (m *MandatoryNetworkUpgrades) CheckMandatoryCompatible(newcfg *MandatoryNet
 	if isForkTimestampIncompatible(m.SubnetEVMTimestamp, newcfg.SubnetEVMTimestamp, time) {
 		return newTimestampCompatError("SubnetEVM fork block timestamp", m.SubnetEVMTimestamp, newcfg.SubnetEVMTimestamp)
 	}
-	if isForkTimestampIncompatible(m.DUpgradeTimestamp, newcfg.DUpgradeTimestamp, time) {
-		return newTimestampCompatError("DUpgrade fork block timestamp", m.DUpgradeTimestamp, newcfg.DUpgradeTimestamp)
+	if isForkTimestampIncompatible(m.DurangoTimestamp, newcfg.DurangoTimestamp, time) {
+		return newTimestampCompatError("Durango fork block timestamp", m.DurangoTimestamp, newcfg.DurangoTimestamp)
 	}
 	if isForkTimestampIncompatible(m.CancunTime, newcfg.CancunTime, time) {
 		return newTimestampCompatError("Cancun fork block timestamp", m.CancunTime, m.CancunTime)
@@ -60,7 +60,7 @@ func (m *MandatoryNetworkUpgrades) CheckMandatoryCompatible(newcfg *MandatoryNet
 func (m *MandatoryNetworkUpgrades) mandatoryForkOrder() []fork {
 	return []fork{
 		{name: "subnetEVMTimestamp", timestamp: m.SubnetEVMTimestamp},
-		{name: "dUpgradeTimestamp", timestamp: m.DUpgradeTimestamp},
+		{name: "durangoTimestamp", timestamp: m.DurangoTimestamp},
 	}
 }
 

--- a/plugin/evm/block.go
+++ b/plugin/evm/block.go
@@ -251,9 +251,9 @@ func (b *Block) verifyPredicates(predicateContext *precompileconfig.PredicateCon
 	rules := b.vm.chainConfig.AvalancheRules(b.ethBlock.Number(), b.ethBlock.Timestamp())
 
 	switch {
-	case !rules.IsDUpgrade && rules.PredicatersExist():
-		return errors.New("cannot enable predicates before DUpgrade activation")
-	case !rules.IsDUpgrade:
+	case !rules.IsDurango && rules.PredicatersExist():
+		return errors.New("cannot enable predicates before Durango activation")
+	case !rules.IsDurango:
 		return nil
 	}
 

--- a/plugin/evm/block_verification.go
+++ b/plugin/evm/block_verification.go
@@ -59,7 +59,7 @@ func (v blockValidator) SyntacticVerify(b *Block, rules params.Rules) error {
 	}
 
 	switch {
-	case rules.IsDUpgrade:
+	case rules.IsDurango:
 		if len(ethHeader.Extra) < params.DynamicFeeExtraDataSize {
 			return fmt.Errorf(
 				"expected header ExtraData to be len >= %d but got %d",

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -81,9 +81,9 @@ var (
 	// Use chainId: 43111, so that it does not overlap with any Avalanche ChainIDs, which may have their
 	// config overridden in vm.Initialize.
 	genesisJSONSubnetEVM    = "{\"config\":{\"chainId\":43111,\"homesteadBlock\":0,\"eip150Block\":0,\"eip155Block\":0,\"eip158Block\":0,\"byzantiumBlock\":0,\"constantinopleBlock\":0,\"petersburgBlock\":0,\"istanbulBlock\":0,\"muirGlacierBlock\":0,\"subnetEVMTimestamp\":0},\"nonce\":\"0x0\",\"timestamp\":\"0x0\",\"extraData\":\"0x00\",\"gasLimit\":\"0x7A1200\",\"difficulty\":\"0x0\",\"mixHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"coinbase\":\"0x0000000000000000000000000000000000000000\",\"alloc\":{\"0x71562b71999873DB5b286dF957af199Ec94617F7\": {\"balance\":\"0x4192927743b88000\"}, \"0x703c4b2bD70c169f5717101CaeE543299Fc946C7\": {\"balance\":\"0x4192927743b88000\"}},\"number\":\"0x0\",\"gasUsed\":\"0x0\",\"parentHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\"}"
-	genesisJSONDUpgrade     = "{\"config\":{\"chainId\":43111,\"homesteadBlock\":0,\"eip150Block\":0,\"eip155Block\":0,\"eip158Block\":0,\"byzantiumBlock\":0,\"constantinopleBlock\":0,\"petersburgBlock\":0,\"istanbulBlock\":0,\"muirGlacierBlock\":0,\"subnetEVMTimestamp\":0,\"dUpgradeTimestamp\":0},\"nonce\":\"0x0\",\"timestamp\":\"0x0\",\"extraData\":\"0x00\",\"gasLimit\":\"0x7A1200\",\"difficulty\":\"0x0\",\"mixHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"coinbase\":\"0x0000000000000000000000000000000000000000\",\"alloc\":{\"0x71562b71999873DB5b286dF957af199Ec94617F7\": {\"balance\":\"0x4192927743b88000\"}, \"0x703c4b2bD70c169f5717101CaeE543299Fc946C7\": {\"balance\":\"0x4192927743b88000\"}},\"number\":\"0x0\",\"gasUsed\":\"0x0\",\"parentHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\"}"
+	genesisJSONDurango      = "{\"config\":{\"chainId\":43111,\"homesteadBlock\":0,\"eip150Block\":0,\"eip155Block\":0,\"eip158Block\":0,\"byzantiumBlock\":0,\"constantinopleBlock\":0,\"petersburgBlock\":0,\"istanbulBlock\":0,\"muirGlacierBlock\":0,\"subnetEVMTimestamp\":0,\"durangoTimestamp\":0},\"nonce\":\"0x0\",\"timestamp\":\"0x0\",\"extraData\":\"0x00\",\"gasLimit\":\"0x7A1200\",\"difficulty\":\"0x0\",\"mixHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"coinbase\":\"0x0000000000000000000000000000000000000000\",\"alloc\":{\"0x71562b71999873DB5b286dF957af199Ec94617F7\": {\"balance\":\"0x4192927743b88000\"}, \"0x703c4b2bD70c169f5717101CaeE543299Fc946C7\": {\"balance\":\"0x4192927743b88000\"}},\"number\":\"0x0\",\"gasUsed\":\"0x0\",\"parentHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\"}"
 	genesisJSONPreSubnetEVM = "{\"config\":{\"chainId\":43111,\"homesteadBlock\":0,\"eip150Block\":0,\"eip155Block\":0,\"eip158Block\":0,\"byzantiumBlock\":0,\"constantinopleBlock\":0,\"petersburgBlock\":0,\"istanbulBlock\":0,\"muirGlacierBlock\":0},\"nonce\":\"0x0\",\"timestamp\":\"0x0\",\"extraData\":\"0x00\",\"gasLimit\":\"0x7A1200\",\"difficulty\":\"0x0\",\"mixHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"coinbase\":\"0x0000000000000000000000000000000000000000\",\"alloc\":{\"0x71562b71999873DB5b286dF957af199Ec94617F7\": {\"balance\":\"0x4192927743b88000\"}, \"0x703c4b2bD70c169f5717101CaeE543299Fc946C7\": {\"balance\":\"0x4192927743b88000\"}},\"number\":\"0x0\",\"gasUsed\":\"0x0\",\"parentHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\"}"
-	genesisJSONLatest       = genesisJSONDUpgrade
+	genesisJSONLatest       = genesisJSONDurango
 
 	firstTxAmount  = new(big.Int).Mul(big.NewInt(testMinGasPrice), big.NewInt(21000*100))
 	genesisBalance = new(big.Int).Mul(big.NewInt(testMinGasPrice), big.NewInt(21000*1000))
@@ -2190,29 +2190,29 @@ func TestTxAllowListSuccessfulTx(t *testing.T) {
 	managerKey := testKeys[1]
 	managerAddress := testEthAddrs[1]
 	genesis := &core.Genesis{}
-	if err := genesis.UnmarshalJSON([]byte(genesisJSONDUpgrade)); err != nil {
+	if err := genesis.UnmarshalJSON([]byte(genesisJSONDurango)); err != nil {
 		t.Fatal(err)
 	}
-	// this manager role should not be activated because DUpgradeTimestamp is in the future
+	// this manager role should not be activated because DurangoTimestamp is in the future
 	genesis.Config.GenesisPrecompiles = params.Precompiles{
 		txallowlist.ConfigKey: txallowlist.NewConfig(utils.NewUint64(0), testEthAddrs[0:1], nil, nil),
 	}
-	dUpgradeTime := time.Now().Add(10 * time.Hour)
-	genesis.Config.DUpgradeTimestamp = utils.TimeToNewUint64(dUpgradeTime)
+	durangoTime := time.Now().Add(10 * time.Hour)
+	genesis.Config.DurangoTimestamp = utils.TimeToNewUint64(durangoTime)
 	genesisJSON, err := genesis.MarshalJSON()
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// prepare the new upgrade bytes to disable the TxAllowList
-	disableAllowListTime := dUpgradeTime.Add(10 * time.Hour)
+	disableAllowListTime := durangoTime.Add(10 * time.Hour)
 	reenableAllowlistTime := disableAllowListTime.Add(10 * time.Hour)
 	upgradeConfig := &params.UpgradeConfig{
 		PrecompileUpgrades: []params.PrecompileUpgrade{
 			{
 				Config: txallowlist.NewDisableConfig(utils.TimeToNewUint64(disableAllowListTime)),
 			},
-			// re-enable the tx allowlist after DUpgrade to set the manager role
+			// re-enable the tx allowlist after Durango to set the manager role
 			{
 				Config: txallowlist.NewConfig(utils.TimeToNewUint64(reenableAllowlistTime), testEthAddrs[0:1], nil, []common.Address{managerAddress}),
 			},
@@ -2245,7 +2245,7 @@ func TestTxAllowListSuccessfulTx(t *testing.T) {
 	if role != allowlist.NoRole {
 		t.Fatalf("Expected allow list status to be set to no role: %s, but found: %s", allowlist.NoRole, role)
 	}
-	// Should not be a manager role because DUpgrade has not activated yet
+	// Should not be a manager role because Durango has not activated yet
 	role = txallowlist.GetTxAllowListStatus(genesisState, managerAddress)
 	require.Equal(t, allowlist.NoRole, role)
 
@@ -2343,11 +2343,11 @@ func TestTxAllowListSuccessfulTx(t *testing.T) {
 
 func TestVerifyManagerConfig(t *testing.T) {
 	genesis := &core.Genesis{}
-	require.NoError(t, genesis.UnmarshalJSON([]byte(genesisJSONDUpgrade)))
+	require.NoError(t, genesis.UnmarshalJSON([]byte(genesisJSONDurango)))
 
-	dUpgradeTimestamp := time.Now().Add(10 * time.Hour)
-	genesis.Config.DUpgradeTimestamp = utils.TimeToNewUint64(dUpgradeTimestamp)
-	// this manager role should not be activated because DUpgradeTimestamp is in the future
+	durangoTimestamp := time.Now().Add(10 * time.Hour)
+	genesis.Config.DurangoTimestamp = utils.TimeToNewUint64(durangoTimestamp)
+	// this manager role should not be activated because DurangoTimestamp is in the future
 	genesis.Config.GenesisPrecompiles = params.Precompiles{
 		txallowlist.ConfigKey: txallowlist.NewConfig(utils.NewUint64(0), testEthAddrs[0:1], nil, []common.Address{testEthAddrs[1]}),
 	}
@@ -2368,18 +2368,18 @@ func TestVerifyManagerConfig(t *testing.T) {
 		[]*commonEng.Fx{},
 		nil,
 	)
-	require.ErrorIs(t, err, allowlist.ErrCannotAddManagersBeforeDUpgrade)
+	require.ErrorIs(t, err, allowlist.ErrCannotAddManagersBeforeDurango)
 
 	genesis = &core.Genesis{}
-	require.NoError(t, genesis.UnmarshalJSON([]byte(genesisJSONDUpgrade)))
-	genesis.Config.DUpgradeTimestamp = utils.TimeToNewUint64(dUpgradeTimestamp)
+	require.NoError(t, genesis.UnmarshalJSON([]byte(genesisJSONDurango)))
+	genesis.Config.DurangoTimestamp = utils.TimeToNewUint64(durangoTimestamp)
 	genesisJSON, err = genesis.MarshalJSON()
 	require.NoError(t, err)
-	// use an invalid upgrade now with managers set before DUpgrade
+	// use an invalid upgrade now with managers set before Durango
 	upgradeConfig := &params.UpgradeConfig{
 		PrecompileUpgrades: []params.PrecompileUpgrade{
 			{
-				Config: txallowlist.NewConfig(utils.TimeToNewUint64(dUpgradeTimestamp.Add(-time.Second)), nil, nil, []common.Address{testEthAddrs[1]}),
+				Config: txallowlist.NewConfig(utils.TimeToNewUint64(durangoTimestamp.Add(-time.Second)), nil, nil, []common.Address{testEthAddrs[1]}),
 			},
 		},
 	}
@@ -2399,7 +2399,7 @@ func TestVerifyManagerConfig(t *testing.T) {
 		[]*commonEng.Fx{},
 		nil,
 	)
-	require.ErrorIs(t, err, allowlist.ErrCannotAddManagersBeforeDUpgrade)
+	require.ErrorIs(t, err, allowlist.ErrCannotAddManagersBeforeDurango)
 }
 
 // Test that the tx allow list allows whitelisted transactions and blocks non-whitelisted addresses

--- a/plugin/evm/vm_warp_test.go
+++ b/plugin/evm/vm_warp_test.go
@@ -47,7 +47,7 @@ var (
 func TestSendWarpMessage(t *testing.T) {
 	require := require.New(t)
 	genesis := &core.Genesis{}
-	require.NoError(genesis.UnmarshalJSON([]byte(genesisJSONDUpgrade)))
+	require.NoError(genesis.UnmarshalJSON([]byte(genesisJSONDurango)))
 	genesis.Config.GenesisPrecompiles = params.Precompiles{
 		warp.ConfigKey: warp.NewDefaultConfig(subnetEVMUtils.NewUint64(0)),
 	}
@@ -247,7 +247,7 @@ func TestValidateInvalidWarpBlockHash(t *testing.T) {
 func testWarpVMTransaction(t *testing.T, unsignedMessage *avalancheWarp.UnsignedMessage, validSignature bool, txPayload []byte) {
 	require := require.New(t)
 	genesis := &core.Genesis{}
-	require.NoError(genesis.UnmarshalJSON([]byte(genesisJSONDUpgrade)))
+	require.NoError(genesis.UnmarshalJSON([]byte(genesisJSONDurango)))
 	genesis.Config.GenesisPrecompiles = params.Precompiles{
 		warp.ConfigKey: warp.NewDefaultConfig(subnetEVMUtils.NewUint64(0)),
 	}
@@ -404,7 +404,7 @@ func testWarpVMTransaction(t *testing.T, unsignedMessage *avalancheWarp.Unsigned
 func TestReceiveWarpMessage(t *testing.T) {
 	require := require.New(t)
 	genesis := &core.Genesis{}
-	require.NoError(genesis.UnmarshalJSON([]byte(genesisJSONDUpgrade)))
+	require.NoError(genesis.UnmarshalJSON([]byte(genesisJSONDurango)))
 	genesis.Config.GenesisPrecompiles = params.Precompiles{
 		warp.ConfigKey: warp.NewDefaultConfig(subnetEVMUtils.NewUint64(0)),
 	}

--- a/precompile/allowlist/allowlist.go
+++ b/precompile/allowlist/allowlist.go
@@ -88,8 +88,8 @@ func createAllowListRoleSetter(precompileAddr common.Address, role Role) contrac
 			return nil, 0, err
 		}
 
-		// do not use strict mode after DUpgrade
-		useStrictMode := !contract.IsDUpgradeActivated(evm)
+		// do not use strict mode after Durango
+		useStrictMode := !contract.IsDurangoActivated(evm)
 		modifyAddress, err := UnpackModifyAllowListInput(input, role, useStrictMode)
 
 		if err != nil {
@@ -109,7 +109,7 @@ func createAllowListRoleSetter(precompileAddr common.Address, role Role) contrac
 		if !callerStatus.CanModify(modifyStatus, role) {
 			return nil, remainingGas, fmt.Errorf("%w: modify address: %s, from role: %s, to role: %s", ErrCannotModifyAllowList, callerAddr, modifyStatus, role)
 		}
-		if contract.IsDUpgradeActivated(evm) {
+		if contract.IsDurangoActivated(evm) {
 			if remainingGas, err = contract.DeductGas(remainingGas, AllowListEventGasCost); err != nil {
 				return nil, 0, err
 			}
@@ -159,8 +159,8 @@ func createReadAllowList(precompileAddr common.Address) contract.RunStatefulPrec
 			return nil, 0, err
 		}
 
-		// We skip the fixed length check with DUpgrade
-		useStrictMode := !contract.IsDUpgradeActivated(evm)
+		// We skip the fixed length check with Durango
+		useStrictMode := !contract.IsDurangoActivated(evm)
 		readAddress, err := UnpackReadAllowListInput(input, useStrictMode)
 		if err != nil {
 			return nil, remainingGas, err
@@ -200,7 +200,7 @@ func CreateAllowListFunctions(precompileAddr common.Address) []*contract.Statefu
 		} else if noRoleFnName, _ := NoRole.GetSetterFunctionName(); name == noRoleFnName {
 			fn = contract.NewStatefulPrecompileFunction(method.ID, createAllowListRoleSetter(precompileAddr, NoRole))
 		} else if managerFnName, _ := ManagerRole.GetSetterFunctionName(); name == managerFnName {
-			fn = contract.NewStatefulPrecompileFunctionWithActivator(method.ID, createAllowListRoleSetter(precompileAddr, ManagerRole), contract.IsDUpgradeActivated)
+			fn = contract.NewStatefulPrecompileFunctionWithActivator(method.ID, createAllowListRoleSetter(precompileAddr, ManagerRole), contract.IsDurangoActivated)
 		} else {
 			panic(fmt.Sprintf("unexpected method name: %s", name))
 		}

--- a/precompile/allowlist/config.go
+++ b/precompile/allowlist/config.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-var ErrCannotAddManagersBeforeDUpgrade = fmt.Errorf("cannot add managers before DUpgrade")
+var ErrCannotAddManagersBeforeDurango = fmt.Errorf("cannot add managers before Durango")
 
 // AllowListConfig specifies the initial set of addresses with Admin or Enabled roles.
 type AllowListConfig struct {
@@ -86,10 +86,10 @@ func (c *AllowListConfig) Verify(chainConfig precompileconfig.ChainConfig, upgra
 	}
 
 	if len(c.ManagerAddresses) != 0 && upgrade.Timestamp() != nil {
-		// If the config attempts to activate a manager before the DUpgrade, fail verification
+		// If the config attempts to activate a manager before the Durango, fail verification
 		timestamp := *upgrade.Timestamp()
-		if !chainConfig.IsDUpgrade(timestamp) {
-			return ErrCannotAddManagersBeforeDUpgrade
+		if !chainConfig.IsDurango(timestamp) {
+			return ErrCannotAddManagersBeforeDurango
 		}
 	}
 

--- a/precompile/allowlist/role.go
+++ b/precompile/allowlist/role.go
@@ -13,7 +13,7 @@ import (
 // 1. NoRole - this is equivalent to common.Hash{} and deletes the key from the DB when set
 // 2. EnabledRole - allowed to call the precompile
 // 3. Admin - allowed to both modify the allowlist and call the precompile
-// 4. Manager - allowed to add and remove only enabled addresses and also call the precompile. (only after DUpgrade)
+// 4. Manager - allowed to add and remove only enabled addresses and also call the precompile. (only after Durango)
 var (
 	NoRole      = Role(common.BigToHash(common.Big0))
 	EnabledRole = Role(common.BigToHash(common.Big1))

--- a/precompile/allowlist/test_allowlist.go
+++ b/precompile/allowlist/test_allowlist.go
@@ -164,12 +164,12 @@ func AllowListTests(t testing.TB, module modules.Module) map[string]testutils.Pr
 			ReadOnly:    false,
 			ExpectedErr: ErrCannotModifyAllowList.Error(),
 		},
-		"no role set manager pre-DUpgrade": {
+		"no role set manager pre-Durango": {
 			Caller:     TestNoRoleAddr,
 			BeforeHook: SetDefaultRoles(contractAddress),
 			ChainConfigFn: func(ctrl *gomock.Controller) precompileconfig.ChainConfig {
 				config := precompileconfig.NewMockChainConfig(ctrl)
-				config.EXPECT().IsDUpgrade(gomock.Any()).Return(false).AnyTimes()
+				config.EXPECT().IsDurango(gomock.Any()).Return(false).AnyTimes()
 				return config
 			},
 			InputFn: func(t testing.TB) []byte {
@@ -187,7 +187,7 @@ func AllowListTests(t testing.TB, module modules.Module) map[string]testutils.Pr
 			BeforeHook: SetDefaultRoles(contractAddress),
 			ChainConfigFn: func(ctrl *gomock.Controller) precompileconfig.ChainConfig {
 				config := precompileconfig.NewMockChainConfig(ctrl)
-				config.EXPECT().IsDUpgrade(gomock.Any()).Return(true).AnyTimes()
+				config.EXPECT().IsDurango(gomock.Any()).Return(true).AnyTimes()
 				return config
 			},
 			InputFn: func(t testing.TB) []byte {
@@ -200,12 +200,12 @@ func AllowListTests(t testing.TB, module modules.Module) map[string]testutils.Pr
 			ReadOnly:    false,
 			ExpectedErr: ErrCannotModifyAllowList.Error(),
 		},
-		"enabled role set manager pre-DUpgrade": {
+		"enabled role set manager pre-Durango": {
 			Caller:     TestEnabledAddr,
 			BeforeHook: SetDefaultRoles(contractAddress),
 			ChainConfigFn: func(ctrl *gomock.Controller) precompileconfig.ChainConfig {
 				config := precompileconfig.NewMockChainConfig(ctrl)
-				config.EXPECT().IsDUpgrade(gomock.Any()).Return(false).AnyTimes()
+				config.EXPECT().IsDurango(gomock.Any()).Return(false).AnyTimes()
 				return config
 			},
 			InputFn: func(t testing.TB) []byte {
@@ -223,7 +223,7 @@ func AllowListTests(t testing.TB, module modules.Module) map[string]testutils.Pr
 			BeforeHook: SetDefaultRoles(contractAddress),
 			ChainConfigFn: func(ctrl *gomock.Controller) precompileconfig.ChainConfig {
 				config := precompileconfig.NewMockChainConfig(ctrl)
-				config.EXPECT().IsDUpgrade(gomock.Any()).Return(true).AnyTimes()
+				config.EXPECT().IsDurango(gomock.Any()).Return(true).AnyTimes()
 				return config
 			},
 			InputFn: func(t testing.TB) []byte {
@@ -247,7 +247,7 @@ func AllowListTests(t testing.TB, module modules.Module) map[string]testutils.Pr
 			},
 			ChainConfigFn: func(ctrl *gomock.Controller) precompileconfig.ChainConfig {
 				config := precompileconfig.NewMockChainConfig(ctrl)
-				config.EXPECT().IsDUpgrade(gomock.Any()).Return(false).AnyTimes()
+				config.EXPECT().IsDurango(gomock.Any()).Return(false).AnyTimes()
 				return config
 			},
 			SuppliedGas: 0,
@@ -266,7 +266,7 @@ func AllowListTests(t testing.TB, module modules.Module) map[string]testutils.Pr
 			ExpectedRes: []byte{},
 			ChainConfigFn: func(ctrl *gomock.Controller) precompileconfig.ChainConfig {
 				config := precompileconfig.NewMockChainConfig(ctrl)
-				config.EXPECT().IsDUpgrade(gomock.Any()).Return(true).AnyTimes()
+				config.EXPECT().IsDurango(gomock.Any()).Return(true).AnyTimes()
 				return config
 			},
 			SuppliedGas: ModifyAllowListGasCost + AllowListEventGasCost,
@@ -327,7 +327,7 @@ func AllowListTests(t testing.TB, module modules.Module) map[string]testutils.Pr
 			BeforeHook: SetDefaultRoles(contractAddress),
 			ChainConfigFn: func(ctrl *gomock.Controller) precompileconfig.ChainConfig {
 				config := precompileconfig.NewMockChainConfig(ctrl)
-				config.EXPECT().IsDUpgrade(gomock.Any()).Return(true).AnyTimes()
+				config.EXPECT().IsDurango(gomock.Any()).Return(true).AnyTimes()
 				return config
 			},
 			InputFn: func(t testing.TB) []byte {
@@ -371,7 +371,7 @@ func AllowListTests(t testing.TB, module modules.Module) map[string]testutils.Pr
 			BeforeHook: SetDefaultRoles(contractAddress),
 			ChainConfigFn: func(ctrl *gomock.Controller) precompileconfig.ChainConfig {
 				config := precompileconfig.NewMockChainConfig(ctrl)
-				config.EXPECT().IsDUpgrade(gomock.Any()).Return(true).AnyTimes()
+				config.EXPECT().IsDurango(gomock.Any()).Return(true).AnyTimes()
 				return config
 			},
 			InputFn: func(t testing.TB) []byte {
@@ -436,7 +436,7 @@ func AllowListTests(t testing.TB, module modules.Module) map[string]testutils.Pr
 			BeforeHook: SetDefaultRoles(contractAddress),
 			ChainConfigFn: func(ctrl *gomock.Controller) precompileconfig.ChainConfig {
 				config := precompileconfig.NewMockChainConfig(ctrl)
-				config.EXPECT().IsDUpgrade(gomock.Any()).Return(true).AnyTimes()
+				config.EXPECT().IsDurango(gomock.Any()).Return(true).AnyTimes()
 				return config
 			},
 			InputFn: func(t testing.TB) []byte {
@@ -579,12 +579,12 @@ func AllowListTests(t testing.TB, module modules.Module) map[string]testutils.Pr
 				require.Equal(t, EnabledRole, GetAllowListStatus(state, contractAddress, TestNoRoleAddr))
 			},
 		},
-		"admin set admin pre-DUpgrade": {
+		"admin set admin pre-Durango": {
 			Caller:     TestAdminAddr,
 			BeforeHook: SetDefaultRoles(contractAddress),
 			ChainConfigFn: func(ctrl *gomock.Controller) precompileconfig.ChainConfig {
 				config := precompileconfig.NewMockChainConfig(ctrl)
-				config.EXPECT().IsDUpgrade(gomock.Any()).Return(false).AnyTimes()
+				config.EXPECT().IsDurango(gomock.Any()).Return(false).AnyTimes()
 				return config
 			},
 			InputFn: func(t testing.TB) []byte {
@@ -602,12 +602,12 @@ func AllowListTests(t testing.TB, module modules.Module) map[string]testutils.Pr
 				require.Len(t, data, 0)
 			},
 		},
-		"admin set enabled pre-DUpgrade": {
+		"admin set enabled pre-Durango": {
 			Caller:     TestAdminAddr,
 			BeforeHook: SetDefaultRoles(contractAddress),
 			ChainConfigFn: func(ctrl *gomock.Controller) precompileconfig.ChainConfig {
 				config := precompileconfig.NewMockChainConfig(ctrl)
-				config.EXPECT().IsDUpgrade(gomock.Any()).Return(false).AnyTimes()
+				config.EXPECT().IsDurango(gomock.Any()).Return(false).AnyTimes()
 				return config
 			},
 			InputFn: func(t testing.TB) []byte {
@@ -625,12 +625,12 @@ func AllowListTests(t testing.TB, module modules.Module) map[string]testutils.Pr
 				require.Len(t, data, 0)
 			},
 		},
-		"admin set no role pre-DUpgrade": {
+		"admin set no role pre-Durango": {
 			Caller:     TestAdminAddr,
 			BeforeHook: SetDefaultRoles(contractAddress),
 			ChainConfigFn: func(ctrl *gomock.Controller) precompileconfig.ChainConfig {
 				config := precompileconfig.NewMockChainConfig(ctrl)
-				config.EXPECT().IsDUpgrade(gomock.Any()).Return(false).AnyTimes()
+				config.EXPECT().IsDurango(gomock.Any()).Return(false).AnyTimes()
 				return config
 			},
 			InputFn: func(t testing.TB) []byte {

--- a/precompile/allowlist/test_allowlist_config.go
+++ b/precompile/allowlist/test_allowlist_config.go
@@ -106,10 +106,10 @@ func AllowListConfigVerifyTests(t testing.TB, module modules.Module) map[string]
 			}),
 			ChainConfig: func() precompileconfig.ChainConfig {
 				config := precompileconfig.NewMockChainConfig(gomock.NewController(t))
-				config.EXPECT().IsDUpgrade(gomock.Any()).Return(false)
+				config.EXPECT().IsDurango(gomock.Any()).Return(false)
 				return config
 			}(),
-			ExpectedError: ErrCannotAddManagersBeforeDUpgrade.Error(),
+			ExpectedError: ErrCannotAddManagersBeforeDurango.Error(),
 		},
 		"nil member allow list config in allowlist": {
 			Config: mkConfigWithAllowList(module, &AllowListConfig{

--- a/precompile/contract/utils.go
+++ b/precompile/contract/utils.go
@@ -59,6 +59,6 @@ func ParseABI(rawABI string) abi.ABI {
 	return parsed
 }
 
-func IsDUpgradeActivated(evm AccessibleState) bool {
-	return evm.GetChainConfig().IsDUpgrade(evm.GetBlockContext().Timestamp())
+func IsDurangoActivated(evm AccessibleState) bool {
+	return evm.GetChainConfig().IsDurango(evm.GetBlockContext().Timestamp())
 }

--- a/precompile/contracts/feemanager/contract.go
+++ b/precompile/contracts/feemanager/contract.go
@@ -178,7 +178,7 @@ func UnpackSetFeeConfigInput(input []byte, useStrictMode bool) (commontype.FeeCo
 	// Initially we had this check to ensure that the input was the correct length.
 	// However solidity does not always pack the input to the correct length, and allows
 	// for extra padding bytes to be added to the end of the input. Therefore, we have removed
-	// this check with the DUpgrade. We still need to keep this check for backwards compatibility.
+	// this check with the Durango. We still need to keep this check for backwards compatibility.
 	if useStrictMode && len(input) != feeConfigInputLen {
 		return commontype.FeeConfig{}, fmt.Errorf("%w: %d", ErrInvalidLen, len(input))
 	}
@@ -213,8 +213,8 @@ func setFeeConfig(accessibleState contract.AccessibleState, caller common.Addres
 		return nil, remainingGas, vmerrs.ErrWriteProtection
 	}
 
-	// do not use strict mode after DUpgrade
-	useStrictMode := !contract.IsDUpgradeActivated(accessibleState)
+	// do not use strict mode after Durango
+	useStrictMode := !contract.IsDurangoActivated(accessibleState)
 	feeConfig, err := UnpackSetFeeConfigInput(input, useStrictMode)
 	if err != nil {
 		return nil, remainingGas, err
@@ -227,7 +227,7 @@ func setFeeConfig(accessibleState contract.AccessibleState, caller common.Addres
 		return nil, remainingGas, fmt.Errorf("%w: %s", ErrCannotChangeFee, caller)
 	}
 
-	if contract.IsDUpgradeActivated(accessibleState) {
+	if contract.IsDurangoActivated(accessibleState) {
 		if remainingGas, err = contract.DeductGas(remainingGas, FeeConfigChangedEventGasCost); err != nil {
 			return nil, 0, err
 		}

--- a/precompile/contracts/feemanager/contract_test.go
+++ b/precompile/contracts/feemanager/contract_test.go
@@ -301,7 +301,7 @@ var (
 			ReadOnly:    false,
 			ExpectedErr: vmerrs.ErrOutOfGas.Error(),
 		},
-		"set config with extra padded bytes should fail before DUpgrade": {
+		"set config with extra padded bytes should fail before Durango": {
 			Caller:     allowlist.TestEnabledAddr,
 			BeforeHook: allowlist.SetDefaultRoles(Module.Address),
 			InputFn: func(t testing.TB) []byte {
@@ -313,7 +313,7 @@ var (
 			},
 			ChainConfigFn: func(ctrl *gomock.Controller) precompileconfig.ChainConfig {
 				config := precompileconfig.NewMockChainConfig(ctrl)
-				config.EXPECT().IsDUpgrade(gomock.Any()).Return(false).AnyTimes()
+				config.EXPECT().IsDurango(gomock.Any()).Return(false).AnyTimes()
 				return config
 			},
 			SuppliedGas: SetFeeConfigGasCost,
@@ -324,7 +324,7 @@ var (
 				mbc.EXPECT().Timestamp().Return(uint64(0)).AnyTimes()
 			},
 		},
-		"set config with extra padded bytes should succeed with DUpgrade": {
+		"set config with extra padded bytes should succeed with Durango": {
 			Caller:     allowlist.TestEnabledAddr,
 			BeforeHook: allowlist.SetDefaultRoles(Module.Address),
 			InputFn: func(t testing.TB) []byte {
@@ -336,7 +336,7 @@ var (
 			},
 			ChainConfigFn: func(ctrl *gomock.Controller) precompileconfig.ChainConfig {
 				config := precompileconfig.NewMockChainConfig(ctrl)
-				config.EXPECT().IsDUpgrade(gomock.Any()).Return(true).AnyTimes()
+				config.EXPECT().IsDurango(gomock.Any()).Return(true).AnyTimes()
 				return config
 			},
 			SuppliedGas: SetFeeConfigGasCost + FeeConfigChangedEventGasCost,
@@ -357,13 +357,13 @@ var (
 			},
 		},
 		// from https://github.com/ava-labs/subnet-evm/issues/487
-		"setFeeConfig regression test should fail before DUpgrade": {
+		"setFeeConfig regression test should fail before Durango": {
 			Caller:     allowlist.TestEnabledAddr,
 			BeforeHook: allowlist.SetDefaultRoles(Module.Address),
 			Input:      common.Hex2Bytes(regressionBytes),
 			ChainConfigFn: func(ctrl *gomock.Controller) precompileconfig.ChainConfig {
 				config := precompileconfig.NewMockChainConfig(ctrl)
-				config.EXPECT().IsDUpgrade(gomock.Any()).Return(false).AnyTimes()
+				config.EXPECT().IsDurango(gomock.Any()).Return(false).AnyTimes()
 				return config
 			},
 			SuppliedGas: SetFeeConfigGasCost,
@@ -374,13 +374,13 @@ var (
 				mbc.EXPECT().Timestamp().Return(uint64(0)).AnyTimes()
 			},
 		},
-		"setFeeConfig regression test should succeed after DUpgrade": {
+		"setFeeConfig regression test should succeed after Durango": {
 			Caller:     allowlist.TestEnabledAddr,
 			BeforeHook: allowlist.SetDefaultRoles(Module.Address),
 			Input:      common.Hex2Bytes(regressionBytes),
 			ChainConfigFn: func(ctrl *gomock.Controller) precompileconfig.ChainConfig {
 				config := precompileconfig.NewMockChainConfig(ctrl)
-				config.EXPECT().IsDUpgrade(gomock.Any()).Return(true).AnyTimes()
+				config.EXPECT().IsDurango(gomock.Any()).Return(true).AnyTimes()
 				return config
 			},
 			SuppliedGas: SetFeeConfigGasCost + FeeConfigChangedEventGasCost,
@@ -400,12 +400,12 @@ var (
 				assertFeeEvent(t, logsTopics, logsData, allowlist.TestEnabledAddr, zeroFeeConfig, regressionFeeConfig)
 			},
 		},
-		"set config should not emit event before DUpgrade": {
+		"set config should not emit event before Durango": {
 			Caller:     allowlist.TestEnabledAddr,
 			BeforeHook: allowlist.SetDefaultRoles(Module.Address),
 			ChainConfigFn: func(ctrl *gomock.Controller) precompileconfig.ChainConfig {
 				config := precompileconfig.NewMockChainConfig(ctrl)
-				config.EXPECT().IsDUpgrade(gomock.Any()).Return(false).AnyTimes()
+				config.EXPECT().IsDurango(gomock.Any()).Return(false).AnyTimes()
 				return config
 			},
 			InputFn: func(t testing.TB) []byte {

--- a/precompile/contracts/nativeminter/config_test.go
+++ b/precompile/contracts/nativeminter/config_test.go
@@ -24,7 +24,7 @@ func TestVerify(t *testing.T) {
 			Config: NewConfig(utils.NewUint64(3), admins, enableds, managers, nil),
 			ChainConfig: func() precompileconfig.ChainConfig {
 				config := precompileconfig.NewMockChainConfig(gomock.NewController(t))
-				config.EXPECT().IsDUpgrade(gomock.Any()).Return(true).AnyTimes()
+				config.EXPECT().IsDurango(gomock.Any()).Return(true).AnyTimes()
 				return config
 			}(),
 			ExpectedError: "",

--- a/precompile/contracts/nativeminter/contract.go
+++ b/precompile/contracts/nativeminter/contract.go
@@ -63,7 +63,7 @@ func UnpackMintNativeCoinInput(input []byte, useStrictMode bool) (common.Address
 	// Initially we had this check to ensure that the input was the correct length.
 	// However solidity does not always pack the input to the correct length, and allows
 	// for extra padding bytes to be added to the end of the input. Therefore, we have removed
-	// this check with the Durango. We still need to keep this check for backwards compatibility.
+	// this check with Durango. We still need to keep this check for backwards compatibility.
 	if useStrictMode && len(input) != mintInputLen {
 		return common.Address{}, nil, fmt.Errorf("%w: %d", ErrInvalidLen, len(input))
 	}

--- a/precompile/contracts/nativeminter/contract.go
+++ b/precompile/contracts/nativeminter/contract.go
@@ -63,7 +63,7 @@ func UnpackMintNativeCoinInput(input []byte, useStrictMode bool) (common.Address
 	// Initially we had this check to ensure that the input was the correct length.
 	// However solidity does not always pack the input to the correct length, and allows
 	// for extra padding bytes to be added to the end of the input. Therefore, we have removed
-	// this check with the DUpgrade. We still need to keep this check for backwards compatibility.
+	// this check with the Durango. We still need to keep this check for backwards compatibility.
 	if useStrictMode && len(input) != mintInputLen {
 		return common.Address{}, nil, fmt.Errorf("%w: %d", ErrInvalidLen, len(input))
 	}
@@ -84,7 +84,7 @@ func mintNativeCoin(accessibleState contract.AccessibleState, caller common.Addr
 		return nil, remainingGas, vmerrs.ErrWriteProtection
 	}
 
-	useStrictMode := !contract.IsDUpgradeActivated(accessibleState)
+	useStrictMode := !contract.IsDurangoActivated(accessibleState)
 	to, amount, err := UnpackMintNativeCoinInput(input, useStrictMode)
 	if err != nil {
 		return nil, remainingGas, err
@@ -97,7 +97,7 @@ func mintNativeCoin(accessibleState contract.AccessibleState, caller common.Addr
 		return nil, remainingGas, fmt.Errorf("%w: %s", ErrCannotMint, caller)
 	}
 
-	if contract.IsDUpgradeActivated(accessibleState) {
+	if contract.IsDurangoActivated(accessibleState) {
 		if remainingGas, err = contract.DeductGas(remainingGas, NativeCoinMintedEventGasCost); err != nil {
 			return nil, 0, err
 		}

--- a/precompile/contracts/nativeminter/contract_test.go
+++ b/precompile/contracts/nativeminter/contract_test.go
@@ -174,12 +174,12 @@ var (
 			ReadOnly:    false,
 			ExpectedErr: vmerrs.ErrOutOfGas.Error(),
 		},
-		"mint doesn't log pre-DUpgrade": {
+		"mint doesn't log pre-Durango": {
 			Caller:     allowlist.TestEnabledAddr,
 			BeforeHook: allowlist.SetDefaultRoles(Module.Address),
 			ChainConfigFn: func(ctrl *gomock.Controller) precompileconfig.ChainConfig {
 				config := precompileconfig.NewMockChainConfig(ctrl)
-				config.EXPECT().IsDUpgrade(gomock.Any()).Return(false).AnyTimes()
+				config.EXPECT().IsDurango(gomock.Any()).Return(false).AnyTimes()
 				return config
 			},
 			InputFn: func(t testing.TB) []byte {
@@ -197,12 +197,12 @@ var (
 				require.Len(t, logsData, 0)
 			},
 		},
-		"mint with extra padded bytes should fail pre-DUpgrade": {
+		"mint with extra padded bytes should fail pre-Durango": {
 			Caller:     allowlist.TestEnabledAddr,
 			BeforeHook: allowlist.SetDefaultRoles(Module.Address),
 			ChainConfigFn: func(ctrl *gomock.Controller) precompileconfig.ChainConfig {
 				config := precompileconfig.NewMockChainConfig(ctrl)
-				config.EXPECT().IsDUpgrade(gomock.Any()).Return(false).AnyTimes()
+				config.EXPECT().IsDurango(gomock.Any()).Return(false).AnyTimes()
 				return config
 			},
 			InputFn: func(t testing.TB) []byte {
@@ -218,12 +218,12 @@ var (
 			ReadOnly:    false,
 			ExpectedErr: ErrInvalidLen.Error(),
 		},
-		"mint with extra padded bytes should succeed with DUpgrade": {
+		"mint with extra padded bytes should succeed with Durango": {
 			Caller:     allowlist.TestEnabledAddr,
 			BeforeHook: allowlist.SetDefaultRoles(Module.Address),
 			ChainConfigFn: func(ctrl *gomock.Controller) precompileconfig.ChainConfig {
 				config := precompileconfig.NewMockChainConfig(ctrl)
-				config.EXPECT().IsDUpgrade(gomock.Any()).Return(true).AnyTimes()
+				config.EXPECT().IsDurango(gomock.Any()).Return(true).AnyTimes()
 				return config
 			},
 			InputFn: func(t testing.TB) []byte {

--- a/precompile/contracts/rewardmanager/contract.go
+++ b/precompile/contracts/rewardmanager/contract.go
@@ -97,7 +97,7 @@ func allowFeeRecipients(accessibleState contract.AccessibleState, caller common.
 	}
 	// allow list code ends here.
 
-	if contract.IsDUpgradeActivated(accessibleState) {
+	if contract.IsDurangoActivated(accessibleState) {
 		if remainingGas, err = contract.DeductGas(remainingGas, FeeRecipientsAllowedEventGasCost); err != nil {
 			return nil, 0, err
 		}
@@ -200,8 +200,8 @@ func setRewardAddress(accessibleState contract.AccessibleState, caller common.Ad
 	}
 	// attempts to unpack [input] into the arguments to the SetRewardAddressInput.
 	// Assumes that [input] does not include selector
-	// do not use strict mode after DUpgrade
-	useStrictMode := !contract.IsDUpgradeActivated(accessibleState)
+	// do not use strict mode after Durango
+	useStrictMode := !contract.IsDurangoActivated(accessibleState)
 	rewardAddress, err := UnpackSetRewardAddressInput(input, useStrictMode)
 	if err != nil {
 		return nil, remainingGas, err
@@ -224,7 +224,7 @@ func setRewardAddress(accessibleState contract.AccessibleState, caller common.Ad
 	}
 
 	// Add a log to be handled if this action is finalized.
-	if contract.IsDUpgradeActivated(accessibleState) {
+	if contract.IsDurangoActivated(accessibleState) {
 		if remainingGas, err = contract.DeductGas(remainingGas, RewardAddressChangedEventGasCost); err != nil {
 			return nil, 0, err
 		}
@@ -288,7 +288,7 @@ func disableRewards(accessibleState contract.AccessibleState, caller common.Addr
 	}
 	// allow list code ends here.
 
-	if contract.IsDUpgradeActivated(accessibleState) {
+	if contract.IsDurangoActivated(accessibleState) {
 		if remainingGas, err = contract.DeductGas(remainingGas, RewardsDisabledEventGasCost); err != nil {
 			return nil, 0, err
 		}

--- a/precompile/contracts/rewardmanager/contract_test.go
+++ b/precompile/contracts/rewardmanager/contract_test.go
@@ -82,7 +82,7 @@ var (
 				assertFeeRecipientsAllowed(t, logsTopics, logsData, allowlist.TestEnabledAddr)
 			},
 		},
-		"set fee recipients should not emit events pre-DUpgrade": {
+		"set fee recipients should not emit events pre-Durango": {
 			Caller:     allowlist.TestEnabledAddr,
 			BeforeHook: allowlist.SetDefaultRoles(Module.Address),
 			InputFn: func(t testing.TB) []byte {
@@ -95,7 +95,7 @@ var (
 				mockChainConfig := precompileconfig.NewMockChainConfig(ctrl)
 				mockChainConfig.EXPECT().GetFeeConfig().AnyTimes().Return(commontype.ValidTestFeeConfig)
 				mockChainConfig.EXPECT().AllowedFeeRecipients().AnyTimes().Return(false)
-				mockChainConfig.EXPECT().IsDUpgrade(gomock.Any()).AnyTimes().Return(false)
+				mockChainConfig.EXPECT().IsDurango(gomock.Any()).AnyTimes().Return(false)
 				return mockChainConfig
 			},
 			SuppliedGas: AllowFeeRecipientsGasCost,
@@ -170,7 +170,7 @@ var (
 				assertRewardAddressChanged(t, logsTopics, logsData, allowlist.TestManagerAddr, common.Address{}, rewardAddress)
 			},
 		},
-		"change reward address should not emit events pre-DUpgrade": {
+		"change reward address should not emit events pre-Durango": {
 			Caller:     allowlist.TestManagerAddr,
 			BeforeHook: allowlist.SetDefaultRoles(Module.Address),
 			InputFn: func(t testing.TB) []byte {
@@ -183,7 +183,7 @@ var (
 				mockChainConfig := precompileconfig.NewMockChainConfig(ctrl)
 				mockChainConfig.EXPECT().GetFeeConfig().AnyTimes().Return(commontype.ValidTestFeeConfig)
 				mockChainConfig.EXPECT().AllowedFeeRecipients().AnyTimes().Return(false)
-				mockChainConfig.EXPECT().IsDUpgrade(gomock.Any()).AnyTimes().Return(false)
+				mockChainConfig.EXPECT().IsDurango(gomock.Any()).AnyTimes().Return(false)
 				return mockChainConfig
 			},
 			SuppliedGas: SetRewardAddressGasCost,
@@ -238,7 +238,7 @@ var (
 				assertRewardsDisabled(t, logsTopics, logsData, allowlist.TestEnabledAddr)
 			},
 		},
-		"disable rewards should not emit event pre-DUpgrade": {
+		"disable rewards should not emit event pre-Durango": {
 			Caller:     allowlist.TestManagerAddr,
 			BeforeHook: allowlist.SetDefaultRoles(Module.Address),
 			InputFn: func(t testing.TB) []byte {
@@ -251,7 +251,7 @@ var (
 				mockChainConfig := precompileconfig.NewMockChainConfig(ctrl)
 				mockChainConfig.EXPECT().GetFeeConfig().AnyTimes().Return(commontype.ValidTestFeeConfig)
 				mockChainConfig.EXPECT().AllowedFeeRecipients().AnyTimes().Return(false)
-				mockChainConfig.EXPECT().IsDUpgrade(gomock.Any()).AnyTimes().Return(false)
+				mockChainConfig.EXPECT().IsDurango(gomock.Any()).AnyTimes().Return(false)
 				return mockChainConfig
 			},
 			SuppliedGas: SetRewardAddressGasCost,

--- a/precompile/precompileconfig/config.go
+++ b/precompile/precompileconfig/config.go
@@ -86,6 +86,6 @@ type ChainConfig interface {
 	GetFeeConfig() commontype.FeeConfig
 	// AllowedFeeRecipients returns true if fee recipients are allowed in the genesis.
 	AllowedFeeRecipients() bool
-	// IsDurango returns true if the time is after the Durango.
+	// IsDurango returns true if the time is after Durango.
 	IsDurango(time uint64) bool
 }

--- a/precompile/precompileconfig/config.go
+++ b/precompile/precompileconfig/config.go
@@ -86,6 +86,6 @@ type ChainConfig interface {
 	GetFeeConfig() commontype.FeeConfig
 	// AllowedFeeRecipients returns true if fee recipients are allowed in the genesis.
 	AllowedFeeRecipients() bool
-	// IsDUpgrade returns true if the time is after the DUpgrade.
-	IsDUpgrade(time uint64) bool
+	// IsDurango returns true if the time is after the Durango.
+	IsDurango(time uint64) bool
 }

--- a/precompile/precompileconfig/mocks.go
+++ b/precompile/precompileconfig/mocks.go
@@ -208,18 +208,18 @@ func (mr *MockChainConfigMockRecorder) GetFeeConfig() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFeeConfig", reflect.TypeOf((*MockChainConfig)(nil).GetFeeConfig))
 }
 
-// IsDUpgrade mocks base method.
-func (m *MockChainConfig) IsDUpgrade(arg0 uint64) bool {
+// IsDurango mocks base method.
+func (m *MockChainConfig) IsDurango(arg0 uint64) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsDUpgrade", arg0)
+	ret := m.ctrl.Call(m, "IsDurango", arg0)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
-// IsDUpgrade indicates an expected call of IsDUpgrade.
-func (mr *MockChainConfigMockRecorder) IsDUpgrade(arg0 interface{}) *gomock.Call {
+// IsDurango indicates an expected call of IsDurango.
+func (mr *MockChainConfigMockRecorder) IsDurango(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsDUpgrade", reflect.TypeOf((*MockChainConfig)(nil).IsDUpgrade), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsDurango", reflect.TypeOf((*MockChainConfig)(nil).IsDurango), arg0)
 }
 
 // MockAccepter is a mock of Accepter interface.

--- a/precompile/testutils/test_config.go
+++ b/precompile/testutils/test_config.go
@@ -38,7 +38,7 @@ func RunVerifyTests(t *testing.T, tests map[string]ConfigVerifyTest) {
 				mockChainConfig := precompileconfig.NewMockChainConfig(ctrl)
 				mockChainConfig.EXPECT().GetFeeConfig().AnyTimes().Return(commontype.ValidTestFeeConfig)
 				mockChainConfig.EXPECT().AllowedFeeRecipients().AnyTimes().Return(false)
-				mockChainConfig.EXPECT().IsDUpgrade(gomock.Any()).AnyTimes().Return(true)
+				mockChainConfig.EXPECT().IsDurango(gomock.Any()).AnyTimes().Return(true)
 				chainConfig = mockChainConfig
 			}
 			err := test.Config.Verify(chainConfig)

--- a/precompile/testutils/test_precompile.go
+++ b/precompile/testutils/test_precompile.go
@@ -95,7 +95,7 @@ func (test PrecompileTest) setup(t testing.TB, module modules.Module, state cont
 			mockChainConfig := precompileconfig.NewMockChainConfig(ctrl)
 			mockChainConfig.EXPECT().GetFeeConfig().AnyTimes().Return(commontype.ValidTestFeeConfig)
 			mockChainConfig.EXPECT().AllowedFeeRecipients().AnyTimes().Return(false)
-			mockChainConfig.EXPECT().IsDUpgrade(gomock.Any()).AnyTimes().Return(true)
+			mockChainConfig.EXPECT().IsDurango(gomock.Any()).AnyTimes().Return(true)
 			return mockChainConfig
 		}
 	}

--- a/predicate/predicate_bytes.go
+++ b/predicate/predicate_bytes.go
@@ -54,8 +54,8 @@ func UnpackPredicate(paddedPredicate []byte) ([]byte, error) {
 // GetPredicateResultBytes returns the predicate result bytes from the extra data and
 // true iff the predicate results bytes have non-zero length.
 func GetPredicateResultBytes(extraData []byte) ([]byte, bool) {
-	// Prior to the Durango, the VM enforces the extra data is smaller than or equal to this size.
-	// After the Durango, the VM pre-verifies the extra data past the dynamic fee rollup window is
+	// Prior to Durango, the VM enforces the extra data is smaller than or equal to this size.
+	// After Durango, the VM pre-verifies the extra data past the dynamic fee rollup window is
 	// valid.
 	if len(extraData) <= params.DynamicFeeExtraDataSize {
 		return nil, false

--- a/predicate/predicate_bytes.go
+++ b/predicate/predicate_bytes.go
@@ -54,8 +54,8 @@ func UnpackPredicate(paddedPredicate []byte) ([]byte, error) {
 // GetPredicateResultBytes returns the predicate result bytes from the extra data and
 // true iff the predicate results bytes have non-zero length.
 func GetPredicateResultBytes(extraData []byte) ([]byte, bool) {
-	// Prior to the DUpgrade, the VM enforces the extra data is smaller than or equal to this size.
-	// After the DUpgrade, the VM pre-verifies the extra data past the dynamic fee rollup window is
+	// Prior to the Durango, the VM enforces the extra data is smaller than or equal to this size.
+	// After the Durango, the VM pre-verifies the extra data past the dynamic fee rollup window is
 	// valid.
 	if len(extraData) <= params.DynamicFeeExtraDataSize {
 		return nil, false

--- a/predicate/predicate_bytes_test.go
+++ b/predicate/predicate_bytes_test.go
@@ -56,11 +56,11 @@ func TestPredicateResultsBytes(t *testing.T) {
 	_, ok := GetPredicateResultBytes(dataTooShort)
 	require.False(ok)
 
-	preDUPgradeData := utils.RandomBytes(params.DynamicFeeExtraDataSize)
-	_, ok = GetPredicateResultBytes(preDUPgradeData)
+	preDurangoData := utils.RandomBytes(params.DynamicFeeExtraDataSize)
+	_, ok = GetPredicateResultBytes(preDurangoData)
 	require.False(ok)
-	postDUpgradeData := utils.RandomBytes(params.DynamicFeeExtraDataSize + 2)
-	resultBytes, ok := GetPredicateResultBytes(postDUpgradeData)
+	postDurangoData := utils.RandomBytes(params.DynamicFeeExtraDataSize + 2)
+	resultBytes, ok := GetPredicateResultBytes(postDurangoData)
 	require.True(ok)
-	require.Equal(resultBytes, postDUpgradeData[params.DynamicFeeExtraDataSize:])
+	require.Equal(resultBytes, postDurangoData[params.DynamicFeeExtraDataSize:])
 }

--- a/tests/init.go
+++ b/tests/init.go
@@ -180,7 +180,7 @@ var Forks = map[string]*params.ChainConfig{
 			SubnetEVMTimestamp: utils.NewUint64(0),
 		},
 	},
-	"DUpgrade": {
+	"Durango": {
 		ChainID:             big.NewInt(1),
 		HomesteadBlock:      big.NewInt(0),
 		EIP150Block:         big.NewInt(0),
@@ -192,7 +192,7 @@ var Forks = map[string]*params.ChainConfig{
 		IstanbulBlock:       big.NewInt(0),
 		MandatoryNetworkUpgrades: params.MandatoryNetworkUpgrades{
 			SubnetEVMTimestamp: utils.NewUint64(0),
-			DUpgradeTimestamp:  utils.NewUint64(0),
+			DurangoTimestamp:   utils.NewUint64(0),
 		},
 	},
 }

--- a/x/warp/config.go
+++ b/x/warp/config.go
@@ -78,7 +78,7 @@ func (*Config) Key() string { return ConfigKey }
 // Verify tries to verify Config and returns an error accordingly.
 func (c *Config) Verify(chainConfig precompileconfig.ChainConfig) error {
 	if c.Timestamp() != nil {
-		// If Warp attempts to activate before the Durango, fail verification
+		// If Warp attempts to activate before Durango, fail verification
 		timestamp := *c.Timestamp()
 		if !chainConfig.IsDurango(timestamp) {
 			return errWarpCannotBeActivated

--- a/x/warp/config.go
+++ b/x/warp/config.go
@@ -34,7 +34,7 @@ var (
 	errInvalidAddressedPayload = errors.New("cannot unpack addressed payload")
 	errInvalidBlockHashPayload = errors.New("cannot unpack block hash payload")
 	errCannotGetNumSigners     = errors.New("cannot fetch num signers from warp message")
-	errWarpCannotBeActivated   = errors.New("warp cannot be activated before DUpgrade")
+	errWarpCannotBeActivated   = errors.New("warp cannot be activated before Durango")
 	errFailedVerification      = errors.New("cannot verify warp signature")
 )
 
@@ -78,9 +78,9 @@ func (*Config) Key() string { return ConfigKey }
 // Verify tries to verify Config and returns an error accordingly.
 func (c *Config) Verify(chainConfig precompileconfig.ChainConfig) error {
 	if c.Timestamp() != nil {
-		// If Warp attempts to activate before the DUpgrade, fail verification
+		// If Warp attempts to activate before the Durango, fail verification
 		timestamp := *c.Timestamp()
-		if !chainConfig.IsDUpgrade(timestamp) {
+		if !chainConfig.IsDurango(timestamp) {
 			return errWarpCannotBeActivated
 		}
 	}

--- a/x/warp/config_test.go
+++ b/x/warp/config_test.go
@@ -33,11 +33,11 @@ func TestVerify(t *testing.T) {
 		"valid quorum numerator 1 more than minimum": {
 			Config: NewConfig(utils.NewUint64(3), params.WarpQuorumNumeratorMinimum+1),
 		},
-		"invalid cannot activated before DUpgrade activation": {
+		"invalid cannot activated before Durango activation": {
 			Config: NewConfig(utils.NewUint64(3), 0),
 			ChainConfig: func() precompileconfig.ChainConfig {
 				config := precompileconfig.NewMockChainConfig(gomock.NewController(t))
-				config.EXPECT().IsDUpgrade(gomock.Any()).Return(false)
+				config.EXPECT().IsDurango(gomock.Any()).Return(false)
 				return config
 			}(),
 			ExpectedError: errWarpCannotBeActivated.Error(),

--- a/x/warp/contract.go
+++ b/x/warp/contract.go
@@ -109,8 +109,8 @@ func getBlockchainID(accessibleState contract.AccessibleState, caller common.Add
 // UnpackGetVerifiedWarpBlockHashInput attempts to unpack [input] into the uint32 type argument
 // assumes that [input] does not include selector (omits first 4 func signature bytes)
 func UnpackGetVerifiedWarpBlockHashInput(input []byte) (uint32, error) {
-	// We don't use strict mode here because it was disabled with the DUpgrade.
-	// Since Warp will be deployed after the DUpgrade, we don't need to use strict mode
+	// We don't use strict mode here because it was disabled with the Durango.
+	// Since Warp will be deployed after the Durango, we don't need to use strict mode
 	res, err := WarpABI.UnpackInput("getVerifiedWarpBlockHash", input, false)
 	if err != nil {
 		return 0, err
@@ -151,8 +151,8 @@ func getVerifiedWarpBlockHash(accessibleState contract.AccessibleState, caller c
 // UnpackGetVerifiedWarpMessageInput attempts to unpack [input] into the uint32 type argument
 // assumes that [input] does not include selector (omits first 4 func signature bytes)
 func UnpackGetVerifiedWarpMessageInput(input []byte) (uint32, error) {
-	// We don't use strict mode here because it was disabled with the DUpgrade.
-	// Since Warp will be deployed after the DUpgrade, we don't need to use strict mode.
+	// We don't use strict mode here because it was disabled with the Durango.
+	// Since Warp will be deployed after the Durango, we don't need to use strict mode.
 	res, err := WarpABI.UnpackInput("getVerifiedWarpMessage", input, false)
 	if err != nil {
 		return 0, err
@@ -195,8 +195,8 @@ func getVerifiedWarpMessage(accessibleState contract.AccessibleState, caller com
 // UnpackSendWarpMessageInput attempts to unpack [input] as []byte
 // assumes that [input] does not include selector (omits first 4 func signature bytes)
 func UnpackSendWarpMessageInput(input []byte) ([]byte, error) {
-	// We don't use strict mode here because it was disabled with the DUpgrade.
-	// Since Warp will be deployed after the DUpgrade, we don't need to use strict mode.
+	// We don't use strict mode here because it was disabled with the Durango.
+	// Since Warp will be deployed after the Durango, we don't need to use strict mode.
 	res, err := WarpABI.UnpackInput("sendWarpMessage", input, false)
 	if err != nil {
 		return []byte{}, err

--- a/x/warp/contract.go
+++ b/x/warp/contract.go
@@ -109,8 +109,8 @@ func getBlockchainID(accessibleState contract.AccessibleState, caller common.Add
 // UnpackGetVerifiedWarpBlockHashInput attempts to unpack [input] into the uint32 type argument
 // assumes that [input] does not include selector (omits first 4 func signature bytes)
 func UnpackGetVerifiedWarpBlockHashInput(input []byte) (uint32, error) {
-	// We don't use strict mode here because it was disabled with the Durango.
-	// Since Warp will be deployed after the Durango, we don't need to use strict mode
+	// We don't use strict mode here because it was disabled with Durango.
+	// Since Warp will be deployed after Durango, we don't need to use strict mode
 	res, err := WarpABI.UnpackInput("getVerifiedWarpBlockHash", input, false)
 	if err != nil {
 		return 0, err

--- a/x/warp/contract.go
+++ b/x/warp/contract.go
@@ -195,8 +195,8 @@ func getVerifiedWarpMessage(accessibleState contract.AccessibleState, caller com
 // UnpackSendWarpMessageInput attempts to unpack [input] as []byte
 // assumes that [input] does not include selector (omits first 4 func signature bytes)
 func UnpackSendWarpMessageInput(input []byte) ([]byte, error) {
-	// We don't use strict mode here because it was disabled with the Durango.
-	// Since Warp will be deployed after the Durango, we don't need to use strict mode.
+	// We don't use strict mode here because it was disabled with Durango.
+	// Since Warp will be deployed after Durango, we don't need to use strict mode.
 	res, err := WarpABI.UnpackInput("sendWarpMessage", input, false)
 	if err != nil {
 		return []byte{}, err

--- a/x/warp/contract.go
+++ b/x/warp/contract.go
@@ -151,8 +151,8 @@ func getVerifiedWarpBlockHash(accessibleState contract.AccessibleState, caller c
 // UnpackGetVerifiedWarpMessageInput attempts to unpack [input] into the uint32 type argument
 // assumes that [input] does not include selector (omits first 4 func signature bytes)
 func UnpackGetVerifiedWarpMessageInput(input []byte) (uint32, error) {
-	// We don't use strict mode here because it was disabled with the Durango.
-	// Since Warp will be deployed after the Durango, we don't need to use strict mode.
+	// We don't use strict mode here because it was disabled with Durango.
+	// Since Warp will be deployed after Durango, we don't need to use strict mode.
 	res, err := WarpABI.UnpackInput("getVerifiedWarpMessage", input, false)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
## Why this should be merged

Renames temporary DUpgrade to Durango

## How this was tested

UTs should cover this

## How is this documented

No needed
