### PR TITLE
Force precompile modules registration by importing ethclient as a package

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -42,6 +42,9 @@ import (
 	"github.com/ava-labs/subnet-evm/rpc"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+
+	// Force-load precompiles to trigger registration
+	_ "github.com/ava-labs/subnet-evm/precompile/registry"
 )
 
 // Verify that Client implements required interfaces


### PR DESCRIPTION
## Why this should be merged

When a project like ```avm-relayer``` imports ```ethclient/ethclient.go``` as a package it ensures that all precompiles defined in ```precompile/registry/registry.go``` are registered.

## How is this documented
This fixes the ```unknown precompiled configuration: ``` error in the unmarshalling of ```params.ChainConfigWithUpgradesJSON```. Bugs and reproduction steps documented in https://github.com/ava-labs/awm-relayer/issues/226