### PR TITLE
move network upgrade code to file

### DIFF
--- a/params/config_extra.go
+++ b/params/config_extra.go
@@ -6,6 +6,8 @@ package params
 import (
 	"encoding/json"
 	"errors"
+	"math/big"
+	"time"
 
 	"github.com/ava-labs/avalanchego/snow"
 )
@@ -144,4 +146,45 @@ func (c *ChainConfig) ToWithUpgradesJSON() *ChainConfigWithUpgradesJSON {
 		ChainConfig:   *c,
 		UpgradeConfig: c.UpgradeConfig,
 	}
+}
+
+func (c *ChainConfig) SetNetworkUpgradeDefaults() {
+	if c.HomesteadBlock == nil {
+		c.HomesteadBlock = big.NewInt(0)
+	}
+	if c.EIP150Block == nil {
+		c.EIP150Block = big.NewInt(0)
+	}
+	if c.EIP155Block == nil {
+		c.EIP155Block = big.NewInt(0)
+	}
+	if c.EIP158Block == nil {
+		c.EIP158Block = big.NewInt(0)
+	}
+	if c.ByzantiumBlock == nil {
+		c.ByzantiumBlock = big.NewInt(0)
+	}
+	if c.ConstantinopleBlock == nil {
+		c.ConstantinopleBlock = big.NewInt(0)
+	}
+	if c.PetersburgBlock == nil {
+		c.PetersburgBlock = big.NewInt(0)
+	}
+	if c.IstanbulBlock == nil {
+		c.IstanbulBlock = big.NewInt(0)
+	}
+	if c.MuirGlacierBlock == nil {
+		c.MuirGlacierBlock = big.NewInt(0)
+	}
+
+	c.NetworkUpgrades.setDefaults(c.SnowCtx.NetworkID)
+}
+
+func getUpgradeTime(networkID uint32, upgradeTimes map[uint32]time.Time) uint64 {
+	if upgradeTime, ok := upgradeTimes[networkID]; ok {
+		return uint64(upgradeTime.Unix())
+	}
+	// If the upgrade time isn't specified, default being enabled in the
+	// genesis.
+	return 0
 }

--- a/params/network_upgrades.go
+++ b/params/network_upgrades.go
@@ -6,19 +6,27 @@ package params
 import (
 	"fmt"
 	"reflect"
-	"strconv"
 
 	"github.com/ava-labs/avalanchego/version"
 	"github.com/ava-labs/subnet-evm/utils"
 )
 
+var (
+	errCannotBeNil = fmt.Errorf("timestamp cannot be nil")
+
+	TestNetworkUpgrades = NetworkUpgrades{
+		SubnetEVMTimestamp: utils.NewUint64(0),
+		DurangoTimestamp:   utils.NewUint64(0),
+	}
+)
+
 // NetworkUpgrades contains timestamps that enable network upgrades.
 // Avalanche specific network upgrades are also included here.
 type NetworkUpgrades struct {
-	// SubnetEVMTimestamp is a placeholder that activates Avalanche Upgrades prior to ApricotPhase6 (nil = no fork, 0 = already activated)
+	// SubnetEVMTimestamp is a placeholder that activates Avalanche Upgrades prior to ApricotPhase6
 	SubnetEVMTimestamp *uint64 `json:"subnetEVMTimestamp,omitempty"`
 	// Durango activates the Shanghai Execution Spec Upgrade from Ethereum (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/shanghai.md#included-eips)
-	// and Avalanche Warp Messaging. (nil = no fork, 0 = already activated)
+	// and Avalanche Warp Messaging.
 	// Note: EIP-4895 is excluded since withdrawals are not relevant to the Avalanche C-Chain or Subnets running the EVM.
 	DurangoTimestamp *uint64 `json:"durangoTimestamp,omitempty"`
 }
@@ -48,10 +56,15 @@ func (n *NetworkUpgrades) forkOrder() []fork {
 // This overrides deactivating the network upgrade by providing a timestamp of nil value.
 func (n *NetworkUpgrades) setDefaults(networkID uint32) {
 	defaults := getDefaultNetworkUpgrades(networkID)
-	if n.SubnetEVMTimestamp == nil {
+	// If the network upgrade is not set, set it to the default value.
+	// If the network upgrade is set to 0, we also treat it as nil and set it default.
+	// This is because in prior versions, upgrades were not modifiable and were directly set to their default values.
+	// Most of the tools and configurations just provide these as 0, so it is safer to treat 0 as nil and set to default
+	// to prevent premature activations of the network upgrades.
+	if n.SubnetEVMTimestamp == nil || *n.SubnetEVMTimestamp == 0 {
 		n.SubnetEVMTimestamp = defaults.SubnetEVMTimestamp
 	}
-	if n.DurangoTimestamp == nil {
+	if n.DurangoTimestamp == nil || *n.DurangoTimestamp == 0 {
 		n.DurangoTimestamp = defaults.DurangoTimestamp
 	}
 }
@@ -59,11 +72,11 @@ func (n *NetworkUpgrades) setDefaults(networkID uint32) {
 // VerifyNetworkUpgrades checks that the network upgrades are well formed.
 func (n *NetworkUpgrades) VerifyNetworkUpgrades(networkID uint32) error {
 	defaults := getDefaultNetworkUpgrades(networkID)
-	if isNilOrSmaller(n.SubnetEVMTimestamp, *defaults.SubnetEVMTimestamp) {
-		return fmt.Errorf("SubnetEVM fork block timestamp (%v) must be greater than or equal to %v", nilOrValueStr(n.SubnetEVMTimestamp), *defaults.SubnetEVMTimestamp)
+	if err := verifyWithDefault(n.SubnetEVMTimestamp, defaults.SubnetEVMTimestamp); err != nil {
+		return fmt.Errorf("SubnetEVM fork block timestamp is invalid: %w", err)
 	}
-	if isNilOrSmaller(n.DurangoTimestamp, *defaults.DurangoTimestamp) {
-		return fmt.Errorf("Durango fork block timestamp (%v) must be greater than or equal to %v", nilOrValueStr(n.DurangoTimestamp), *defaults.DurangoTimestamp)
+	if err := verifyWithDefault(n.DurangoTimestamp, defaults.DurangoTimestamp); err != nil {
+		return fmt.Errorf("Durango fork block timestamp is invalid: %w", err)
 	}
 	return nil
 }
@@ -77,25 +90,60 @@ func (n *NetworkUpgrades) Override(o *NetworkUpgrades) {
 	}
 }
 
+// IsSubnetEVM returns whether [time] represents a block
+// with a timestamp after the SubnetEVM upgrade time.
+func (n *NetworkUpgrades) IsSubnetEVM(time uint64) bool {
+	return utils.IsTimestampForked(n.SubnetEVMTimestamp, time)
+}
+
+// IsDurango returns whether [time] represents a block
+// with a timestamp after the Durango upgrade time.
+func (n *NetworkUpgrades) IsDurango(time uint64) bool {
+	return utils.IsTimestampForked(n.DurangoTimestamp, time)
+}
+
+func (n *NetworkUpgrades) Description() string {
+	var banner string
+	banner += fmt.Sprintf(" - SubnetEVM Timestamp:           @%-10v (https://github.com/ava-labs/avalanchego/releases/tag/v1.10.0)\n", ptrToString(n.SubnetEVMTimestamp))
+	banner += fmt.Sprintf(" - Durango Timestamp:            @%-10v (https://github.com/ava-labs/avalanchego/releases/tag/v1.11.0)\n", ptrToString(n.DurangoTimestamp))
+	return banner
+}
+
+type AvalancheRules struct {
+	IsSubnetEVM bool
+	IsDurango   bool
+	IsEUpgrade  bool
+}
+
+func (n *NetworkUpgrades) GetAvalancheRules(time uint64) AvalancheRules {
+	return AvalancheRules{
+		IsSubnetEVM: n.IsSubnetEVM(time),
+		IsDurango:   n.IsDurango(time),
+	}
+}
+
 // getDefaultNetworkUpgrades returns the network upgrades for the specified network ID.
 // These should not return nil values.
 func getDefaultNetworkUpgrades(networkID uint32) NetworkUpgrades {
 	return NetworkUpgrades{
 		SubnetEVMTimestamp: utils.NewUint64(0),
-		DurangoTimestamp:   getUpgradeTime(networkID, version.DurangoTimes),
+		DurangoTimestamp:   utils.NewUint64(getUpgradeTime(networkID, version.DurangoTimes)),
 	}
 }
 
-func isNilOrSmaller(a *uint64, b uint64) bool {
-	if a == nil {
-		return true
+// verifyWithDefault checks that the provided timestamp is greater than or equal to the default timestamp.
+func verifyWithDefault(configTimestamp *uint64, defaultTimestamp *uint64) error {
+	if configTimestamp == nil {
+		return errCannotBeNil
 	}
-	return *a < b
+
+	if *configTimestamp < *defaultTimestamp {
+		return fmt.Errorf("provided timestamp (%d) must be greater than or equal to the default timestamp (%d)", *configTimestamp, defaultTimestamp)
+	}
+	return nil
 }
 
-func nilOrValueStr(a *uint64) string {
-	if a == nil {
-		return "nil"
-	}
-	return strconv.FormatUint(*a, 10)
+// SetMappedUpgrades sets the mapped upgrades (usually Avalanche > EVM upgrades) for the chain config.
+func (c *ChainConfig) SetMappedUpgrades() {
+	// c.CancunTime = utils.NewUint64(*c.EUpgradeTimestamp)
 }

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -369,6 +369,8 @@ func (vm *VM) Initialize(
 		g.Config.Override(overrides)
 	}
 
+	g.Config.SetMappedUpgrades()
+
 	if err := g.Verify(); err != nil {
 		return fmt.Errorf("failed to verify genesis: %w", err)
 	}


### PR DESCRIPTION
## Why this should be merged

Moves network upgrade code to it's own file. 

Fixes the Durango timestamp = 0 issue in https://github.com/ava-labs/avalanchego/issues/2877

## How this works

0 timestamps now defaults to the network defaults

## How this was tested

Locally tested

## How is this documented
