### PR TITLE
bind_test: remove auth.GasFeeCap

### DIFF
--- a/accounts/abi/bind/bind_test.go
+++ b/accounts/abi/bind/bind_test.go
@@ -1443,13 +1443,11 @@ var bindTests = []struct {
 		"github.com/ava-labs/subnet-evm/accounts/abi/bind/backends"
 		"github.com/ava-labs/subnet-evm/core"
 		"github.com/ethereum/go-ethereum/crypto"
-		"github.com/ava-labs/subnet-evm/params"
 		`,
 		`
 		// Initialize test accounts
 		key, _ := crypto.GenerateKey()
 		auth, _ := bind.NewKeyedTransactorWithChainID(key, big.NewInt(1337))
-		auth.GasFeeCap = new(big.Int).SetInt64(params.TestMaxBaseFee)
 		sim := backends.NewSimulatedBackend(core.GenesisAlloc{auth.From: {Balance: new(big.Int).Mul(big.NewInt(10000000000000000), big.NewInt(1000))}}, 10000000)
 		defer sim.Close()
 


### PR DESCRIPTION
## Why this should be merged
Does not seem this is necessary for the tests to pass, since this is both different in coreth and is not present in upstream, I suggest we remove it.

## How this works
Removes setting auth.GasFeeCap

## How this was tested
CI + running test several times locally
