### PR TITLE
[testing] Remove dep on gomega

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,6 @@ require (
 	github.com/mattn/go-isatty v0.0.17
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/onsi/ginkgo/v2 v2.13.1
-	github.com/onsi/gomega v1.29.0
 	github.com/prometheus/client_golang v1.16.0
 	github.com/prometheus/client_model v0.3.0
 	github.com/shirou/gopsutil v3.21.11+incompatible
@@ -84,7 +83,6 @@ require (
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golang/snappy v0.0.5-0.20220116011046-fa5810519dcb // indirect
 	github.com/google/btree v1.1.2 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/pprof v0.0.0-20230207041349-798e818bf904 // indirect
 	github.com/google/renameio/v2 v2.0.0 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect

--- a/tests/load/load_test.go
+++ b/tests/load/load_test.go
@@ -13,8 +13,6 @@ import (
 
 	ginkgo "github.com/onsi/ginkgo/v2"
 
-	"github.com/onsi/gomega"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/log"
@@ -46,7 +44,6 @@ func init() {
 }
 
 func TestE2E(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
 	ginkgo.RunSpecs(t, "subnet-evm small load simulator test suite")
 }
 

--- a/tests/precompile/precompile_test.go
+++ b/tests/precompile/precompile_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	ginkgo "github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 
 	// Import the solidity package, so that ginkgo maps out the tests declared within the package
 	"github.com/ava-labs/subnet-evm/tests/precompile/solidity"
@@ -18,7 +17,6 @@ func TestE2E(t *testing.T) {
 	if basePath := os.Getenv("TEST_SOURCE_ROOT"); basePath != "" {
 		os.Chdir(basePath)
 	}
-	gomega.RegisterFailHandler(ginkgo.Fail)
 	solidity.RegisterAsyncTests()
 	ginkgo.RunSpecs(t, "subnet-evm precompile ginkgo test suite")
 }

--- a/tests/warp/warp_test.go
+++ b/tests/warp/warp_test.go
@@ -18,8 +18,6 @@ import (
 
 	ginkgo "github.com/onsi/ginkgo/v2"
 
-	"github.com/onsi/gomega"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -87,7 +85,6 @@ type Subnet struct {
 }
 
 func TestE2E(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
 	ginkgo.RunSpecs(t, "subnet-evm warp e2e test")
 }
 


### PR DESCRIPTION
## Why this should be merged

Previously gomega was replaced by testify so that only a single assertion library was used across all types of testing. The replacement was incomplete, though, since registration of a fail handler for gomega was still being performed and somehow the  `tests/utils` path was missed entirely. This changeset removes the use of gomega entirely.

## How this was tested

CI
