### PR TITLE
Genesis chainconfig cleanup

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -27,6 +27,7 @@
 package core
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/big"
 
@@ -197,7 +198,15 @@ func ApplyPrecompileActivations(c *params.ChainConfig, parentTimestamp *uint64, 
 				// since Suicide will be committed after the reconfiguration.
 				statedb.Finalise(true)
 			} else {
-				log.Info("Activating new precompile", "name", module.ConfigKey, "config", activatingConfig)
+				var printIntf interface{}
+				marshalled, err := json.Marshal(activatingConfig)
+				if err == nil {
+					printIntf = string(marshalled)
+				} else {
+					printIntf = activatingConfig
+				}
+
+				log.Info("Activating new precompile", "name", module.ConfigKey, "config", printIntf)
 				// Set the nonce of the precompile's address (as is done when a contract is created) to ensure
 				// that it is marked as non-empty and will not be cleaned up when the statedb is finalized.
 				statedb.SetNonce(module.Address, 1)

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -360,7 +360,7 @@ func TestBadTxAllowListBlock(t *testing.T) {
 			PetersburgBlock:     big.NewInt(0),
 			IstanbulBlock:       big.NewInt(0),
 			MuirGlacierBlock:    big.NewInt(0),
-			MandatoryNetworkUpgrades: params.MandatoryNetworkUpgrades{
+			NetworkUpgrades: params.NetworkUpgrades{
 				SubnetEVMTimestamp: utils.NewUint64(0),
 			},
 			GenesisPrecompiles: params.Precompiles{

--- a/core/vm/runtime/runtime.go
+++ b/core/vm/runtime/runtime.go
@@ -74,7 +74,7 @@ func setDefaults(cfg *Config) {
 			PetersburgBlock:     new(big.Int),
 			IstanbulBlock:       new(big.Int),
 			MuirGlacierBlock:    new(big.Int),
-			MandatoryNetworkUpgrades: params.MandatoryNetworkUpgrades{
+			NetworkUpgrades: params.NetworkUpgrades{
 				SubnetEVMTimestamp: new(uint64),
 			},
 		}

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/gballet/go-libpcsclite v0.0.0-20191108122812-4678299bea08
 	github.com/go-cmd/cmd v1.4.1
-	github.com/golang/protobuf v1.5.3
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/rpc v1.2.0
 	github.com/gorilla/websocket v1.4.2
@@ -82,6 +81,7 @@ require (
 	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golang/snappy v0.0.5-0.20220116011046-fa5810519dcb // indirect
 	github.com/google/btree v1.1.2 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -226,7 +226,7 @@ func newBackendMock() *backendMock {
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
 		MuirGlacierBlock:    big.NewInt(0),
-		MandatoryNetworkUpgrades: params.MandatoryNetworkUpgrades{
+		NetworkUpgrades: params.NetworkUpgrades{
 			SubnetEVMTimestamp: utils.NewUint64(1000),
 		},
 	}

--- a/params/config.go
+++ b/params/config.go
@@ -477,12 +477,12 @@ func checkForks(forks []fork, blockFork bool) error {
 			// Next one must be higher number
 			if lastFork.timestamp == nil && cur.timestamp != nil {
 				return fmt.Errorf("unsupported fork ordering: %v not enabled, but %v enabled at %v",
-					lastFork.name, cur.name, cur.timestamp)
+					lastFork.name, cur.name, *cur.timestamp)
 			}
 			if lastFork.timestamp != nil && cur.timestamp != nil {
 				if *lastFork.timestamp > *cur.timestamp {
 					return fmt.Errorf("unsupported fork ordering: %v enabled at %v, but %v enabled at %v",
-						lastFork.name, lastFork.timestamp, cur.name, cur.timestamp)
+						lastFork.name, *lastFork.timestamp, cur.name, *cur.timestamp)
 				}
 			}
 		}

--- a/params/config.go
+++ b/params/config.go
@@ -78,17 +78,17 @@ var (
 		FeeConfig:          DefaultFeeConfig,
 		AllowFeeRecipients: false,
 
-		HomesteadBlock:           big.NewInt(0),
-		EIP150Block:              big.NewInt(0),
-		EIP155Block:              big.NewInt(0),
-		EIP158Block:              big.NewInt(0),
-		ByzantiumBlock:           big.NewInt(0),
-		ConstantinopleBlock:      big.NewInt(0),
-		PetersburgBlock:          big.NewInt(0),
-		IstanbulBlock:            big.NewInt(0),
-		MuirGlacierBlock:         big.NewInt(0),
-		MandatoryNetworkUpgrades: GetMandatoryNetworkUpgrades(constants.MainnetID), // This can be changed to correct network (local, test) via VM.
-		GenesisPrecompiles:       Precompiles{},
+		HomesteadBlock:      big.NewInt(0),
+		EIP150Block:         big.NewInt(0),
+		EIP155Block:         big.NewInt(0),
+		EIP158Block:         big.NewInt(0),
+		ByzantiumBlock:      big.NewInt(0),
+		ConstantinopleBlock: big.NewInt(0),
+		PetersburgBlock:     big.NewInt(0),
+		IstanbulBlock:       big.NewInt(0),
+		MuirGlacierBlock:    big.NewInt(0),
+		NetworkUpgrades:     getDefaultNetworkUpgrades(constants.MainnetID), // This can be changed to correct network (local, test) via VM.
+		GenesisPrecompiles:  Precompiles{},
 	}
 
 	TestChainConfig = &ChainConfig{
@@ -105,7 +105,7 @@ var (
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
 		MuirGlacierBlock:    big.NewInt(0),
-		MandatoryNetworkUpgrades: MandatoryNetworkUpgrades{
+		NetworkUpgrades: NetworkUpgrades{
 			SubnetEVMTimestamp: utils.NewUint64(0),
 			DurangoTimestamp:   utils.NewUint64(0),
 		},
@@ -127,7 +127,7 @@ var (
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
 		MuirGlacierBlock:    big.NewInt(0),
-		MandatoryNetworkUpgrades: MandatoryNetworkUpgrades{
+		NetworkUpgrades: NetworkUpgrades{
 			SubnetEVMTimestamp: utils.NewUint64(0),
 		},
 		GenesisPrecompiles: Precompiles{},
@@ -135,22 +135,22 @@ var (
 	}
 
 	TestPreSubnetEVMConfig = &ChainConfig{
-		AvalancheContext:         AvalancheContext{utils.TestSnowContext()},
-		ChainID:                  big.NewInt(1),
-		FeeConfig:                DefaultFeeConfig,
-		AllowFeeRecipients:       false,
-		HomesteadBlock:           big.NewInt(0),
-		EIP150Block:              big.NewInt(0),
-		EIP155Block:              big.NewInt(0),
-		EIP158Block:              big.NewInt(0),
-		ByzantiumBlock:           big.NewInt(0),
-		ConstantinopleBlock:      big.NewInt(0),
-		PetersburgBlock:          big.NewInt(0),
-		IstanbulBlock:            big.NewInt(0),
-		MuirGlacierBlock:         big.NewInt(0),
-		MandatoryNetworkUpgrades: MandatoryNetworkUpgrades{},
-		GenesisPrecompiles:       Precompiles{},
-		UpgradeConfig:            UpgradeConfig{},
+		AvalancheContext:    AvalancheContext{utils.TestSnowContext()},
+		ChainID:             big.NewInt(1),
+		FeeConfig:           DefaultFeeConfig,
+		AllowFeeRecipients:  false,
+		HomesteadBlock:      big.NewInt(0),
+		EIP150Block:         big.NewInt(0),
+		EIP155Block:         big.NewInt(0),
+		EIP158Block:         big.NewInt(0),
+		ByzantiumBlock:      big.NewInt(0),
+		ConstantinopleBlock: big.NewInt(0),
+		PetersburgBlock:     big.NewInt(0),
+		IstanbulBlock:       big.NewInt(0),
+		MuirGlacierBlock:    big.NewInt(0),
+		NetworkUpgrades:     NetworkUpgrades{},
+		GenesisPrecompiles:  Precompiles{},
+		UpgradeConfig:       UpgradeConfig{},
 	}
 
 	TestRules = TestChainConfig.Rules(new(big.Int), 0)
@@ -186,8 +186,10 @@ type ChainConfig struct {
 	IstanbulBlock       *big.Int `json:"istanbulBlock,omitempty"`       // Istanbul switch block (nil = no fork, 0 = already on istanbul)
 	MuirGlacierBlock    *big.Int `json:"muirGlacierBlock,omitempty"`    // Eip-2384 (bomb delay) switch block (nil = no fork, 0 = already activated)
 
-	MandatoryNetworkUpgrades // Config for timestamps that enable mandatory network upgrades. Skip encoding/decoding directly into ChainConfig.
-	OptionalNetworkUpgrades  // Config for optional timestamps that enable network upgrades
+	// Cancun activates the Cancun upgrade from Ethereum. (nil = no fork, 0 = already activated)
+	CancunTime *uint64 `json:"cancunTime,omitempty"`
+
+	NetworkUpgrades // Config for timestamps that enable network upgrades. Skip encoding/decoding directly into ChainConfig.
 
 	AvalancheContext `json:"-"` // Avalanche specific context set during VM initialization. Not serialized.
 
@@ -224,17 +226,9 @@ func (c *ChainConfig) Description() string {
 	banner += "Hard forks (timestamp based):\n"
 	banner += fmt.Sprintf(" - Cancun Timestamp:              @%-10v (https://github.com/ava-labs/avalanchego/releases/tag/v1.12.0)\n", ptrToString(c.CancunTime))
 
-	banner += "Mandatory Avalanche Upgrades (timestamp based):\n"
+	banner += "Avalanche Upgrades (timestamp based):\n"
 	banner += fmt.Sprintf(" - SubnetEVM Timestamp:           @%-10v (https://github.com/ava-labs/avalanchego/releases/tag/v1.10.0)\n", ptrToString(c.SubnetEVMTimestamp))
 	banner += fmt.Sprintf(" - Durango Timestamp:            @%-10v (https://github.com/ava-labs/avalanchego/releases/tag/v1.11.0)\n", ptrToString(c.DurangoTimestamp))
-	banner += "\n"
-
-	// Add Subnet-EVM custom fields
-	optionalNetworkUpgradeBytes, err := json.Marshal(c.OptionalNetworkUpgrades)
-	if err != nil {
-		optionalNetworkUpgradeBytes = []byte("cannot marshal OptionalNetworkUpgrades")
-	}
-	banner += fmt.Sprintf("Optional Network Upgrades: %s", string(optionalNetworkUpgradeBytes))
 	banner += "\n"
 
 	precompileUpgradeBytes, err := json.Marshal(c.GenesisPrecompiles)
@@ -261,6 +255,42 @@ func (c *ChainConfig) Description() string {
 	banner += fmt.Sprintf("Allow Fee Recipients: %v", c.AllowFeeRecipients)
 	banner += "\n"
 	return banner
+}
+
+func (c *ChainConfig) SetNetworkUpgradeDefaults() {
+	if c.HomesteadBlock == nil {
+		c.HomesteadBlock = big.NewInt(0)
+	}
+	if c.EIP150Block == nil {
+		c.EIP150Block = big.NewInt(0)
+	}
+	if c.EIP155Block == nil {
+		c.EIP155Block = big.NewInt(0)
+	}
+	if c.EIP158Block == nil {
+		c.EIP158Block = big.NewInt(0)
+	}
+	if c.ByzantiumBlock == nil {
+		c.ByzantiumBlock = big.NewInt(0)
+	}
+	if c.ConstantinopleBlock == nil {
+		c.ConstantinopleBlock = big.NewInt(0)
+	}
+	if c.PetersburgBlock == nil {
+		c.PetersburgBlock = big.NewInt(0)
+	}
+	if c.IstanbulBlock == nil {
+		c.IstanbulBlock = big.NewInt(0)
+	}
+	if c.MuirGlacierBlock == nil {
+		c.MuirGlacierBlock = big.NewInt(0)
+	}
+
+	c.NetworkUpgrades.setDefaults(c.SnowCtx.NetworkID)
+
+	// if c.CancunTime == nil {
+	// 	c.CancunTime = c.EUpgrade
+	// }
 }
 
 // IsHomestead returns whether num is either equal to the homestead block or greater.
@@ -316,6 +346,7 @@ func (c *ChainConfig) IsSubnetEVM(time uint64) bool {
 	return utils.IsTimestampForked(c.SubnetEVMTimestamp, time)
 }
 
+// TODO: move avalanche hardforks to network_upgrades.go
 // IsDurango returns whether [time] represents a block
 // with a timestamp after the Durango upgrade time.
 func (c *ChainConfig) IsDurango(time uint64) bool {
@@ -384,6 +415,11 @@ func (c *ChainConfig) Verify() error {
 		return fmt.Errorf("invalid state upgrades: %w", err)
 	}
 
+	// Verify the network upgrades are internally consistent given the existing chainConfig.
+	if err := c.VerifyNetworkUpgrades(c.SnowCtx.NetworkID); err != nil {
+		return fmt.Errorf("invalid network upgrades: %w", err)
+	}
+
 	return nil
 }
 
@@ -422,12 +458,7 @@ func (c *ChainConfig) CheckConfigForkOrder() error {
 	// Note: we do not add the optional stateful precompile configs in here because they are optional
 	// and independent, such that the ordering they are enabled does not impact the correctness of the
 	// chain config.
-	if err := checkForks(c.mandatoryForkOrder(), false); err != nil {
-		return err
-	}
-
-	// Check optional forks are enabled in order
-	if err := checkForks(c.optionalForkOrder(), false); err != nil {
+	if err := checkForks(c.forkOrder(), false); err != nil {
 		return err
 	}
 
@@ -502,20 +533,12 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, height *big.Int, time
 		return newBlockCompatError("Muir Glacier fork block", c.MuirGlacierBlock, newcfg.MuirGlacierBlock)
 	}
 
-	// Check avalanhe network upgrades
-	if err := c.CheckMandatoryCompatible(&newcfg.MandatoryNetworkUpgrades, time); err != nil {
-		return err
+	if isForkTimestampIncompatible(c.CancunTime, newcfg.CancunTime, time) {
+		return newTimestampCompatError("Cancun fork block timestamp", c.CancunTime, c.CancunTime)
 	}
 
-	// Check subnet-evm specific activations
-	newOptionalNetworkUpgrades := newcfg.getOptionalNetworkUpgrades()
-	if c.UpgradeConfig.OptionalNetworkUpgrades != nil && newcfg.UpgradeConfig.OptionalNetworkUpgrades == nil {
-		// Note: if the current OptionalNetworkUpgrades are set via UpgradeConfig, then a new config
-		// without OptionalNetworkUpgrades will be treated as having specified an empty set of network
-		// upgrades (ie., treated as the user intends to cancel scheduled forks)
-		newOptionalNetworkUpgrades = &OptionalNetworkUpgrades{}
-	}
-	if err := c.getOptionalNetworkUpgrades().CheckOptionalCompatible(newOptionalNetworkUpgrades, time); err != nil {
+	// Check avalanche network upgrades
+	if err := c.CheckNetworkUpgradesCompatible(&newcfg.NetworkUpgrades, time); err != nil {
 		return err
 	}
 
@@ -732,13 +755,4 @@ func (c *ChainConfig) GetFeeConfig() commontype.FeeConfig {
 // Implements precompile.ChainConfig interface.
 func (c *ChainConfig) AllowedFeeRecipients() bool {
 	return c.AllowFeeRecipients
-}
-
-// getOptionalNetworkUpgrades returns OptionalNetworkUpgrades from upgrade config if set there,
-// otherwise it falls back to the genesis chain config.
-func (c *ChainConfig) getOptionalNetworkUpgrades() *OptionalNetworkUpgrades {
-	if upgradeConfigOverride := c.UpgradeConfig.OptionalNetworkUpgrades; upgradeConfigOverride != nil {
-		return upgradeConfigOverride
-	}
-	return &c.OptionalNetworkUpgrades
 }

--- a/params/config_extra.go
+++ b/params/config_extra.go
@@ -14,10 +14,8 @@ import (
 // - Timestamps that enable avalanche network upgrades,
 // - Enabling or disabling precompiles as network upgrades.
 type UpgradeConfig struct {
-	// Config for optional timestamps that enable network upgrades.
-	// Note: if OptionalUpgrades is specified in the JSON all previously activated
-	// forks must be present or upgradeBytes will be rejected.
-	OptionalNetworkUpgrades *OptionalNetworkUpgrades `json:"networkUpgrades,omitempty"`
+	// Config for timestamps that enable network upgrades.
+	NetworkUpgradeOverrides *NetworkUpgrades `json:"networkUpgradeOverrides,omitempty"`
 
 	// Config for modifying state as a network upgrade.
 	StateUpgrades []StateUpgrade `json:"stateUpgrades,omitempty"`

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -151,7 +151,7 @@ func TestCheckCompatible(t *testing.T) {
 
 func TestConfigRules(t *testing.T) {
 	c := &ChainConfig{
-		MandatoryNetworkUpgrades: MandatoryNetworkUpgrades{
+		NetworkUpgrades: NetworkUpgrades{
 			SubnetEVMTimestamp: utils.NewUint64(500),
 		},
 	}
@@ -272,7 +272,7 @@ func TestChainConfigMarshalWithUpgrades(t *testing.T) {
 			PetersburgBlock:     big.NewInt(0),
 			IstanbulBlock:       big.NewInt(0),
 			MuirGlacierBlock:    big.NewInt(0),
-			MandatoryNetworkUpgrades: MandatoryNetworkUpgrades{
+			NetworkUpgrades: NetworkUpgrades{
 				SubnetEVMTimestamp: utils.NewUint64(0),
 				DurangoTimestamp:   utils.NewUint64(0),
 			},

--- a/params/network_upgrades.go
+++ b/params/network_upgrades.go
@@ -23,57 +23,57 @@ type NetworkUpgrades struct {
 	DurangoTimestamp *uint64 `json:"durangoTimestamp,omitempty"`
 }
 
-func (s *NetworkUpgrades) Equal(other *NetworkUpgrades) bool {
-	return reflect.DeepEqual(s, other)
+func (n *NetworkUpgrades) Equal(other *NetworkUpgrades) bool {
+	return reflect.DeepEqual(n, other)
 }
 
-func (m *NetworkUpgrades) CheckNetworkUpgradesCompatible(newcfg *NetworkUpgrades, time uint64) *ConfigCompatError {
-	if isForkTimestampIncompatible(m.SubnetEVMTimestamp, newcfg.SubnetEVMTimestamp, time) {
-		return newTimestampCompatError("SubnetEVM fork block timestamp", m.SubnetEVMTimestamp, newcfg.SubnetEVMTimestamp)
+func (n *NetworkUpgrades) CheckNetworkUpgradesCompatible(newcfg *NetworkUpgrades, time uint64) *ConfigCompatError {
+	if isForkTimestampIncompatible(n.SubnetEVMTimestamp, newcfg.SubnetEVMTimestamp, time) {
+		return newTimestampCompatError("SubnetEVM fork block timestamp", n.SubnetEVMTimestamp, newcfg.SubnetEVMTimestamp)
 	}
-	if isForkTimestampIncompatible(m.DurangoTimestamp, newcfg.DurangoTimestamp, time) {
-		return newTimestampCompatError("Durango fork block timestamp", m.DurangoTimestamp, newcfg.DurangoTimestamp)
+	if isForkTimestampIncompatible(n.DurangoTimestamp, newcfg.DurangoTimestamp, time) {
+		return newTimestampCompatError("Durango fork block timestamp", n.DurangoTimestamp, newcfg.DurangoTimestamp)
 	}
 	return nil
 }
 
-func (m *NetworkUpgrades) forkOrder() []fork {
+func (n *NetworkUpgrades) forkOrder() []fork {
 	return []fork{
-		{name: "subnetEVMTimestamp", timestamp: m.SubnetEVMTimestamp},
-		{name: "durangoTimestamp", timestamp: m.DurangoTimestamp},
+		{name: "subnetEVMTimestamp", timestamp: n.SubnetEVMTimestamp},
+		{name: "durangoTimestamp", timestamp: n.DurangoTimestamp},
 	}
 }
 
 // setDefaults sets the default values for the network upgrades.
 // This overrides deactivating the network upgrade by providing a timestamp of nil value.
-func (m *NetworkUpgrades) setDefaults(networkID uint32) {
+func (n *NetworkUpgrades) setDefaults(networkID uint32) {
 	defaults := getDefaultNetworkUpgrades(networkID)
-	if m.SubnetEVMTimestamp == nil {
-		m.SubnetEVMTimestamp = defaults.SubnetEVMTimestamp
+	if n.SubnetEVMTimestamp == nil {
+		n.SubnetEVMTimestamp = defaults.SubnetEVMTimestamp
 	}
-	if m.DurangoTimestamp == nil {
-		m.DurangoTimestamp = defaults.DurangoTimestamp
+	if n.DurangoTimestamp == nil {
+		n.DurangoTimestamp = defaults.DurangoTimestamp
 	}
 }
 
-// verify checks that the network upgrades are well formed.
-func (m *NetworkUpgrades) VerifyNetworkUpgrades(networkID uint32) error {
+// VerifyNetworkUpgrades checks that the network upgrades are well formed.
+func (n *NetworkUpgrades) VerifyNetworkUpgrades(networkID uint32) error {
 	defaults := getDefaultNetworkUpgrades(networkID)
-	if isNilOrSmaller(m.SubnetEVMTimestamp, *defaults.SubnetEVMTimestamp) {
-		return fmt.Errorf("SubnetEVM fork block timestamp (%v) must be greater than or equal to %v", nilOrValueStr(m.SubnetEVMTimestamp), *defaults.SubnetEVMTimestamp)
+	if isNilOrSmaller(n.SubnetEVMTimestamp, *defaults.SubnetEVMTimestamp) {
+		return fmt.Errorf("SubnetEVM fork block timestamp (%v) must be greater than or equal to %v", nilOrValueStr(n.SubnetEVMTimestamp), *defaults.SubnetEVMTimestamp)
 	}
-	if isNilOrSmaller(m.DurangoTimestamp, *defaults.DurangoTimestamp) {
-		return fmt.Errorf("Durango fork block timestamp (%v) must be greater than or equal to %v", nilOrValueStr(m.DurangoTimestamp), *defaults.DurangoTimestamp)
+	if isNilOrSmaller(n.DurangoTimestamp, *defaults.DurangoTimestamp) {
+		return fmt.Errorf("Durango fork block timestamp (%v) must be greater than or equal to %v", nilOrValueStr(n.DurangoTimestamp), *defaults.DurangoTimestamp)
 	}
 	return nil
 }
 
-func (m *NetworkUpgrades) Override(o *NetworkUpgrades) {
+func (n *NetworkUpgrades) Override(o *NetworkUpgrades) {
 	if o.SubnetEVMTimestamp != nil {
-		m.SubnetEVMTimestamp = o.SubnetEVMTimestamp
+		n.SubnetEVMTimestamp = o.SubnetEVMTimestamp
 	}
 	if o.DurangoTimestamp != nil {
-		m.DurangoTimestamp = o.DurangoTimestamp
+		n.DurangoTimestamp = o.DurangoTimestamp
 	}
 }
 

--- a/params/network_upgrades.go
+++ b/params/network_upgrades.go
@@ -6,6 +6,7 @@ package params
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 
 	"github.com/ava-labs/avalanchego/version"
 	"github.com/ava-labs/subnet-evm/utils"
@@ -59,10 +60,10 @@ func (m *NetworkUpgrades) setDefaults(networkID uint32) {
 func (m *NetworkUpgrades) VerifyNetworkUpgrades(networkID uint32) error {
 	defaults := getDefaultNetworkUpgrades(networkID)
 	if isNilOrSmaller(m.SubnetEVMTimestamp, *defaults.SubnetEVMTimestamp) {
-		return fmt.Errorf("SubnetEVM fork block timestamp (%v) must be greater than or equal to %v", m.SubnetEVMTimestamp, *defaults.SubnetEVMTimestamp)
+		return fmt.Errorf("SubnetEVM fork block timestamp (%v) must be greater than or equal to %v", nilOrValueStr(m.SubnetEVMTimestamp), *defaults.SubnetEVMTimestamp)
 	}
 	if isNilOrSmaller(m.DurangoTimestamp, *defaults.DurangoTimestamp) {
-		return fmt.Errorf("Durango fork block timestamp (%v) must be greater than or equal to %v", m.DurangoTimestamp, *defaults.DurangoTimestamp)
+		return fmt.Errorf("Durango fork block timestamp (%v) must be greater than or equal to %v", nilOrValueStr(m.DurangoTimestamp), *defaults.DurangoTimestamp)
 	}
 	return nil
 }
@@ -77,6 +78,7 @@ func (m *NetworkUpgrades) Override(o *NetworkUpgrades) {
 }
 
 // getDefaultNetworkUpgrades returns the network upgrades for the specified network ID.
+// These should not return nil values.
 func getDefaultNetworkUpgrades(networkID uint32) NetworkUpgrades {
 	return NetworkUpgrades{
 		SubnetEVMTimestamp: utils.NewUint64(0),
@@ -89,4 +91,11 @@ func isNilOrSmaller(a *uint64, b uint64) bool {
 		return true
 	}
 	return *a < b
+}
+
+func nilOrValueStr(a *uint64) string {
+	if a == nil {
+		return "nil"
+	}
+	return strconv.FormatUint(*a, 10)
 }

--- a/params/network_upgrades.go
+++ b/params/network_upgrades.go
@@ -4,63 +4,89 @@
 package params
 
 import (
+	"fmt"
+	"reflect"
+
 	"github.com/ava-labs/avalanchego/version"
 	"github.com/ava-labs/subnet-evm/utils"
 )
 
-// MandatoryNetworkUpgrades contains timestamps that enable mandatory network upgrades.
-// These upgrades are mandatory, meaning that if a node does not upgrade by the
-// specified timestamp, it will be unable to participate in consensus.
+// NetworkUpgrades contains timestamps that enable network upgrades.
 // Avalanche specific network upgrades are also included here.
-type MandatoryNetworkUpgrades struct {
+type NetworkUpgrades struct {
 	// SubnetEVMTimestamp is a placeholder that activates Avalanche Upgrades prior to ApricotPhase6 (nil = no fork, 0 = already activated)
 	SubnetEVMTimestamp *uint64 `json:"subnetEVMTimestamp,omitempty"`
 	// Durango activates the Shanghai Execution Spec Upgrade from Ethereum (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/shanghai.md#included-eips)
 	// and Avalanche Warp Messaging. (nil = no fork, 0 = already activated)
 	// Note: EIP-4895 is excluded since withdrawals are not relevant to the Avalanche C-Chain or Subnets running the EVM.
 	DurangoTimestamp *uint64 `json:"durangoTimestamp,omitempty"`
-	// Cancun activates the Cancun upgrade from Ethereum. (nil = no fork, 0 = already activated)
-	CancunTime *uint64 `json:"cancunTime,omitempty"`
 }
 
-func (m *MandatoryNetworkUpgrades) CheckMandatoryCompatible(newcfg *MandatoryNetworkUpgrades, time uint64) *ConfigCompatError {
+func (s *NetworkUpgrades) Equal(other *NetworkUpgrades) bool {
+	return reflect.DeepEqual(s, other)
+}
+
+func (m *NetworkUpgrades) CheckNetworkUpgradesCompatible(newcfg *NetworkUpgrades, time uint64) *ConfigCompatError {
 	if isForkTimestampIncompatible(m.SubnetEVMTimestamp, newcfg.SubnetEVMTimestamp, time) {
 		return newTimestampCompatError("SubnetEVM fork block timestamp", m.SubnetEVMTimestamp, newcfg.SubnetEVMTimestamp)
 	}
 	if isForkTimestampIncompatible(m.DurangoTimestamp, newcfg.DurangoTimestamp, time) {
 		return newTimestampCompatError("Durango fork block timestamp", m.DurangoTimestamp, newcfg.DurangoTimestamp)
 	}
-	if isForkTimestampIncompatible(m.CancunTime, newcfg.CancunTime, time) {
-		return newTimestampCompatError("Cancun fork block timestamp", m.CancunTime, m.CancunTime)
-	}
 	return nil
 }
 
-func (m *MandatoryNetworkUpgrades) mandatoryForkOrder() []fork {
+func (m *NetworkUpgrades) forkOrder() []fork {
 	return []fork{
 		{name: "subnetEVMTimestamp", timestamp: m.SubnetEVMTimestamp},
 		{name: "durangoTimestamp", timestamp: m.DurangoTimestamp},
 	}
 }
 
-// GetMandatoryNetworkUpgrades returns the mandatory network upgrades for the specified network ID.
-func GetMandatoryNetworkUpgrades(networkID uint32) MandatoryNetworkUpgrades {
-	return MandatoryNetworkUpgrades{
+// setDefaults sets the default values for the network upgrades.
+// This overrides deactivating the network upgrade by providing a timestamp of nil value.
+func (m *NetworkUpgrades) setDefaults(networkID uint32) {
+	defaults := getDefaultNetworkUpgrades(networkID)
+	if m.SubnetEVMTimestamp == nil {
+		m.SubnetEVMTimestamp = defaults.SubnetEVMTimestamp
+	}
+	if m.DurangoTimestamp == nil {
+		m.DurangoTimestamp = defaults.DurangoTimestamp
+	}
+}
+
+// verify checks that the network upgrades are well formed.
+func (m *NetworkUpgrades) VerifyNetworkUpgrades(networkID uint32) error {
+	defaults := getDefaultNetworkUpgrades(networkID)
+	if isNilOrSmaller(m.SubnetEVMTimestamp, *defaults.SubnetEVMTimestamp) {
+		return fmt.Errorf("SubnetEVM fork block timestamp (%v) must be greater than or equal to %v", m.SubnetEVMTimestamp, *defaults.SubnetEVMTimestamp)
+	}
+	if isNilOrSmaller(m.DurangoTimestamp, *defaults.DurangoTimestamp) {
+		return fmt.Errorf("Durango fork block timestamp (%v) must be greater than or equal to %v", m.DurangoTimestamp, *defaults.DurangoTimestamp)
+	}
+	return nil
+}
+
+func (m *NetworkUpgrades) Override(o *NetworkUpgrades) {
+	if o.SubnetEVMTimestamp != nil {
+		m.SubnetEVMTimestamp = o.SubnetEVMTimestamp
+	}
+	if o.DurangoTimestamp != nil {
+		m.DurangoTimestamp = o.DurangoTimestamp
+	}
+}
+
+// getDefaultNetworkUpgrades returns the network upgrades for the specified network ID.
+func getDefaultNetworkUpgrades(networkID uint32) NetworkUpgrades {
+	return NetworkUpgrades{
 		SubnetEVMTimestamp: utils.NewUint64(0),
 		DurangoTimestamp:   getUpgradeTime(networkID, version.DurangoTimes),
 	}
 }
 
-// OptionalNetworkUpgrades includes overridable and optional Subnet-EVM network upgrades.
-// These can be specified in genesis and upgrade configs.
-// Timestamps can be different for each subnet network.
-// TODO: once we add the first optional upgrade here, we should uncomment TestVMUpgradeBytesOptionalNetworkUpgrades
-type OptionalNetworkUpgrades struct{}
-
-func (n *OptionalNetworkUpgrades) CheckOptionalCompatible(newcfg *OptionalNetworkUpgrades, time uint64) *ConfigCompatError {
-	return nil
-}
-
-func (n *OptionalNetworkUpgrades) optionalForkOrder() []fork {
-	return []fork{}
+func isNilOrSmaller(a *uint64, b uint64) bool {
+	if a == nil {
+		return true
+	}
+	return *a < b
 }

--- a/params/network_upgrades_test.go
+++ b/params/network_upgrades_test.go
@@ -1,0 +1,262 @@
+// (c) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package params
+
+import (
+	"testing"
+
+	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/subnet-evm/utils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNetworkUpgradesEqual(t *testing.T) {
+	testcases := []struct {
+		name      string
+		upgrades1 *NetworkUpgrades
+		upgrades2 *NetworkUpgrades
+		expected  bool
+	}{
+		{
+			name: "EqualNetworkUpgrades",
+			upgrades1: &NetworkUpgrades{
+				SubnetEVMTimestamp: utils.NewUint64(1),
+				DurangoTimestamp:   utils.NewUint64(2),
+			},
+			upgrades2: &NetworkUpgrades{
+				SubnetEVMTimestamp: utils.NewUint64(1),
+				DurangoTimestamp:   utils.NewUint64(2),
+			},
+			expected: true,
+		},
+		{
+			name: "NotEqualNetworkUpgrades",
+			upgrades1: &NetworkUpgrades{
+				SubnetEVMTimestamp: utils.NewUint64(1),
+				DurangoTimestamp:   utils.NewUint64(2),
+			},
+			upgrades2: &NetworkUpgrades{
+				SubnetEVMTimestamp: utils.NewUint64(1),
+				DurangoTimestamp:   utils.NewUint64(3),
+			},
+			expected: false,
+		},
+		{
+			name: "NilNetworkUpgrades",
+			upgrades1: &NetworkUpgrades{
+				SubnetEVMTimestamp: utils.NewUint64(1),
+				DurangoTimestamp:   utils.NewUint64(2),
+			},
+			upgrades2: nil,
+			expected:  false,
+		},
+		{
+			name: "NilNetworkUpgrade",
+			upgrades1: &NetworkUpgrades{
+				SubnetEVMTimestamp: utils.NewUint64(1),
+				DurangoTimestamp:   utils.NewUint64(2),
+			},
+			upgrades2: &NetworkUpgrades{
+				SubnetEVMTimestamp: utils.NewUint64(1),
+				DurangoTimestamp:   nil,
+			},
+			expected: false,
+		},
+	}
+	for _, test := range testcases {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.expected, test.upgrades1.Equal(test.upgrades2))
+		})
+	}
+}
+
+func TestCheckNetworkUpgradesCompatible(t *testing.T) {
+	testcases := []struct {
+		name      string
+		upgrades1 *NetworkUpgrades
+		upgrades2 *NetworkUpgrades
+		time      uint64
+		expected  bool
+	}{
+		{
+			name: "Compatible same NetworkUpgrades",
+			upgrades1: &NetworkUpgrades{
+				SubnetEVMTimestamp: utils.NewUint64(1),
+				DurangoTimestamp:   utils.NewUint64(2),
+			},
+			upgrades2: &NetworkUpgrades{
+				SubnetEVMTimestamp: utils.NewUint64(1),
+				DurangoTimestamp:   utils.NewUint64(2),
+			},
+			time:     1,
+			expected: true,
+		},
+		{
+			name: "Compatible different NetworkUpgrades",
+			upgrades1: &NetworkUpgrades{
+				SubnetEVMTimestamp: utils.NewUint64(1),
+				DurangoTimestamp:   utils.NewUint64(2),
+			},
+			upgrades2: &NetworkUpgrades{
+				SubnetEVMTimestamp: utils.NewUint64(1),
+				DurangoTimestamp:   utils.NewUint64(3),
+			},
+			time:     1,
+			expected: true,
+		},
+		{
+			name: "Compatible nil NetworkUpgrades",
+			upgrades1: &NetworkUpgrades{
+				SubnetEVMTimestamp: utils.NewUint64(1),
+				DurangoTimestamp:   utils.NewUint64(2),
+			},
+			upgrades2: &NetworkUpgrades{
+				SubnetEVMTimestamp: utils.NewUint64(1),
+				DurangoTimestamp:   nil,
+			},
+			time:     1,
+			expected: true,
+		},
+		{
+			name: "Incompatible rewinded NetworkUpgrades",
+			upgrades1: &NetworkUpgrades{
+				SubnetEVMTimestamp: utils.NewUint64(1),
+				DurangoTimestamp:   utils.NewUint64(2),
+			},
+			upgrades2: &NetworkUpgrades{
+				SubnetEVMTimestamp: utils.NewUint64(1),
+				DurangoTimestamp:   utils.NewUint64(1),
+			},
+			time:     1,
+			expected: false,
+		},
+		{
+			name: "Incompatible fastforward NetworkUpgrades",
+			upgrades1: &NetworkUpgrades{
+				SubnetEVMTimestamp: utils.NewUint64(1),
+				DurangoTimestamp:   utils.NewUint64(2),
+			},
+			upgrades2: &NetworkUpgrades{
+				SubnetEVMTimestamp: utils.NewUint64(1),
+				DurangoTimestamp:   utils.NewUint64(3),
+			},
+			time:     4,
+			expected: false,
+		},
+		{
+			name: "Incompatible nil NetworkUpgrades",
+			upgrades1: &NetworkUpgrades{
+				SubnetEVMTimestamp: utils.NewUint64(1),
+				DurangoTimestamp:   utils.NewUint64(2),
+			},
+			upgrades2: &NetworkUpgrades{
+				SubnetEVMTimestamp: utils.NewUint64(1),
+				DurangoTimestamp:   nil,
+			},
+			time:     2,
+			expected: false,
+		},
+	}
+	for _, test := range testcases {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.upgrades1.CheckNetworkUpgradesCompatible(test.upgrades2, test.time)
+			if test.expected {
+				require.Nil(t, err)
+			} else {
+				require.NotNil(t, err)
+			}
+		})
+	}
+}
+
+func TestVerifyNetworkUpgrades(t *testing.T) {
+	testcases := []struct {
+		name      string
+		upgrades  *NetworkUpgrades
+		networkID uint32
+		expected  bool
+	}{
+		{
+			name: "ValidNetworkUpgrades",
+			upgrades: &NetworkUpgrades{
+				SubnetEVMTimestamp: utils.NewUint64(0),
+				DurangoTimestamp:   utils.NewUint64(2),
+			},
+			networkID: 1111,
+			expected:  true,
+		},
+		{
+			name: "Invalid Durango nil upgrade",
+			upgrades: &NetworkUpgrades{
+				SubnetEVMTimestamp: utils.NewUint64(1),
+				DurangoTimestamp:   nil,
+			},
+			networkID: 1,
+			expected:  false,
+		},
+		{
+			name: "Invalid Subnet-EVM non-zero",
+			upgrades: &NetworkUpgrades{
+				SubnetEVMTimestamp: utils.NewUint64(1),
+				DurangoTimestamp:   utils.NewUint64(2),
+			},
+			networkID: 1,
+			expected:  false,
+		},
+		{
+			name: "Invalid Durango before default upgrade",
+			upgrades: &NetworkUpgrades{
+				SubnetEVMTimestamp: utils.NewUint64(0),
+				DurangoTimestamp:   utils.NewUint64(1),
+			},
+			networkID: constants.MainnetID,
+			expected:  false,
+		},
+	}
+	for _, test := range testcases {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.upgrades.VerifyNetworkUpgrades(test.networkID)
+			if test.expected {
+				require.Nil(t, err)
+			} else {
+				require.NotNil(t, err)
+			}
+		})
+	}
+}
+
+func TestForkOrder(t *testing.T) {
+	testcases := []struct {
+		name        string
+		upgrades    *NetworkUpgrades
+		expectedErr bool
+	}{
+		{
+			name: "ValidNetworkUpgrades",
+			upgrades: &NetworkUpgrades{
+				SubnetEVMTimestamp: utils.NewUint64(0),
+				DurangoTimestamp:   utils.NewUint64(2),
+			},
+			expectedErr: false,
+		},
+		{
+			name: "Invalid order",
+			upgrades: &NetworkUpgrades{
+				SubnetEVMTimestamp: utils.NewUint64(1),
+				DurangoTimestamp:   utils.NewUint64(0),
+			},
+			expectedErr: true,
+		},
+	}
+	for _, test := range testcases {
+		t.Run(test.name, func(t *testing.T) {
+			err := checkForks(test.upgrades.forkOrder(), false)
+			if test.expectedErr {
+				require.NotNil(t, err)
+			} else {
+				require.Nil(t, err)
+			}
+		})
+	}
+}

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -19,7 +19,6 @@ import (
 	avalanchegoMetrics "github.com/ava-labs/avalanchego/api/metrics"
 	"github.com/ava-labs/avalanchego/network/p2p"
 	"github.com/ava-labs/avalanchego/network/p2p/gossip"
-	avalanchegoConstants "github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/ava-labs/subnet-evm/commontype"
@@ -326,18 +325,12 @@ func (vm *VM) Initialize(
 		g.Config = params.SubnetEVMDefaultChainConfig
 	}
 
-	mandatoryNetworkUpgrades := params.GetMandatoryNetworkUpgrades(chainCtx.NetworkID)
-	if avalanchegoConstants.ProductionNetworkIDs.Contains(chainCtx.NetworkID) {
-		// We enforce network upgrades here, regardless of the chain config
-		// provided in the genesis file
-		g.Config.MandatoryNetworkUpgrades = mandatoryNetworkUpgrades
-	} else {
-		// If we are not enforcing, then apply those only if they are not
-		// already set in the genesis file
-		if g.Config.MandatoryNetworkUpgrades == (params.MandatoryNetworkUpgrades{}) {
-			g.Config.MandatoryNetworkUpgrades = mandatoryNetworkUpgrades
-		}
+	// Set the Avalanche Context on the ChainConfig
+	g.Config.AvalancheContext = params.AvalancheContext{
+		SnowCtx: chainCtx,
 	}
+
+	g.Config.SetNetworkUpgradeDefaults()
 
 	// Load airdrop file if provided
 	if vm.config.AirdropFile != "" {
@@ -346,10 +339,7 @@ func (vm *VM) Initialize(
 			return fmt.Errorf("could not read airdrop file '%s': %w", vm.config.AirdropFile, err)
 		}
 	}
-	// Set the Avalanche Context on the ChainConfig
-	g.Config.AvalancheContext = params.AvalancheContext{
-		SnowCtx: chainCtx,
-	}
+
 	vm.syntacticBlockValidator = NewBlockValidator()
 
 	if g.Config.FeeConfig == commontype.EmptyFeeConfig {
@@ -366,6 +356,14 @@ func (vm *VM) Initialize(
 			return fmt.Errorf("failed to parse upgrade bytes: %w", err)
 		}
 		g.Config.UpgradeConfig = upgradeConfig
+	}
+
+	if g.Config.UpgradeConfig.NetworkUpgradeOverrides != nil {
+		overrides := g.Config.UpgradeConfig.NetworkUpgradeOverrides
+		if err := overrides.VerifyNetworkUpgrades(chainCtx.NetworkID); err != nil {
+			return fmt.Errorf("failed to verify network upgrade overrides: %w", err)
+		}
+		g.Config.Override(overrides)
 	}
 
 	if err := g.Verify(); err != nil {

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -360,8 +360,11 @@ func (vm *VM) Initialize(
 
 	if g.Config.UpgradeConfig.NetworkUpgradeOverrides != nil {
 		overrides := g.Config.UpgradeConfig.NetworkUpgradeOverrides
-		if err := overrides.VerifyNetworkUpgrades(chainCtx.NetworkID); err != nil {
-			return fmt.Errorf("failed to verify network upgrade overrides: %w", err)
+		marshaled, err := json.Marshal(overrides)
+		if err != nil {
+			log.Warn("Failed to marshal network upgrade overrides", "error", err, "overrides", overrides)
+		} else {
+			log.Info("Applying network upgrade overrides", "overrides", string(marshaled))
 		}
 		g.Config.Override(overrides)
 	}

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -2819,7 +2819,7 @@ func TestRewardManagerPrecompileSetRewardAddress(t *testing.T) {
 	data, err := rewardmanager.PackSetRewardAddress(testAddr)
 	require.NoError(t, err)
 
-	gas := 21000 + 240 + rewardmanager.SetRewardAddressGasCost // 21000 for tx, 240 for tx data
+	gas := 21000 + 240 + rewardmanager.SetRewardAddressGasCost + rewardmanager.RewardAddressChangedEventGasCost // 21000 for tx, 240 for tx data
 
 	tx := types.NewTransaction(uint64(0), rewardmanager.ContractAddress, big.NewInt(1), gas, big.NewInt(testMinGasPrice), data)
 
@@ -2957,7 +2957,7 @@ func TestRewardManagerPrecompileAllowFeeRecipients(t *testing.T) {
 	data, err := rewardmanager.PackAllowFeeRecipients()
 	require.NoError(t, err)
 
-	gas := 21000 + 240 + rewardmanager.AllowFeeRecipientsGasCost // 21000 for tx, 240 for tx data
+	gas := 21000 + 240 + rewardmanager.SetRewardAddressGasCost + rewardmanager.RewardAddressChangedEventGasCost // 21000 for tx, 240 for tx data
 
 	tx := types.NewTransaction(uint64(0), rewardmanager.ContractAddress, big.NewInt(1), gas, big.NewInt(testMinGasPrice), data)
 

--- a/plugin/evm/vm_upgrade_bytes_test.go
+++ b/plugin/evm/vm_upgrade_bytes_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/ava-labs/avalanchego/snow"
 	commonEng "github.com/ava-labs/avalanchego/snow/engine/common"
-	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/vms/components/chain"
 	"github.com/ava-labs/subnet-evm/core"
 	"github.com/ava-labs/subnet-evm/core/types"
@@ -159,149 +158,56 @@ func TestVMUpgradeBytesPrecompile(t *testing.T) {
 	assert.Equal(t, signedTx1.Hash(), txs[0].Hash())
 }
 
-// func TestVMUpgradeBytesOptionalNetworkUpgrades(t *testing.T) {
-// 	tests := []struct {
-// 		name           string
-// 		setTimestampFn func(upgrade *params.UpgradeConfig, timestamp *big.Int)
-// 		checkUpgradeFn func(config *params.ChainConfig, blockTimestamp *big.Int) bool
-// 	}{
-// 		{
-// 			name: "Test",
-// 			setTimestampFn: func(upgrade *params.UpgradeConfig, timestamp *big.Int) {
-// 				upgrade.OptionalNetworkUpgrades.TestTimestamp = timestamp
-// 			},
-// 			checkUpgradeFn: func(config *params.ChainConfig, blockTimestamp *big.Int) bool {
-// 				return config.IsTest(blockTimestamp)
-// 			},
-// 		},
-// 	}
-// 	// Hack: registering metrics uses global variables, so we need to disable metrics here so that we can initialize the VM twice.
-// 	metrics.Enabled = false
-// 	defer func() {
-// 		metrics.Enabled = true
-// 	}()
-// 	for _, test := range tests {
-// 		t.Run(test.name, func(t *testing.T) {
-// 			// Get a json specifying a Network upgrade at genesis
-// 			// to apply as upgradeBytes.
-// 			testTimestamp := time.Unix(10, 0)
-// 			upgradeConfig := &params.UpgradeConfig{
-// 				OptionalNetworkUpgrades: &params.OptionalNetworkUpgrades{},
-// 			}
-// 			test.setTimestampFn(upgradeConfig, big.NewInt(testTimestamp.Unix()))
-// 			upgradeBytesJSON, err := json.Marshal(upgradeConfig)
-// 			require.NoError(t, err)
-
-// 			// initialize the VM with these upgrade bytes
-// 			issuer, vm, dbManager, appSender := GenesisVM(t, true, genesisJSONPreSubnetEVM, "", string(upgradeBytesJSON))
-// 			vm.clock.Set(testTimestamp)
-
-// 			// verify upgrade is applied
-// 			require.True(t, test.checkUpgradeFn(vm.chainConfig, big.NewInt(testTimestamp.Unix())))
-
-// 			// Submit a successful transaction and build a block to move the chain head past the SubnetEVMTimestamp network upgrade
-// 			tx0 := types.NewTransaction(uint64(0), testEthAddrs[0], big.NewInt(1), 21000, big.NewInt(testMinGasPrice), nil)
-// 			signedTx0, err := types.SignTx(tx0, types.NewEIP155Signer(vm.chainConfig.ChainID), testKeys[0])
-// 			require.NoError(t, err)
-// 			errs := vm.txPool.AddRemotesSync([]*types.Transaction{signedTx0})
-// 			require.NoError(t, errs[0])
-
-// 			issueAndAccept(t, issuer, vm) // make a block
-
-// 			require.NoError(t, vm.Shutdown(context.Background()))
-// 			// VM should not start again without proper upgrade bytes.
-// 			err = vm.Initialize(context.Background(), vm.ctx, dbManager, []byte(genesisJSONPreSubnetEVM), []byte{}, []byte{}, issuer, []*commonEng.Fx{}, appSender)
-// 			require.ErrorContains(t, err, fmt.Sprintf("mismatching %s fork block timestamp in database", test.name))
-
-// 			// VM should not start if fork is moved back
-// 			test.setTimestampFn(upgradeConfig, big.NewInt(2))
-// 			upgradeBytesJSON, err = json.Marshal(upgradeConfig)
-// 			require.NoError(t, err)
-// 			err = vm.Initialize(context.Background(), vm.ctx, dbManager, []byte(genesisJSONPreSubnetEVM), upgradeBytesJSON, []byte{}, issuer, []*commonEng.Fx{}, appSender)
-// 			require.ErrorContains(t, err, fmt.Sprintf("mismatching %s fork block timestamp in database", test.name))
-
-// 			// VM should not start if fork is moved forward
-// 			test.setTimestampFn(upgradeConfig, big.NewInt(30))
-// 			upgradeBytesJSON, err = json.Marshal(upgradeConfig)
-// 			require.NoError(t, err)
-// 			err = vm.Initialize(context.Background(), vm.ctx, dbManager, []byte(genesisJSONPreSubnetEVM), upgradeBytesJSON, []byte{}, issuer, []*commonEng.Fx{}, appSender)
-// 			require.ErrorContains(t, err, fmt.Sprintf("mismatching %s fork block timestamp in database", test.name))
-// 		})
-// 	}
-// }
-
-func TestMandatoryUpgradesEnforced(t *testing.T) {
-	// make genesis w/ fork at block 5
-	// but this should not be used because we are enforcing
-	// network upgrades within the code
+func TestNetworkUpgradesOverriden(t *testing.T) {
 	var genesis core.Genesis
 	if err := json.Unmarshal([]byte(genesisJSONPreSubnetEVM), &genesis); err != nil {
 		t.Fatalf("could not unmarshal genesis bytes: %s", err)
 	}
-	genesisSubnetEVMTimestamp := utils.NewUint64(5)
-	genesis.Config.SubnetEVMTimestamp = genesisSubnetEVMTimestamp
 	genesisBytes, err := json.Marshal(&genesis)
 	if err != nil {
 		t.Fatalf("could not unmarshal genesis bytes: %s", err)
 	}
 
-	// initialize the VM with these upgrade bytes
-	tests := []struct {
-		networkID uint32
-		expected  bool
-	}{
-		{
-			networkID: constants.MainnetID,
-			expected:  true,
-		},
-		{
-			networkID: constants.FujiID,
-			expected:  true,
-		},
-		{
-			networkID: constants.LocalID,
-			expected:  false,
-		},
-		{
-			networkID: constants.UnitTestID,
-			expected:  false,
-		},
-	}
+	upgradeBytesJSON := `{
+			"networkUpgradeOverrides": {
+				"subnetEVMTimestamp": 2,
+				"durangoTimestamp": 5
+			}
+		}`
 
-	for _, test := range tests {
-		t.Run(fmt.Sprintf("networkID %d", test.networkID), func(t *testing.T) {
-			vm := &VM{}
-			ctx, dbManager, genesisBytes, issuer, _ := setupGenesis(t, string(genesisBytes))
-			ctx.NetworkID = test.networkID
-			appSender := &commonEng.SenderTest{T: t}
-			appSender.CantSendAppGossip = true
-			appSender.SendAppGossipF = func(context.Context, []byte, int, int, int) error { return nil }
-			err := vm.Initialize(
-				context.Background(),
-				ctx,
-				dbManager,
-				genesisBytes,
-				nil,
-				nil,
-				issuer,
-				[]*commonEng.Fx{},
-				appSender,
-			)
-			require.NoError(t, err, "error initializing GenesisVM")
+	vm := &VM{}
+	ctx, dbManager, genesisBytes, issuer, _ := setupGenesis(t, string(genesisBytes))
+	appSender := &commonEng.SenderTest{T: t}
+	appSender.CantSendAppGossip = true
+	appSender.SendAppGossipF = func(context.Context, []byte, int, int, int) error { return nil }
+	err = vm.Initialize(
+		context.Background(),
+		ctx,
+		dbManager,
+		genesisBytes,
+		[]byte(upgradeBytesJSON),
+		nil,
+		issuer,
+		[]*commonEng.Fx{},
+		appSender,
+	)
+	require.NoError(t, err, "error initializing GenesisVM")
 
-			require.NoError(t, vm.SetState(context.Background(), snow.Bootstrapping))
-			require.NoError(t, vm.SetState(context.Background(), snow.NormalOp))
+	require.NoError(t, vm.SetState(context.Background(), snow.Bootstrapping))
+	require.NoError(t, vm.SetState(context.Background(), snow.NormalOp))
 
-			defer func() {
-				if err := vm.Shutdown(context.Background()); err != nil {
-					t.Fatal(err)
-				}
-			}()
+	defer func() {
+		if err := vm.Shutdown(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}()
 
-			// verify upgrade is rescheduled
-			require.Equal(t, test.expected, vm.chainConfig.IsSubnetEVM(0))
-		})
-	}
+	// verify upgrade overrides
+	require.False(t, vm.chainConfig.IsSubnetEVM(0))
+	require.True(t, vm.chainConfig.IsSubnetEVM(2))
+	require.False(t, vm.chainConfig.IsDurango(0))
+	require.True(t, vm.chainConfig.IsDurango(5))
+
 }
 
 func mustMarshal(t *testing.T, v interface{}) string {

--- a/plugin/evm/vm_upgrade_bytes_test.go
+++ b/plugin/evm/vm_upgrade_bytes_test.go
@@ -207,7 +207,6 @@ func TestNetworkUpgradesOverriden(t *testing.T) {
 	require.True(t, vm.chainConfig.IsSubnetEVM(2))
 	require.False(t, vm.chainConfig.IsDurango(0))
 	require.True(t, vm.chainConfig.IsDurango(5))
-
 }
 
 func mustMarshal(t *testing.T, v interface{}) string {

--- a/tests/init.go
+++ b/tests/init.go
@@ -178,7 +178,7 @@ var Forks = map[string]*params.ChainConfig{
 		ConstantinopleBlock: big.NewInt(0),
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
-		MandatoryNetworkUpgrades: params.MandatoryNetworkUpgrades{
+		NetworkUpgrades: params.NetworkUpgrades{
 			SubnetEVMTimestamp: utils.NewUint64(0),
 		},
 	},
@@ -192,7 +192,7 @@ var Forks = map[string]*params.ChainConfig{
 		ConstantinopleBlock: big.NewInt(0),
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
-		MandatoryNetworkUpgrades: params.MandatoryNetworkUpgrades{
+		NetworkUpgrades: params.NetworkUpgrades{
 			SubnetEVMTimestamp: utils.NewUint64(0),
 			DurangoTimestamp:   utils.NewUint64(0),
 		},
@@ -207,10 +207,10 @@ var Forks = map[string]*params.ChainConfig{
 		ConstantinopleBlock: big.NewInt(0),
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
-		MandatoryNetworkUpgrades: params.MandatoryNetworkUpgrades{
+		CancunTime:          utils.NewUint64(0),
+		NetworkUpgrades: params.NetworkUpgrades{
 			SubnetEVMTimestamp: utils.NewUint64(0),
 			DurangoTimestamp:   utils.NewUint64(0),
-			CancunTime:         utils.NewUint64(0),
 		},
 	},
 }


### PR DESCRIPTION
## Why this should be merged

1- This adds a new upgrade config `networkUpgradeOverrides` to override any avalanche network upgrade. With this upgrade config and `skip-upgrade-check` flag set to true, one can modify the timestamp of activated upgrade. This will come handy if a subnet has missed the upgrade (failed to update nodes) and as a result their chain has become unsyncable with newer versions. In this case `networkUpgradeOverrides` can be used to set a later time for upgrades. I.e:
`upgrade.json`:
```
{
  "networkUpgradeOverrides": {
    "durangoTimestamp": 1710415083
  }
}
```
2- Default Network Upgrades are introduced. `nil` and `blank` values in network upgrades (eth forks + avalanche upgrades) will now default to values. Meaning that it won't be possible to deactivate an existing upgrade via `nil` values. 

3- This PR also removes `OptionalNetworkUpgrades` since now we can modify all NetworkUpgrades.


## How this was tested

Unit tests + local tests

## How is this documented

it will be documented in docs repo.

