### PR TITLE
remove unnecessary upgrades

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -111,16 +111,6 @@ Subnet-EVM must activate any precompiles used in the test in the genesis:
 {
   "config": {
     "chainId": 43214,
-    "homesteadBlock": 0,
-    "eip150Block": 0,
-    "eip155Block": 0,
-    "eip158Block": 0,
-    "byzantiumBlock": 0,
-    "constantinopleBlock": 0,
-    "petersburgBlock": 0,
-    "istanbulBlock": 0,
-    "muirGlacierBlock": 0,
-    "subnetEVMTimestamp": 0,
     "feeConfig": {
       "gasLimit": 8000000,
       "minBaseFee": 25000000000,

--- a/tests/load/genesis/genesis.json
+++ b/tests/load/genesis/genesis.json
@@ -1,16 +1,6 @@
 {
   "config": {
     "chainId": 99999,
-    "homesteadBlock": 0,
-    "eip150Block": 0,
-    "eip155Block": 0,
-    "eip158Block": 0,
-    "byzantiumBlock": 0,
-    "constantinopleBlock": 0,
-    "petersburgBlock": 0,
-    "istanbulBlock": 0,
-    "muirGlacierBlock": 0,
-    "subnetEVMTimestamp": 0,
     "feeConfig": {
       "gasLimit": 200000000,
       "minBaseFee": 1000000000,

--- a/tests/precompile/genesis/contract_deployer_allow_list.json
+++ b/tests/precompile/genesis/contract_deployer_allow_list.json
@@ -1,15 +1,6 @@
 {
   "config": {
     "chainId": 99999,
-    "homesteadBlock": 0,
-    "eip150Block": 0,
-    "eip155Block": 0,
-    "eip158Block": 0,
-    "byzantiumBlock": 0,
-    "constantinopleBlock": 0,
-    "petersburgBlock": 0,
-    "istanbulBlock": 0,
-    "muirGlacierBlock": 0,
     "feeConfig": {
       "gasLimit": 20000000,
       "minBaseFee": 1000000000,

--- a/tests/precompile/genesis/contract_native_minter.json
+++ b/tests/precompile/genesis/contract_native_minter.json
@@ -1,15 +1,6 @@
 {
   "config": {
     "chainId": 99999,
-    "homesteadBlock": 0,
-    "eip150Block": 0,
-    "eip155Block": 0,
-    "eip158Block": 0,
-    "byzantiumBlock": 0,
-    "constantinopleBlock": 0,
-    "petersburgBlock": 0,
-    "istanbulBlock": 0,
-    "muirGlacierBlock": 0,
     "feeConfig": {
       "gasLimit": 20000000,
       "minBaseFee": 1000000000,

--- a/tests/precompile/genesis/fee_manager.json
+++ b/tests/precompile/genesis/fee_manager.json
@@ -1,15 +1,6 @@
 {
   "config": {
     "chainId": 99999,
-    "homesteadBlock": 0,
-    "eip150Block": 0,
-    "eip155Block": 0,
-    "eip158Block": 0,
-    "byzantiumBlock": 0,
-    "constantinopleBlock": 0,
-    "petersburgBlock": 0,
-    "istanbulBlock": 0,
-    "muirGlacierBlock": 0,
     "feeConfig": {
       "gasLimit": 20000000,
       "minBaseFee": 1000000000,

--- a/tests/precompile/genesis/reward_manager.json
+++ b/tests/precompile/genesis/reward_manager.json
@@ -1,15 +1,6 @@
 {
   "config": {
     "chainId": 99999,
-    "homesteadBlock": 0,
-    "eip150Block": 0,
-    "eip155Block": 0,
-    "eip158Block": 0,
-    "byzantiumBlock": 0,
-    "constantinopleBlock": 0,
-    "petersburgBlock": 0,
-    "istanbulBlock": 0,
-    "muirGlacierBlock": 0,
     "feeConfig": {
       "gasLimit": 20000000,
       "minBaseFee": 1000000000,

--- a/tests/precompile/genesis/tx_allow_list.json
+++ b/tests/precompile/genesis/tx_allow_list.json
@@ -1,15 +1,6 @@
 {
   "config": {
     "chainId": 99999,
-    "homesteadBlock": 0,
-    "eip150Block": 0,
-    "eip155Block": 0,
-    "eip158Block": 0,
-    "byzantiumBlock": 0,
-    "constantinopleBlock": 0,
-    "petersburgBlock": 0,
-    "istanbulBlock": 0,
-    "muirGlacierBlock": 0,
     "feeConfig": {
       "gasLimit": 20000000,
       "minBaseFee": 1000000000,

--- a/tests/precompile/genesis/warp.json
+++ b/tests/precompile/genesis/warp.json
@@ -1,15 +1,6 @@
 {
   "config": {
     "chainId": 99999,
-    "homesteadBlock": 0,
-    "eip150Block": 0,
-    "eip155Block": 0,
-    "eip158Block": 0,
-    "byzantiumBlock": 0,
-    "constantinopleBlock": 0,
-    "petersburgBlock": 0,
-    "istanbulBlock": 0,
-    "muirGlacierBlock": 0,
     "feeConfig": {
       "gasLimit": 20000000,
       "minBaseFee": 1000000000,


### PR DESCRIPTION
## Why this should be merged

We no longer require those to be present in genesis chain configs.

## How this works

Removes unnecessary upgrade timestamps/forks from genesis files

## How this was tested

CI covers this

## How is this documented

https://github.com/ava-labs/avalanche-docs/pull/1717
