### PR TITLE
fix space in log levels

### DIFF
--- a/log/format.go
+++ b/log/format.go
@@ -78,6 +78,8 @@ func (h *TerminalHandler) format(buf []byte, r slog.Record, usecolor bool) []byt
 		b.WriteString(LevelAlignedString(r.Level))
 	}
 
+	b.WriteByte(' ')
+
 	// Prefix is added compared to upstream
 	if h.Prefix != nil {
 		b.WriteString(h.Prefix(r))

--- a/log/logger.go
+++ b/log/logger.go
@@ -71,13 +71,13 @@ func LevelAlignedString(l slog.Level) string {
 	case slog.LevelDebug:
 		return "DEBUG"
 	case slog.LevelInfo:
-		return "INFO "
+		return "INFO"
 	case slog.LevelWarn:
-		return "WARN "
+		return "WARN"
 	case slog.LevelError:
 		return "ERROR"
 	case LevelCrit:
-		return "CRIT "
+		return "CRIT"
 	default:
 		return "unknown level"
 	}


### PR DESCRIPTION
Fixes level spacing problems like
`[05-07|12:25:21.446] DEBUG<hBRSYikeL9fzeioygWcgDKFtEnaGsLS5VFxRFNxUiDpan79rg Chain> plugin/evm/gossip.go:138 shutting down subscription
`
