### PR TITLE
Use typed error when reverting in EthereumAPI

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1099,9 +1099,9 @@ func DoCall(ctx context.Context, b Backend, args TransactionArgs, blockNrOrHash 
 
 func newRevertError(result *core.ExecutionResult) *revertError {
 	reason, errUnpack := abi.UnpackRevert(result.Revert())
-	err := errors.New("execution reverted")
+	err := vmerrs.ErrExecutionReverted
 	if errUnpack == nil {
-		err = fmt.Errorf("execution reverted: %v", reason)
+		err = fmt.Errorf("%w: %v", err, reason)
 	}
 	return &revertError{
 		error:  err,


### PR DESCRIPTION
## Why this should be merged
When calling a contract via the `EthereumAPI`, there's no type-safe way to check if an error is due to a revert or something else. The client could of course check for the string "execution reverted", but that runs the risk of becoming mismatched. The proposed change uses an error var that's defined once, eliminating that risk.

## How this works
Uses the existing error `vmerrs.ErrExecutionReverted` so that the client can use `errors.Is` on the returned value. The returned error string is unchanged.

See https://go.dev/play/p/XuGfk6VdmJ5 for an example. I can also add a unit test.

## How this was tested
CI, above Go playground testing

## How is this documented
N/A
