### PR TITLE
add missing fields to "toCallArg"

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -763,5 +763,14 @@ func toCallArg(msg interfaces.CallMsg) interface{} {
 	if msg.GasTipCap != nil {
 		arg["maxPriorityFeePerGas"] = (*hexutil.Big)(msg.GasTipCap)
 	}
+	if msg.AccessList != nil {
+		arg["accessList"] = msg.AccessList
+	}
+	if msg.BlobGasFeeCap != nil {
+		arg["maxFeePerBlobGas"] = (*hexutil.Big)(msg.BlobGasFeeCap)
+	}
+	if msg.BlobHashes != nil {
+		arg["blobVersionedHashes"] = msg.BlobHashes
+	}
 	return arg
 }

--- a/ethclient/subnetevmclient/subnet_evm_client.go
+++ b/ethclient/subnetevmclient/subnet_evm_client.go
@@ -197,6 +197,15 @@ func toCallArg(msg interfaces.CallMsg) interface{} {
 	if msg.GasPrice != nil {
 		arg["gasPrice"] = (*hexutil.Big)(msg.GasPrice)
 	}
+	if msg.AccessList != nil {
+		arg["accessList"] = msg.AccessList
+	}
+	if msg.BlobGasFeeCap != nil {
+		arg["maxFeePerBlobGas"] = (*hexutil.Big)(msg.BlobGasFeeCap)
+	}
+	if msg.BlobHashes != nil {
+		arg["blobVersionedHashes"] = msg.BlobHashes
+	}
 	return arg
 }
 

--- a/interfaces/interfaces.go
+++ b/interfaces/interfaces.go
@@ -115,6 +115,10 @@ type CallMsg struct {
 	Data      []byte          // input data, usually an ABI-encoded contract method invocation
 
 	AccessList types.AccessList // EIP-2930 access list.
+
+	// For BlobTxType
+	BlobGasFeeCap *big.Int
+	BlobHashes    []common.Hash
 }
 
 // A ContractCaller provides contract calls, essentially transactions that are executed by


### PR DESCRIPTION
## Why this should be merged
These fields were missing. Notably, accessList is needed for warp gas estimation.

## How this works
Passes the missing fields along.

## How this was tested
Against https://github.com/ava-labs/teleporter/tree/gas-estimate which issues gas estimation calls with warp.

## How is this documented
N/A