### PR TITLE
disable running for all tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
         required: true
   push:
     tags:
-      - "*"
+     - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   release:


### PR DESCRIPTION
We have changed this to include pre-releases (fuji) but this also includes release candidates (rc). We should only release for full versions and if there is something we want to release (as pre-release) we can trigger it manually. 