### PR TITLE
miner, eth: remove unused event mux

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -428,10 +428,6 @@ func (b *EthAPIBackend) ChainDb() ethdb.Database {
 	return b.eth.ChainDb()
 }
 
-func (b *EthAPIBackend) EventMux() *event.TypeMux {
-	return b.eth.EventMux()
-}
-
 func (b *EthAPIBackend) AccountManager() *accounts.Manager {
 	return b.eth.AccountManager()
 }

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -58,7 +58,6 @@ import (
 	"github.com/ava-labs/subnet-evm/rpc"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethdb"
-	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -91,7 +90,6 @@ type Ethereum struct {
 	// DB interfaces
 	chainDb ethdb.Database // Block chain database
 
-	eventMux       *event.TypeMux
 	engine         consensus.Engine
 	accountManager *accounts.Manager
 
@@ -174,7 +172,6 @@ func New(
 		config:            config,
 		gossiper:          gossiper,
 		chainDb:           chainDb,
-		eventMux:          new(event.TypeMux),
 		accountManager:    stack.AccountManager(),
 		engine:            dummy.NewFakerWithClock(clock),
 		closeBloomHandler: make(chan struct{}),
@@ -258,7 +255,7 @@ func New(
 		return nil, err
 	}
 
-	eth.miner = miner.New(eth, &config.Miner, eth.blockchain.Config(), eth.EventMux(), eth.engine, clock)
+	eth.miner = miner.New(eth, &config.Miner, eth.blockchain.Config(), eth.engine, clock)
 
 	allowUnprotectedTxHashes := make(map[common.Hash]struct{})
 	for _, txHash := range config.AllowUnprotectedTxHashes {
@@ -359,7 +356,6 @@ func (s *Ethereum) Miner() *miner.Miner { return s.miner }
 func (s *Ethereum) AccountManager() *accounts.Manager { return s.accountManager }
 func (s *Ethereum) BlockChain() *core.BlockChain      { return s.blockchain }
 func (s *Ethereum) TxPool() *txpool.TxPool            { return s.txPool }
-func (s *Ethereum) EventMux() *event.TypeMux          { return s.eventMux }
 func (s *Ethereum) Engine() consensus.Engine          { return s.engine }
 func (s *Ethereum) ChainDb() ethdb.Database           { return s.chainDb }
 
@@ -393,8 +389,6 @@ func (s *Ethereum) Stop() error {
 
 	s.chainDb.Close()
 	log.Info("Closed chaindb")
-	s.eventMux.Stop()
-	log.Info("Stopped EventMux")
 	return nil
 }
 

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -54,9 +54,9 @@ type Miner struct {
 	worker *worker
 }
 
-func New(eth Backend, config *Config, chainConfig *params.ChainConfig, mux *event.TypeMux, engine consensus.Engine, clock *mockable.Clock) *Miner {
+func New(eth Backend, config *Config, chainConfig *params.ChainConfig, engine consensus.Engine, clock *mockable.Clock) *Miner {
 	return &Miner{
-		worker: newWorker(config, chainConfig, engine, eth, mux, clock),
+		worker: newWorker(config, chainConfig, engine, eth, clock),
 	}
 }
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -98,21 +98,19 @@ type worker struct {
 	pendingLogsFeed event.Feed
 
 	// Subscriptions
-	mux        *event.TypeMux // TODO replace
-	mu         sync.RWMutex   // The lock used to protect the coinbase and extra fields
+	mu         sync.RWMutex // The lock used to protect the coinbase and extra fields
 	coinbase   common.Address
 	clock      *mockable.Clock // Allows us mock the clock for testing
 	beaconRoot *common.Hash    // TODO: set to empty hash, retained for upstream compatibility and future use
 }
 
-func newWorker(config *Config, chainConfig *params.ChainConfig, engine consensus.Engine, eth Backend, mux *event.TypeMux, clock *mockable.Clock) *worker {
+func newWorker(config *Config, chainConfig *params.ChainConfig, engine consensus.Engine, eth Backend, clock *mockable.Clock) *worker {
 	worker := &worker{
 		config:      config,
 		chainConfig: chainConfig,
 		engine:      engine,
 		eth:         eth,
 		chain:       eth.BlockChain(),
-		mux:         mux,
 		coinbase:    config.Etherbase,
 		clock:       clock,
 		beaconRoot:  &common.Hash{},


### PR DESCRIPTION
## Why this should be merged
Avoids creating and passing around unneeded object

## How this works
Removes code

## How this was tested
CI

## How is this documented
N/A