### PR TITLE
Deprecate active precompiles

### DIFF
--- a/internal/ethapi/api_extra.go
+++ b/internal/ethapi/api_extra.go
@@ -122,6 +122,7 @@ func (s *BlockChainAPI) FeeConfig(ctx context.Context, blockNrOrHash *rpc.BlockN
 }
 
 // GetActivePrecompilesAt returns the active precompile configs at the given block timestamp.
+// DEPRECATED: Use GetActiveRulesAt instead.
 func (s *BlockChainAPI) GetActivePrecompilesAt(ctx context.Context, blockTimestamp *uint64) params.Precompiles {
 	var timestamp uint64
 	if blockTimestamp == nil {

--- a/internal/ethapi/api_extra.go
+++ b/internal/ethapi/api_extra.go
@@ -133,12 +133,37 @@ func (s *BlockChainAPI) GetActivePrecompilesAt(ctx context.Context, blockTimesta
 	return s.b.ChainConfig().EnabledStatefulPrecompiles(timestamp)
 }
 
-func (s *BlockChainAPI) GetActiveRulesAt(ctx context.Context, blockTimestamp *uint64) params.Rules {
+type ActivePrecompilesResult struct {
+	Timestamp uint64 `json:"timestamp"`
+}
+
+type ActiveRulesResult struct {
+	EthRules          params.EthRules                    `json:"ethRules"`
+	AvalancheRules    params.AvalancheRules              `json:"avalancheRules"`
+	ActivePrecompiles map[string]ActivePrecompilesResult `json:"precompiles"`
+}
+
+// GetActiveRulesAt returns the active rules at the given block timestamp.
+func (s *BlockChainAPI) GetActiveRulesAt(ctx context.Context, blockTimestamp *uint64) ActiveRulesResult {
 	var timestamp uint64
 	if blockTimestamp == nil {
 		timestamp = s.b.CurrentHeader().Time
 	} else {
 		timestamp = *blockTimestamp
 	}
-	return s.b.ChainConfig().Rules(common.Big0, timestamp)
+	rules := s.b.ChainConfig().Rules(common.Big0, timestamp)
+	res := ActiveRulesResult{
+		EthRules:       rules.EthRules,
+		AvalancheRules: rules.AvalancheRules,
+	}
+	res.ActivePrecompiles = make(map[string]ActivePrecompilesResult)
+	for _, precompileConfig := range rules.ActivePrecompiles {
+		if precompileConfig.Timestamp() == nil {
+			continue
+		}
+		res.ActivePrecompiles[precompileConfig.Key()] = ActivePrecompilesResult{
+			Timestamp: *precompileConfig.Timestamp(),
+		}
+	}
+	return res
 }

--- a/params/config.go
+++ b/params/config.go
@@ -622,16 +622,22 @@ func ptrToString(val *uint64) string {
 	return fmt.Sprintf("%d", *val)
 }
 
+type EthRules struct {
+	IsHomestead, IsEIP150, IsEIP155, IsEIP158               bool
+	IsByzantium, IsConstantinople, IsPetersburg, IsIstanbul bool
+	IsCancun                                                bool
+}
+
 // Rules wraps ChainConfig and is merely syntactic sugar or can be used for functions
 // that do not have or require information about the block.
 //
 // Rules is a one time interface meaning that it shouldn't be used in between transition
 // phases.
 type Rules struct {
-	ChainID                                                 *big.Int
-	IsHomestead, IsEIP150, IsEIP155, IsEIP158               bool
-	IsByzantium, IsConstantinople, IsPetersburg, IsIstanbul bool
-	IsCancun                                                bool
+	ChainID *big.Int
+
+	// Rules for Ethereum releases
+	EthRules
 
 	// Rules for Avalanche releases
 	AvalancheRules
@@ -662,16 +668,18 @@ func (c *ChainConfig) rules(num *big.Int, timestamp uint64) Rules {
 		chainID = new(big.Int)
 	}
 	return Rules{
-		ChainID:          new(big.Int).Set(chainID),
-		IsHomestead:      c.IsHomestead(num),
-		IsEIP150:         c.IsEIP150(num),
-		IsEIP155:         c.IsEIP155(num),
-		IsEIP158:         c.IsEIP158(num),
-		IsByzantium:      c.IsByzantium(num),
-		IsConstantinople: c.IsConstantinople(num),
-		IsPetersburg:     c.IsPetersburg(num),
-		IsIstanbul:       c.IsIstanbul(num),
-		IsCancun:         c.IsCancun(num, timestamp),
+		ChainID: new(big.Int).Set(chainID),
+		EthRules: EthRules{
+			IsHomestead:      c.IsHomestead(num),
+			IsEIP150:         c.IsEIP150(num),
+			IsEIP155:         c.IsEIP155(num),
+			IsEIP158:         c.IsEIP158(num),
+			IsByzantium:      c.IsByzantium(num),
+			IsConstantinople: c.IsConstantinople(num),
+			IsPetersburg:     c.IsPetersburg(num),
+			IsIstanbul:       c.IsIstanbul(num),
+			IsCancun:         c.IsCancun(num, timestamp),
+		},
 	}
 }
 


### PR DESCRIPTION
## Why this should be merged

This PR deprecates `eth_getActivatedPrecompilesAt` in favor of `eth_getActiveRulesAt` and expands the API.

https://docs.avax.network/reference/subnet-evm/api#eth_getactiverulesat

## How this works

Added precompiles to `getActiveRulesAt` API:
```
{
    "jsonrpc": "2.0",
    "id": 1,
    "result": {
        "ethRules": {
            "IsHomestead": true,
            "IsEIP150": true,
            "IsEIP155": true,
            "IsEIP158": true,
            "IsByzantium": true,
            "IsConstantinople": true,
            "IsPetersburg": true,
            "IsIstanbul": true,
            "IsCancun": false
        },
        "avalancheRules": {
            "IsSubnetEVM": true,
            "IsDurango": false,
            "IsEUpgrade": false
        },
        "precompiles": {
            "contractNativeMinterConfig": {
                "timestamp": 0
            }
        }
    }
}
```

## How this was tested

Locally

## How is this documented

Documents PR:
