### PR TITLE
bump min go version

### DIFF
--- a/.github/workflows/auto-generated-code-checker.yml
+++ b/.github/workflows/auto-generated-code-checker.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '~1.20.10'
+          go-version: '~1.20.12'
           check-latest: true
       - shell: bash
         run: scripts/mock.gen.sh

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '~1.20.10'
+          go-version: '~1.20.12'
           check-latest: true
       - run: go mod download
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,12 @@ jobs:
         shell: bash
       - uses: actions/setup-go@v3
         with:
-          go-version: '~1.20.10'
+          go-version: '~1.20.12'
           check-latest: true
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.54
+          version: v1.55
           working-directory: .
           args: --timeout 10m
 
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '~1.20.10'
+          go-version: '~1.20.12'
           check-latest: true
       - run: go mod download
         shell: bash
@@ -66,7 +66,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '~1.20.10'
+          go-version: '~1.20.12'
           check-latest: true
       - name: Use Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.55
+          version: v1.54
           working-directory: .
           args: --timeout 10m
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '~1.20.10'
+          go-version: '~1.20.12'
           check-latest: true
       - name: Set up arm64 cross compiler
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 ARG AVALANCHE_VERSION
 
 # ============= Compilation Stage ================
-FROM golang:1.20.10-bullseye AS builder
+FROM golang:1.20.12-bullseye AS builder
 
 WORKDIR /build
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ To support these changes, there have been a number of changes to the SubnetEVM b
 
 ### Clone Subnet-evm
 
-First install Go 1.20.10 or later. Follow the instructions [here](https://go.dev/doc/install). You can verify by running `go version`.
+First install Go 1.20.12 or later. Follow the instructions [here](https://go.dev/doc/install). You can verify by running `go version`.
 
 Set `$GOPATH` environment variable properly for Go to look for Go Workspaces. Please read [this](https://go.dev/doc/code) for details. You can verify by running `echo $GOPATH`.
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,7 +4,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-go_version_minimum="1.20.10"
+go_version_minimum="1.20.12"
 
 go_version() {
     go version | sed -nE -e 's/[^0-9.]+([0-9.]+).+/\1/p'


### PR DESCRIPTION
## Why this should be merged

Bumps minimum go version to 1.20.12 (same with avalanchego)

## How this works

Replaces 1.20.11 > 1.20.12
bumps golangci version

## How this was tested

UTs should cover this

## How is this documented

Changed readme
