### PR TITLE
fix transaction history flag

### DIFF
--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -609,7 +609,7 @@ func TestTransactionIndices(t *testing.T) {
 	}
 	for i, l := range limits {
 		t.Run(fmt.Sprintf("test-%d, limit: %d", i+1, l), func(t *testing.T) {
-			conf.TxLookupLimit = l
+			conf.TransactionHistory = l
 
 			chain, err := createBlockChain(chainDB, conf, gspec, lastAcceptedBlock.Hash())
 			require.NoError(err)
@@ -701,19 +701,19 @@ func TestTransactionSkipIndexing(t *testing.T) {
 	chain.Stop()
 
 	// test2: specify lookuplimit with tx index skipping enabled. Blocks should not be indexed but tail should be updated.
-	conf.TxLookupLimit = 2
+	conf.TransactionHistory = 2
 	chainDB = rawdb.NewMemoryDatabase()
 	chain, err = createAndInsertChain(chainDB, conf, gspec, blocks, common.Hash{},
 		func(b *types.Block) {
 			bNumber := b.NumberU64()
-			tail := bNumber - conf.TxLookupLimit + 1
+			tail := bNumber - conf.TransactionHistory + 1
 			checkTxIndicesHelper(t, &tail, bNumber+1, bNumber+1, bNumber, chainDB, false) // check all indices has been skipped
 		})
 	require.NoError(err)
 	chain.Stop()
 
 	// test3: tx index skipping and unindexer disabled. Blocks should be indexed and tail should be updated.
-	conf.TxLookupLimit = 0
+	conf.TransactionHistory = 0
 	conf.SkipTxIndexing = false
 	chainDB = rawdb.NewMemoryDatabase()
 	chain, err = createAndInsertChain(chainDB, conf, gspec, blocks, common.Hash{},
@@ -726,12 +726,12 @@ func TestTransactionSkipIndexing(t *testing.T) {
 
 	// now change tx index skipping to true and check that the indices are skipped for the last block
 	// and old indices are removed up to the tail, but [tail, current) indices are still there.
-	conf.TxLookupLimit = 2
+	conf.TransactionHistory = 2
 	conf.SkipTxIndexing = true
 	chain, err = createAndInsertChain(chainDB, conf, gspec, blocks2[0:1], chain.CurrentHeader().Hash(),
 		func(b *types.Block) {
 			bNumber := b.NumberU64()
-			tail := bNumber - conf.TxLookupLimit + 1
+			tail := bNumber - conf.TransactionHistory + 1
 			checkTxIndicesHelper(t, &tail, tail, bNumber-1, bNumber, chainDB, false)
 		})
 	require.NoError(err)
@@ -865,7 +865,7 @@ func TestTxLookupBlockChain(t *testing.T) {
 		SnapshotLimit:             256,
 		SnapshotNoBuild:           true, // Ensure the test errors if snapshot initialization fails
 		AcceptorQueueLimit:        64,   // ensure channel doesn't block
-		TxLookupLimit:             5,
+		TransactionHistory:        5,
 	}
 	createTxLookupBlockChain := func(db ethdb.Database, gspec *Genesis, lastAcceptedHash common.Hash) (*BlockChain, error) {
 		return createBlockChain(db, cacheConf, gspec, lastAcceptedHash)
@@ -888,7 +888,7 @@ func TestTxLookupSkipIndexingBlockChain(t *testing.T) {
 		SnapshotLimit:             256,
 		SnapshotNoBuild:           true, // Ensure the test errors if snapshot initialization fails
 		AcceptorQueueLimit:        64,   // ensure channel doesn't block
-		TxLookupLimit:             5,
+		TransactionHistory:        5,
 		SkipTxIndexing:            true,
 	}
 	createTxLookupBlockChain := func(db ethdb.Database, gspec *Genesis, lastAcceptedHash common.Hash) (*BlockChain, error) {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -214,7 +214,7 @@ func New(
 			SnapshotNoBuild:                 config.SkipSnapshotRebuild,
 			Preimages:                       config.Preimages,
 			AcceptedCacheSize:               config.AcceptedCacheSize,
-			TxLookupLimit:                   config.TxLookupLimit,
+			TransactionHistory:              config.TransactionHistory,
 			SkipTxIndexing:                  config.SkipTxIndexing,
 			StateHistory:                    config.StateHistory,
 			StateScheme:                     config.StateScheme,

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -158,12 +158,10 @@ type Config struct {
 	// identical state with the pre-upgrade ruleset.
 	SkipUpgradeCheck bool
 
-	// TxLookupLimit is the maximum number of blocks from head whose tx indices
+	// TransactionHistory is the maximum number of blocks from head whose tx indices
 	// are reserved:
 	//  * 0:   means no limit
 	//  * N:   means N block limit [HEAD-N+1, HEAD] and delete extra indexes
-	// Deprecated, use 'TransactionHistory' instead.
-	TxLookupLimit      uint64 `toml:",omitempty"` // The maximum number of blocks from head whose tx indices are reserved.
 	TransactionHistory uint64 `toml:",omitempty"` // The maximum number of blocks from head whose tx indices are reserved.
 	StateHistory       uint64 `toml:",omitempty"` // The maximum number of blocks from head whose state histories are reserved.
 	StateScheme        string `toml:",omitempty"` // State scheme used to store ethereum state and merkle trie nodes on top

--- a/plugin/evm/syncervm_test.go
+++ b/plugin/evm/syncervm_test.go
@@ -456,7 +456,7 @@ func testSyncerVM(t *testing.T, vmSetup *syncVMSetup, test syncTest) {
 	}
 
 	// tail should be the last block synced
-	if syncerVM.ethConfig.TxLookupLimit != 0 {
+	if syncerVM.ethConfig.TransactionHistory != 0 {
 		tail := lastSyncedBlock.NumberU64()
 
 		core.CheckTxIndices(t, &tail, tail, syncerVM.chaindb, true)
@@ -484,8 +484,8 @@ func testSyncerVM(t *testing.T, vmSetup *syncVMSetup, test syncTest) {
 		}
 	},
 		func(block *types.Block) {
-			if syncerVM.ethConfig.TxLookupLimit != 0 {
-				tail := block.NumberU64() - syncerVM.ethConfig.TxLookupLimit + 1
+			if syncerVM.ethConfig.TransactionHistory != 0 {
+				tail := block.NumberU64() - syncerVM.ethConfig.TransactionHistory + 1
 				// tail should be the minimum last synced block, since we skipped it to the last block
 				if tail < lastSyncedBlock.NumberU64() {
 					tail = lastSyncedBlock.NumberU64()
@@ -517,8 +517,8 @@ func testSyncerVM(t *testing.T, vmSetup *syncVMSetup, test syncTest) {
 		}
 	},
 		func(block *types.Block) {
-			if syncerVM.ethConfig.TxLookupLimit != 0 {
-				tail := block.NumberU64() - syncerVM.ethConfig.TxLookupLimit + 1
+			if syncerVM.ethConfig.TransactionHistory != 0 {
+				tail := block.NumberU64() - syncerVM.ethConfig.TransactionHistory + 1
 				// tail should be the minimum last synced block, since we skipped it to the last block
 				if tail < lastSyncedBlock.NumberU64() {
 					tail = lastSyncedBlock.NumberU64()

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -433,7 +433,7 @@ func (vm *VM) Initialize(
 	vm.ethConfig.CommitInterval = vm.config.CommitInterval
 	vm.ethConfig.SkipUpgradeCheck = vm.config.SkipUpgradeCheck
 	vm.ethConfig.AcceptedCacheSize = vm.config.AcceptedCacheSize
-	vm.ethConfig.TxLookupLimit = vm.config.TxLookupLimit
+	vm.ethConfig.TransactionHistory = vm.config.TransactionHistory
 	vm.ethConfig.SkipTxIndexing = vm.config.SkipTxIndexing
 
 	// Create directory for offline pruning


### PR DESCRIPTION
## Why this should be merged

New `transaction-history` flag was not being passed correctly.

## How this works

Removes old `TxLookupLimit` config (keeps the flag) and uses the new `TransactionHistory` config and correctly deprecates old one and uses the new one.

## How this was tested

Locally

## How is this documented

Already documented
