### PR TITLE
Bump go version

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: '~1.21.7'
+          go-version: '~1.21.9'
           check-latest: true
       - run: go mod download
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.21.7'
+          go-version: '~1.21.9'
           check-latest: true
       - name: Set up arm64 cross compiler
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
 
 env:
-  min_go_version: '~1.21.7'
+  min_go_version: '~1.21.9'
   grafana_url: https://grafana-experimental.avax-dev.network/d/kBQpRdWnk/avalanche-main-dashboard?orgId=1&refresh=10s&var-filter=is_ephemeral_node%7C%3D%7Cfalse&var-filter=gh_repo%7C%3D%7Cava-labs%2Fsubnet-evm&var-filter=gh_run_id%7C%3D%7C${{ github.run_id }}&var-filter=gh_run_attempt%7C%3D%7C${{ github.run_attempt }}
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 ARG AVALANCHE_VERSION
 
 # ============= Compilation Stage ================
-FROM golang:1.21.7-bullseye AS builder
+FROM golang:1.21.9-bullseye AS builder
 
 WORKDIR /build
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ To support these changes, there have been a number of changes to the SubnetEVM b
 
 ### Clone Subnet-evm
 
-First install Go 1.21.7 or later. Follow the instructions [here](https://go.dev/doc/install). You can verify by running `go version`.
+First install Go 1.21.9 or later. Follow the instructions [here](https://go.dev/doc/install). You can verify by running `go version`.
 
 Set `$GOPATH` environment variable properly for Go to look for Go Workspaces. Please read [this](https://go.dev/doc/code) for details. You can verify by running `echo $GOPATH`.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ava-labs/subnet-evm
 
-go 1.21
+go 1.21.9
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.10.0

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,29 +4,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-go_version_minimum="1.21.7"
-
-go_version() {
-    go version | sed -nE -e 's/[^0-9.]+([0-9.]+).+/\1/p'
-}
-
-version_lt() {
-    # Return true if $1 is a lower version than than $2,
-    local ver1=$1
-    local ver2=$2
-    # Reverse sort the versions, if the 1st item != ver1 then ver1 < ver2
-    if [[ $(echo -e -n "$ver1\n$ver2\n" | sort -rV | head -n1) != "$ver1" ]]; then
-        return 0
-    else
-        return 1
-    fi
-}
-
-if version_lt "$(go_version)" "$go_version_minimum"; then
-    echo "SubnetEVM requires Go >= $go_version_minimum, Go $(go_version) found." >&2
-    exit 1
-fi
-
 # Root directory
 SUBNET_EVM_PATH=$(
     cd "$(dirname "${BASH_SOURCE[0]}")"


### PR DESCRIPTION
## Why this should be merged

Bumps golang version to 1.21.9 in go.mod file and removes check in build script.

## How this was tested

CI & locally tested

## How is this documented

No need
