### PR TITLE
eth/filters, eth/api: update rpc numbers in unfinalized query mode

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -911,7 +911,7 @@ func (fb *filterBackend) EventMux() *event.TypeMux { panic("not supported") }
 
 func (fb *filterBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Header, error) {
 	switch number {
-	case rpc.PendingBlockNumber, rpc.AcceptedBlockNumber:
+	case rpc.PendingBlockNumber, rpc.FinalizedBlockNumber:
 		if block := fb.backend.acceptedBlock; block != nil {
 			return block.Header(), nil
 		}

--- a/eth/api.go
+++ b/eth/api.go
@@ -197,7 +197,11 @@ func (api *DebugAPI) DumpBlock(blockNr rpc.BlockNumber) (state.Dump, error) {
 	}
 	var header *types.Header
 	if blockNr.IsAccepted() {
-		header = api.eth.LastAcceptedBlock().Header()
+		if blockNr.IsLatest() && api.eth.APIBackend.IsAllowUnfinalizedQueries() {
+			header = api.eth.blockchain.CurrentHeader()
+		} else {
+			header = api.eth.LastAcceptedBlock().Header()
+		}
 	} else {
 		block := api.eth.blockchain.GetBlockByNumber(uint64(blockNr))
 		if block == nil {
@@ -241,7 +245,11 @@ func (api *DebugAPI) AccountRange(blockNrOrHash rpc.BlockNumberOrHash, start hex
 	if number, ok := blockNrOrHash.Number(); ok {
 		var header *types.Header
 		if number.IsAccepted() {
-			header = api.eth.LastAcceptedBlock().Header()
+			if number.IsLatest() && api.eth.APIBackend.IsAllowUnfinalizedQueries() {
+				header = api.eth.blockchain.CurrentHeader()
+			} else {
+				header = api.eth.LastAcceptedBlock().Header()
+			}
 		} else {
 			block := api.eth.blockchain.GetBlockByNumber(uint64(number))
 			if block == nil {

--- a/eth/api.go
+++ b/eth/api.go
@@ -197,7 +197,7 @@ func (api *DebugAPI) DumpBlock(blockNr rpc.BlockNumber) (state.Dump, error) {
 	}
 	var header *types.Header
 	if blockNr.IsAccepted() {
-		if blockNr.IsLatest() && api.eth.APIBackend.IsAllowUnfinalizedQueries() {
+		if api.eth.APIBackend.isLatestAndAllowed(blockNr) {
 			header = api.eth.blockchain.CurrentHeader()
 		} else {
 			header = api.eth.LastAcceptedBlock().Header()
@@ -245,7 +245,7 @@ func (api *DebugAPI) AccountRange(blockNrOrHash rpc.BlockNumberOrHash, start hex
 	if number, ok := blockNrOrHash.Number(); ok {
 		var header *types.Header
 		if number.IsAccepted() {
-			if number.IsLatest() && api.eth.APIBackend.IsAllowUnfinalizedQueries() {
+			if api.eth.APIBackend.isLatestAndAllowed(number) {
 				header = api.eth.blockchain.CurrentHeader()
 			} else {
 				header = api.eth.LastAcceptedBlock().Header()

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -92,6 +92,9 @@ func (b *EthAPIBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumb
 	// identically.
 	acceptedBlock := b.eth.LastAcceptedBlock()
 	if number.IsAccepted() {
+		if b.IsAllowUnfinalizedQueries() && number.IsLatest() {
+			return b.eth.blockchain.CurrentHeader(), nil
+		}
 		return acceptedBlock.Header(), nil
 	}
 
@@ -156,6 +159,10 @@ func (b *EthAPIBackend) BlockByNumber(ctx context.Context, number rpc.BlockNumbe
 	// identically.
 	acceptedBlock := b.eth.LastAcceptedBlock()
 	if number.IsAccepted() {
+		if b.IsAllowUnfinalizedQueries() && number.IsLatest() {
+			header := b.eth.blockchain.CurrentBlock()
+			return b.eth.blockchain.GetBlock(header.Hash(), header.Number.Uint64()), nil
+		}
 		return acceptedBlock, nil
 	}
 

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -92,7 +92,7 @@ func (b *EthAPIBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumb
 	// identically.
 	acceptedBlock := b.eth.LastAcceptedBlock()
 	if number.IsAccepted() {
-		if b.IsAllowUnfinalizedQueries() && number.IsLatest() {
+		if b.isLatestAndAllowed(number) {
 			return b.eth.blockchain.CurrentHeader(), nil
 		}
 		return acceptedBlock.Header(), nil
@@ -159,7 +159,7 @@ func (b *EthAPIBackend) BlockByNumber(ctx context.Context, number rpc.BlockNumbe
 	// identically.
 	acceptedBlock := b.eth.LastAcceptedBlock()
 	if number.IsAccepted() {
-		if b.IsAllowUnfinalizedQueries() && number.IsLatest() {
+		if b.isLatestAndAllowed(number) {
 			header := b.eth.blockchain.CurrentBlock()
 			return b.eth.blockchain.GetBlock(header.Hash(), header.Number.Uint64()), nil
 		}
@@ -492,4 +492,8 @@ func (b *EthAPIBackend) StateAtTransaction(ctx context.Context, block *types.Blo
 
 func (b *EthAPIBackend) MinRequiredTip(ctx context.Context, header *types.Header) (*big.Int, error) {
 	return dummy.MinRequiredTip(b.ChainConfig(), header)
+}
+
+func (b *EthAPIBackend) isLatestAndAllowed(number rpc.BlockNumber) bool {
+	return number.IsLatest() && b.IsAllowUnfinalizedQueries()
 }

--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -95,13 +95,26 @@ func (b *testBackend) HeaderByNumber(ctx context.Context, blockNr rpc.BlockNumbe
 		num  uint64
 	)
 	switch blockNr {
-	case rpc.LatestBlockNumber, rpc.AcceptedBlockNumber:
+	case rpc.AcceptedBlockNumber:
+		var err error
+		hash, err = rawdb.ReadAcceptorTip(b.db)
+		if err != nil {
+			return nil, err
+		}
+		number := rawdb.ReadHeaderNumber(b.db, hash)
+		if number == nil {
+			return nil, nil
+		}
+		num = *number
+	case rpc.LatestBlockNumber, rpc.PendingBlockNumber:
 		hash = rawdb.ReadHeadBlockHash(b.db)
 		number := rawdb.ReadHeaderNumber(b.db, hash)
 		if number == nil {
 			return nil, nil
 		}
 		num = *number
+	case rpc.SafeBlockNumber:
+		return nil, errors.New("safe block not found")
 	default:
 		num = uint64(blockNr)
 		hash = rawdb.ReadCanonicalHash(b.db, num)

--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -95,7 +95,7 @@ func (b *testBackend) HeaderByNumber(ctx context.Context, blockNr rpc.BlockNumbe
 		num  uint64
 	)
 	switch blockNr {
-	case rpc.AcceptedBlockNumber:
+	case rpc.FinalizedBlockNumber:
 		var err error
 		hash, err = rawdb.ReadAcceptorTip(b.db)
 		if err != nil {

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -74,7 +74,6 @@ type BlockNumber int64
 const (
 	SafeBlockNumber      = BlockNumber(-4)
 	FinalizedBlockNumber = BlockNumber(-3)
-	AcceptedBlockNumber  = BlockNumber(-3)
 	LatestBlockNumber    = BlockNumber(-2)
 	PendingBlockNumber   = BlockNumber(-1)
 	EarliestBlockNumber  = BlockNumber(0)
@@ -104,7 +103,7 @@ func (bn *BlockNumber) UnmarshalJSON(data []byte) error {
 		return nil
 	// Include "finalized" as an option for compatibility with FinalizedBlockNumber from geth.
 	case "accepted", "finalized":
-		*bn = AcceptedBlockNumber
+		*bn = FinalizedBlockNumber
 		return nil
 	case "safe":
 		*bn = SafeBlockNumber
@@ -142,7 +141,7 @@ func (bn BlockNumber) String() string {
 		return "latest"
 	case PendingBlockNumber:
 		return "pending"
-	case AcceptedBlockNumber:
+	case FinalizedBlockNumber:
 		return "accepted"
 	case SafeBlockNumber:
 		return "safe"
@@ -202,7 +201,7 @@ func (bnh *BlockNumberOrHash) UnmarshalJSON(data []byte) error {
 		return nil
 	// Include "finalized" as an option for compatibility with FinalizedBlockNumber from geth.
 	case "accepted", "finalized":
-		bn := AcceptedBlockNumber
+		bn := FinalizedBlockNumber
 		bnh.BlockNumber = &bn
 		return nil
 	case "safe":

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -72,11 +72,12 @@ type jsonWriter interface {
 type BlockNumber int64
 
 const (
-	SafeBlockNumber     = BlockNumber(-4)
-	AcceptedBlockNumber = BlockNumber(-3)
-	LatestBlockNumber   = BlockNumber(-2)
-	PendingBlockNumber  = BlockNumber(-1)
-	EarliestBlockNumber = BlockNumber(0)
+	SafeBlockNumber      = BlockNumber(-4)
+	FinalizedBlockNumber = BlockNumber(-3)
+	AcceptedBlockNumber  = BlockNumber(-3)
+	LatestBlockNumber    = BlockNumber(-2)
+	PendingBlockNumber   = BlockNumber(-1)
+	EarliestBlockNumber  = BlockNumber(0)
 )
 
 // UnmarshalJSON parses the given JSON fragment into a BlockNumber. It supports:
@@ -156,6 +157,10 @@ func (bn BlockNumber) String() string {
 // IsAccepted returns true if this blockNumber should be treated as a request for the last accepted block
 func (bn BlockNumber) IsAccepted() bool {
 	return bn < EarliestBlockNumber && bn >= SafeBlockNumber
+}
+
+func (bn BlockNumber) IsLatest() bool {
+	return bn == LatestBlockNumber || bn == PendingBlockNumber
 }
 
 type BlockNumberOrHash struct {


### PR DESCRIPTION
## Why this should be merged
Seems in geth the rpc numbers (when resolved to real blocks) semantically follow a pattern of
Finalized <= Safe <= Latest <= Pending

Since we don't have Pending, we can map Latest/Pending to the chain's head in unfinalized query mode
Without unfinalized query mode, we can use last accepted for all.

## How this works
Updates semantics as above
Aligns code with upstream & adds FinalizedBlockNumber as an alias for AcceptedBlockNumber (esp in tests)

## How this was tested
CI

## How is this documented
not yet