### PR TITLE
Fix bloom reset

### DIFF
--- a/plugin/evm/gossip.go
+++ b/plugin/evm/gossip.go
@@ -129,7 +129,7 @@ func (g *GossipEthTxPool) Subscribe(ctx context.Context) {
 					log.Debug("resetting bloom filter", "reason", "reached max filled ratio")
 
 					g.mempool.IteratePending(func(tx *types.Transaction) bool {
-						g.bloom.Add(&GossipEthTx{Tx: pendingTx})
+						g.bloom.Add(&GossipEthTx{Tx: tx})
 						return true
 					})
 				}

--- a/plugin/evm/gossip_test.go
+++ b/plugin/evm/gossip_test.go
@@ -94,7 +94,9 @@ func setupPoolWithConfig(t *testing.T, config *params.ChainConfig, fundedAddress
 	}
 	chain, err := core.NewBlockChain(diskdb, core.DefaultCacheConfig, gspec, engine, vm.Config{}, common.Hash{}, false)
 	require.NoError(t, err)
-	pool := txpool.NewTxPool(txpool.DefaultConfig, config, chain)
+	testTxPoolConfig := txpool.DefaultConfig
+	testTxPoolConfig.Journal = ""
+	pool := txpool.NewTxPool(testTxPoolConfig, config, chain)
 
 	return pool
 }

--- a/plugin/evm/gossip_test.go
+++ b/plugin/evm/gossip_test.go
@@ -68,7 +68,7 @@ func TestGossipSubscribe(t *testing.T) {
 	for _, err := range errs {
 		require.NoError(err, "failed adding subnet-evm tx to remote mempool")
 	}
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(1 * time.Second)
 	cancel()
 	for i, tx := range ethTxs {
 		gossipable := &GossipEthTx{Tx: tx}

--- a/plugin/evm/gossip_test.go
+++ b/plugin/evm/gossip_test.go
@@ -60,19 +60,11 @@ func TestGossipSubscribe(t *testing.T) {
 		gossipTxPool.Subscribe(ctx)
 	}()
 
-	// create first eth txes
+	// create eth txs
 	ethTxs := getValidEthTxs(key, 10, big.NewInt(226*params.GWei))
 
-	// Notify VM about first eth txs batch
-	batch1 := ethTxs[:5]
-	errs := txPool.AddRemotesSync(batch1)
-	for _, err := range errs {
-		require.NoError(err, "failed adding subnet-evm tx to remote mempool")
-	}
-
-	// Notify VM about second eth txs batch
-	batch2 := ethTxs[5:]
-	errs = txPool.AddRemotesSync(batch2)
+	// Notify mempool about txs
+	errs := txPool.AddRemotesSync(ethTxs)
 	for _, err := range errs {
 		require.NoError(err, "failed adding subnet-evm tx to remote mempool")
 	}

--- a/plugin/evm/gossip_test.go
+++ b/plugin/evm/gossip_test.go
@@ -4,9 +4,21 @@
 package evm
 
 import (
+	"context"
+	"math/big"
 	"testing"
+	"time"
 
+	"github.com/ava-labs/avalanchego/network/p2p/gossip"
+	"github.com/ava-labs/subnet-evm/consensus/dummy"
+	"github.com/ava-labs/subnet-evm/core"
+	"github.com/ava-labs/subnet-evm/core/rawdb"
+	"github.com/ava-labs/subnet-evm/core/txpool"
 	"github.com/ava-labs/subnet-evm/core/types"
+	"github.com/ava-labs/subnet-evm/core/vm"
+	"github.com/ava-labs/subnet-evm/params"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,4 +35,66 @@ func TestGossipEthTxMarshaller(t *testing.T) {
 	got, err := marshaller.UnmarshalGossip(bytes)
 	require.NoError(err)
 	require.Equal(want.GossipID(), got.GossipID())
+}
+
+func TestGossipSubscribe(t *testing.T) {
+	require := require.New(t)
+	key, err := crypto.GenerateKey()
+	require.NoError(err)
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+
+	require.NoError(err)
+	txPool := setupPoolWithConfig(t, params.TestChainConfig, addr)
+	defer txPool.Stop()
+	txPool.SetGasPrice(common.Big1)
+	txPool.SetMinFee(common.Big0)
+
+	gossipTxPool, err := NewGossipEthTxPool(txPool)
+	require.NoError(err)
+
+	// use a custom bloom filter to test the bloom filter reset
+	gossipTxPool.bloom, err = gossip.NewBloomFilter(1, 0.01, 0.0000000000000001) // maxCount =1
+	require.NoError(err)
+	ctx, cancel := context.WithCancel(context.TODO())
+	go func() {
+		gossipTxPool.Subscribe(ctx)
+	}()
+
+	// create first eth txes
+	ethTxs := getValidEthTxs(key, 10, big.NewInt(226*params.GWei))
+
+	// Notify VM about first eth txs batch
+	batch1 := ethTxs[:5]
+	errs := txPool.AddRemotesSync(batch1)
+	for _, err := range errs {
+		require.NoError(err, "failed adding subnet-evm tx to remote mempool")
+	}
+
+	// Notify VM about second eth txs batch
+	batch2 := ethTxs[5:]
+	errs = txPool.AddRemotesSync(batch2)
+	for _, err := range errs {
+		require.NoError(err, "failed adding subnet-evm tx to remote mempool")
+	}
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	for i, tx := range ethTxs {
+		gossipable := &GossipEthTx{Tx: tx}
+		require.Truef(gossipTxPool.bloom.Has(gossipable), "expected tx to be in bloom filter: index %d", i)
+	}
+}
+
+func setupPoolWithConfig(t *testing.T, config *params.ChainConfig, fundedAddress common.Address) *txpool.TxPool {
+	diskdb := rawdb.NewMemoryDatabase()
+	engine := dummy.NewETHFaker()
+
+	var gspec = &core.Genesis{
+		Config: config,
+		Alloc:  core.GenesisAlloc{fundedAddress: core.GenesisAccount{Balance: big.NewInt(1000000000000000000)}},
+	}
+	chain, err := core.NewBlockChain(diskdb, core.DefaultCacheConfig, gspec, engine, vm.Config{}, common.Hash{}, false)
+	require.NoError(t, err)
+	pool := txpool.NewTxPool(txpool.DefaultConfig, config, chain)
+
+	return pool
 }

--- a/plugin/evm/gossipper_test.go
+++ b/plugin/evm/gossipper_test.go
@@ -53,8 +53,8 @@ func getValidEthTxs(key *ecdsa.PrivateKey, count int, gasPrice *big.Int) []*type
 	res := make([]*types.Transaction, count)
 
 	to := common.Address{}
-	amount := big.NewInt(10000)
-	gasLimit := uint64(100000)
+	amount := big.NewInt(0)
+	gasLimit := uint64(37000)
 
 	for i := 0; i < count; i++ {
 		tx, _ := types.SignTx(


### PR DESCRIPTION
## Why this should be merged

There is a bug that prevents pending txs to be added to bloom filter after reset.

## How this works

Change variables from pendingTxs to iterated txs 

## How this was tested

Added UT

## How is this documented

No need
