### PR TITLE
Fix mismatched method names in comments

### DIFF
--- a/accounts/abi/bind/bind.go
+++ b/accounts/abi/bind/bind.go
@@ -373,7 +373,7 @@ func bindBasicTypeGo(kind abi.Type) string {
 	}
 }
 
-// bindNewTypeNewGo converts new types to Go ones.
+// bindTypeNewGo converts new types to Go ones.
 func bindTypeNewGo(kind abi.Type, structs map[string]*TmplStruct) string {
 	switch kind.T {
 	case abi.TupleTy:

--- a/consensus/dummy/dynamic_fees.go
+++ b/consensus/dummy/dynamic_fees.go
@@ -107,7 +107,7 @@ func CalcBaseFee(config *params.ChainConfig, feeConfig commontype.FeeConfig, par
 	return newRollupWindow, baseFee, nil
 }
 
-// EstiamteNextBaseFee attempts to estimate the next base fee based on a block with [parent] being built at
+// EstimateNextBaseFee attempts to estimate the next base fee based on a block with [parent] being built at
 // [timestamp].
 // If [timestamp] is less than the timestamp of [parent], then it uses the same timestamp as parent.
 // Warning: This function should only be used in estimation and should not be used when calculating the canonical

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1104,7 +1104,7 @@ func (bc *BlockChain) setPreference(block *types.Block) error {
 	return nil
 }
 
-// LastAcceptedBlock returns the last block to be marked as accepted. It may or
+// LastConsensusAcceptedBlock returns the last block to be marked as accepted. It may or
 // may not yet be processed.
 func (bc *BlockChain) LastConsensusAcceptedBlock() *types.Block {
 	bc.chainmu.Lock()


### PR DESCRIPTION
## Why this should be merged

Fix mismatched method names in comments

## How this works

## How this was tested

## How is this documented
