### PR TITLE
remember initial gasTip

### DIFF
--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -114,6 +114,7 @@ func New(gasTip *big.Int, chain BlockChain, subpools []SubPool) (*TxPool, error)
 			return nil, err
 		}
 	}
+	pool.gasTip.Store(gasTip)
 
 	// Subscribe to chain head events to trigger subpool resets
 	var (


### PR DESCRIPTION
The txpool stores the last set gastip in addition to setting it in the subpools.
So it should be set on init.

The value is only read in tests.