### PR TITLE
update tsconfig & bump to 1.2.2

### DIFF
--- a/contracts/package-lock.json
+++ b/contracts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@avalabs/subnet-evm-contracts",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@avalabs/subnet-evm-contracts",
-      "version": "1.2.0",
+      "version": "1.2.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@avalabs/avalanchejs": "^4.0.5",

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -14,7 +14,7 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.4.5"
   },
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -26,13 +26,13 @@
   },
   "license": "BSD-3-Clause",
   "scripts": {
-    "build": "rm -rf dist/ && npx hardhat compile && tsc -b ",
+    "build": "rm -rf dist/ && npx hardhat compile && npx tsc -b ",
     "compile": "npx hardhat compile",
     "console": "npx hardhat console",
     "test": "npx hardhat test",
     "lint": "prettier --list-different 'contracts/**/*.sol'",
     "prepublish": "npm run build",
-    "release:prepare": "rm -rf ./dist ./node_modules && npm install && npm run build"
+    "release:prepare": "rm -rf ./node_modules && npm install && npm run build"
   },
   "dependencies": {
     "@avalabs/avalanchejs": "^4.0.5",

--- a/contracts/tsconfig.json
+++ b/contracts/tsconfig.json
@@ -10,8 +10,6 @@
     "skipLibCheck": true,
     "resolveJsonModule": true,
   },
-  "include": ["./scripts", "./test", "./typechain-types"],
-  "files": ["./hardhat.config.ts"],
   "exclude": ["node_modules", "artifacts", "cache"],
   "typeAcquisition": {
     "enable": true,


### PR DESCRIPTION
## Why this should be merged

In the previous version we introduced a broken tsconfig which would skip `index.js` to be packed, and also dist package did not updated from 1.2.0. This fixes those issues by reverting tsconfig and bumping to 1.2.2 

## How this was tested

Locally against precompile-evm

## How is this documented
