### PR TITLE
snapshot: fix race in abort/generate

### DIFF
--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -568,6 +568,9 @@ func (t *Tree) AbortGeneration() {
 // for it to shutdown before returning (if it is running). This call should not
 // be made concurrently.
 func (dl *diskLayer) abortGeneration() bool {
+	dl.lock.Lock()
+	defer dl.lock.Unlock()
+
 	// Store ideal time for abort to get better estimate of load
 	//
 	// Note that we set this time regardless if abortion was skipped otherwise we

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,6 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/ava-labs/avalanchego v1.11.3 h1:Fgf2R46SFsbe3dbaCu0vFPaA8F1zMqdf6Y/NYjG/wcA=
 github.com/ava-labs/avalanchego v1.11.3/go.mod h1:ruzSPKSH8GBFegvNsnKerD8+8oVnkJ5ejRAOUQ4pAZU=
-github.com/ava-labs/coreth v0.13.2-rc.2 h1:GmXSyDykDUuDyW7933T8lK7Fp6/4k/IcHhLJjkvjUYI=
-github.com/ava-labs/coreth v0.13.2-rc.2/go.mod h1:jOapwtgvroqZ2U8PJpoaq1PHrUFOrlgshUWQfM3nba0=
 github.com/ava-labs/coreth v0.13.3-0.20240326002912-83b1aa1c7a43 h1:CR0HAG6CYakCyxibAmehCDyjvyriWt2pSxhmDR8MrKk=
 github.com/ava-labs/coreth v0.13.3-0.20240326002912-83b1aa1c7a43/go.mod h1:n128DRgabYrCAUsGEXOKP0uzBLSV37zGIGs7xTAQZDY=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=


### PR DESCRIPTION
Excerpts from https://github.com/ava-labs/subnet-evm/actions/runs/8725583610/job/23938886724?pr=1154

```
Previous write at 0x00c0075f5590 by goroutine 14701:
  github.com/ava-labs/subnet-evm/core/state/snapshot.(*diskLayer).generate()
      /home/runner/work/subnet-evm/subnet-evm/core/state/snapshot/generate.go:402 +0x238e
  github.com/ava-labs/subnet-evm/core/state/snapshot.generateSnapshot.func1()
      /home/runner/work/subnet-evm/subnet-evm/core/state/snapshot/generate.go:160 +0x44

Goroutine 14701 (running) created at:
  github.com/ava-labs/subnet-evm/core/state/snapshot.generateSnapshot()
      /home/runner/work/subnet-evm/subnet-evm/core/state/snapshot/generate.go:160 +0x71b
  github.com/ava-labs/subnet-evm/core/state/snapshot.(*Tree).Rebuild()
      /home/runner/work/subnet-evm/subnet-evm/core/state/snapshot/snapshot.go:784 +0x4a6
  github.com/ava-labs/subnet-evm/core/state/snapshot.New()
      /home/runner/work/subnet-evm/subnet-evm/core/state/snapshot/snapshot.go:227 +0x571
  github.com/ava-labs/subnet-evm/core.(*BlockChain).initSnapshot()
      /home/runner/work/subnet-evm/subnet-evm/core/blockchain.go:1880 +0x6bc
  github.com/ava-labs/subnet-evm/core.(*BlockChain).reprocessState()
      /home/runner/work/subnet-evm/subnet-evm/core/blockchain.go:1982 +0x1564
  github.com/ava-labs/subnet-evm/core.(*BlockChain).loadLastState()
```

```
Read at 0x00c0075f5590 by goroutine 14527:
  github.com/ava-labs/subnet-evm/core/state/snapshot.(*diskLayer).abortGeneration()
      /home/runner/work/subnet-evm/subnet-evm/core/state/snapshot/snapshot.go:580 +0x18d
  github.com/ava-labs/subnet-evm/core/state/snapshot.(*Tree).AbortGeneration()
      /home/runner/work/subnet-evm/subnet-evm/core/state/snapshot/snapshot.go:564 +0x97
  github.com/ava-labs/subnet-evm/core.(*BlockChain).flattenSnapshot()
      /home/runner/work/subnet-evm/subnet-evm/core/blockchain.go:5[94](https://github.com/ava-labs/subnet-evm/actions/runs/8725583610/job/23938886724?pr=1154#step:6:95) +0x88
  github.com/ava-labs/subnet-evm/core.(*BlockChain).reprocessState()
      /home/runner/work/subnet-evm/subnet-evm/core/blockchain.go:19[95](https://github.com/ava-labs/subnet-evm/actions/runs/8725583610/job/23938886724?pr=1154#step:6:96) +0x16d1
  github.com/ava-labs/subnet-evm/core.(*BlockChain).loadLastState()
      /home/runner/work/subnet-evm/subnet-evm/core/blockchain.go:816 +0xcf6
  github.com/ava-labs/subnet-evm/core.NewBlockChain()
```
