### PR TITLE
chore: make function comments match function names

### DIFF
--- a/core/rawdb/accessors_snapshot.go
+++ b/core/rawdb/accessors_snapshot.go
@@ -70,7 +70,7 @@ func ReadSnapshotBlockHash(db ethdb.KeyValueReader) common.Hash {
 	return common.BytesToHash(data)
 }
 
-// WriteSnapshotRoot stores the root of the block whose state is contained in
+// WriteSnapshotBlockHash stores the root of the block whose state is contained in
 // the persisted snapshot.
 func WriteSnapshotBlockHash(db ethdb.KeyValueWriter, blockHash common.Hash) {
 	if err := db.Put(snapshotBlockHashKey, blockHash[:]); err != nil {

--- a/core/rawdb/accessors_state_sync.go
+++ b/core/rawdb/accessors_state_sync.go
@@ -81,7 +81,7 @@ func WriteSyncSegment(db ethdb.KeyValueWriter, root common.Hash, start []byte) e
 	return db.Put(packSyncSegmentKey(root, start), []byte{0x01})
 }
 
-// ClearSegment removes segment markers for root from db
+// ClearSyncSegments removes segment markers for root from db
 func ClearSyncSegments(db ethdb.KeyValueStore, root common.Hash) error {
 	segmentsPrefix := make([]byte, len(syncSegmentsPrefix)+common.HashLength)
 	copy(segmentsPrefix, syncSegmentsPrefix)

--- a/core/state/snapshot/snapshot_test.go
+++ b/core/state/snapshot/snapshot_test.go
@@ -232,7 +232,7 @@ func TestDiffLayerExternalInvalidationPartialFlatten(t *testing.T) {
 	}
 }
 
-// TestPostCapBasicDataAccess tests some functionality regarding capping/flattening.
+// TestPostFlattenBasicDataAccess tests some functionality regarding capping/flattening.
 func TestPostFlattenBasicDataAccess(t *testing.T) {
 	// setAccount is a helper to construct a random account entry and assign it to
 	// an account slot in a snapshot


### PR DESCRIPTION
## Why this should be merged

make function comments match function names

## How this works

## How this was tested

## How is this documented
