### PR TITLE
Bump avalanchego to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/VictoriaMetrics/fastcache v1.10.0
 	github.com/ava-labs/avalanche-network-runner v1.7.4-rc.0
-	github.com/ava-labs/avalanchego v1.10.19-legacy-upgrade-times
+	github.com/ava-labs/avalanchego v1.11.0-rc.1
 	github.com/cespare/cp v0.1.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckarep/golang-set/v2 v2.1.0
@@ -54,7 +54,7 @@ require (
 	github.com/DataDog/zstd v1.5.2 // indirect
 	github.com/Microsoft/go-winio v0.5.2 // indirect
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
-	github.com/ava-labs/coreth v0.12.10-wip-bloom-metrics // indirect
+	github.com/ava-labs/coreth v0.12.11-rc.2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.7.0 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -61,10 +61,10 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/ava-labs/avalanche-network-runner v1.7.4-rc.0 h1:xNbCMNqenaDr0bb35j27sqwa+C8t8BgRz51vXd6q0QM=
 github.com/ava-labs/avalanche-network-runner v1.7.4-rc.0/go.mod h1:B7Ynk/avkCk49CCIWbM4j1UrPlqIi0IHCPAB2MZNvLw=
-github.com/ava-labs/avalanchego v1.10.19-legacy-upgrade-times h1:VWI/+vOP63QzrHK2HFw+So+qK1f8gKGpFmdvrKFzOM8=
-github.com/ava-labs/avalanchego v1.10.19-legacy-upgrade-times/go.mod h1:bxbOXEYGnwz0K6uPsiB56Ig3pQbBfi4P8NOLtRNhNgw=
-github.com/ava-labs/coreth v0.12.10-wip-bloom-metrics h1:uSISbdHpLVlTkwUUqVonMgdX91ePbgP/qJ7iHup9xS4=
-github.com/ava-labs/coreth v0.12.10-wip-bloom-metrics/go.mod h1:bw3pxnF+IBw5SoxAKujUiZPbPimieJHPd9fQWZZ/MOM=
+github.com/ava-labs/avalanchego v1.11.0-rc.1 h1:nmA2kTh4GPVtDdukonQG0xAXUY0KhdVfJMwEPzw7ICU=
+github.com/ava-labs/avalanchego v1.11.0-rc.1/go.mod h1:1z/GGtH/p70ai+KjSdEudNziiQ5yKIC2XTlcDIkD56w=
+github.com/ava-labs/coreth v0.12.11-rc.2 h1:roDTUOuTLoku4FYr7icHh2IMkxk2GRAqUocGZCXh2Mw=
+github.com/ava-labs/coreth v0.12.11-rc.2/go.mod h1:YEYzy0l/7ig9gKV2P9yxzucnIml1TUa4L8foGQ15KO0=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -4,7 +4,7 @@
 # shellcheck disable=SC2034
 
 # Don't export them as they're used in the context of other calls
-AVALANCHE_VERSION=${AVALANCHE_VERSION:-'v1.10.19-legacy-upgrade-times'}
+AVALANCHE_VERSION=${AVALANCHE_VERSION:-'v1.11.0-rc.1'}
 GINKGO_VERSION=${GINKGO_VERSION:-'v2.2.0'}
 
 # This won't be used, but it's here to make code syncs easier


### PR DESCRIPTION
This PR bumps Subnet-EVM to depend on the latest tag of AvalancheGo