### PR TITLE
feat(plugin/evm): make tx pool lifetime configurable

### DIFF
--- a/plugin/evm/config.go
+++ b/plugin/evm/config.go
@@ -139,6 +139,7 @@ type Config struct {
 	TxPoolGlobalSlots  uint64   `json:"tx-pool-global-slots"`
 	TxPoolAccountQueue uint64   `json:"tx-pool-account-queue"`
 	TxPoolGlobalQueue  uint64   `json:"tx-pool-global-queue"`
+	TxPoolLifetime     Duration `json:"tx-pool-lifetime"`
 
 	APIMaxDuration           Duration      `json:"api-max-duration"`
 	WSCPURefillRate          Duration      `json:"ws-cpu-refill-rate"`
@@ -240,6 +241,7 @@ func (c *Config) SetDefaults() {
 	c.TxPoolGlobalSlots = txpool.DefaultConfig.GlobalSlots
 	c.TxPoolAccountQueue = txpool.DefaultConfig.AccountQueue
 	c.TxPoolGlobalQueue = txpool.DefaultConfig.GlobalQueue
+	c.TxPoolLifetime = Duration{txpool.DefaultConfig.Lifetime}
 
 	c.APIMaxDuration.Duration = defaultApiMaxDuration
 	c.WSCPURefillRate.Duration = defaultWsCpuRefillRate

--- a/plugin/evm/config_test.go
+++ b/plugin/evm/config_test.go
@@ -39,6 +39,18 @@ func TestUnmarshalConfig(t *testing.T) {
 			false,
 		},
 		{
+			"nanosecond durations parsed for tx pool lifetime for minutes",
+			[]byte(`{"tx-pool-lifetime": 1800000000000}`),
+			Config{TxPoolLifetime: Duration{30 * time.Minute}},
+			false,
+		},
+		{
+			"nanosecond durations parsed for tx pool lifetime",
+			[]byte(`{"api-max-duration": 5000000000,"tx-pool-lifetime": 7000000000}`),
+			Config{APIMaxDuration: Duration{5 * time.Second}, TxPoolLifetime: Duration{7 * time.Second}},
+			false,
+		},
+		{
 			"bad durations",
 			[]byte(`{"api-max-duration": "bad-duration"}`),
 			Config{},

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -397,6 +397,7 @@ func (vm *VM) Initialize(
 	vm.ethConfig.TxPool.GlobalSlots = vm.config.TxPoolGlobalSlots
 	vm.ethConfig.TxPool.AccountQueue = vm.config.TxPoolAccountQueue
 	vm.ethConfig.TxPool.GlobalQueue = vm.config.TxPoolGlobalQueue
+	vm.ethConfig.TxPool.Lifetime = vm.config.TxPoolLifetime.Duration
 
 	vm.ethConfig.AllowUnfinalizedQueries = vm.config.AllowUnfinalizedQueries
 	vm.ethConfig.AllowUnprotectedTxs = vm.config.AllowUnprotectedTxs


### PR DESCRIPTION
## Why this should be merged

Currently, tx-pool lifetime is hard-coded to 3-hour and not configurable.

## How this works

Make it configurable via flag `tx-pool-lifetime`.

## How this was tested

Local.

## How is this documented

Flag.