### PR TITLE
TestVMUpgrades: extend timeout and stop ticker (#554)

### DIFF
--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -316,8 +316,10 @@ func TestVMUpgrades(t *testing.T) {
 				}
 
 				go shutdownFunc()
-				shutdownTimeout := 50 * time.Millisecond
+				shutdownTimeout := 250 * time.Millisecond
 				ticker := time.NewTicker(shutdownTimeout)
+				defer ticker.Stop()
+
 				select {
 				case <-ticker.C:
 					t.Fatalf("VM shutdown took longer than timeout: %v", shutdownTimeout)
@@ -2026,8 +2028,10 @@ func TestConfigureLogLevel(t *testing.T) {
 				}
 				go shutdownFunc()
 
-				shutdownTimeout := 50 * time.Millisecond
+				shutdownTimeout := 250 * time.Millisecond
 				ticker := time.NewTicker(shutdownTimeout)
+				defer ticker.Stop()
+
 				select {
 				case <-ticker.C:
 					t.Fatalf("VM shutdown took longer than timeout: %v", shutdownTimeout)


### PR DESCRIPTION
* TestVMUpgrades: extend timeout and stop ticker

* other instance

## Why this should be merged

## How this works

## How this was tested

## How is this documented
