### PR TITLE
warp: SubnetOnlyValidator flag to verify incoming msg w/ primary (not subnet) vdrs

### DIFF
--- a/plugin/evm/block.go
+++ b/plugin/evm/block.go
@@ -175,8 +175,9 @@ func (b *Block) syntacticVerify() error {
 // Verify implements the snowman.Block interface
 func (b *Block) Verify(context.Context) error {
 	return b.verify(&precompileconfig.PredicateContext{
-		SnowCtx:            b.vm.ctx,
-		ProposerVMBlockCtx: nil,
+		SnowCtx:             b.vm.ctx,
+		ProposerVMBlockCtx:  nil,
+		SubnetOnlyValidator: b.vm.config.SubnetOnlyValidator,
 	}, true)
 }
 
@@ -206,8 +207,9 @@ func (b *Block) ShouldVerifyWithContext(context.Context) (bool, error) {
 // VerifyWithContext implements the block.WithVerifyContext interface
 func (b *Block) VerifyWithContext(ctx context.Context, proposerVMBlockCtx *block.Context) error {
 	return b.verify(&precompileconfig.PredicateContext{
-		SnowCtx:            b.vm.ctx,
-		ProposerVMBlockCtx: proposerVMBlockCtx,
+		SnowCtx:             b.vm.ctx,
+		ProposerVMBlockCtx:  proposerVMBlockCtx,
+		SubnetOnlyValidator: b.vm.config.SubnetOnlyValidator,
 	}, true)
 }
 

--- a/plugin/evm/config.go
+++ b/plugin/evm/config.go
@@ -224,6 +224,12 @@ type Config struct {
 	// Note: only supports AddressedCall payloads as defined here:
 	// https://github.com/ava-labs/avalanchego/tree/7623ffd4be915a5185c9ed5e11fa9be15a6e1f00/vms/platformvm/warp/payload#addressedcall
 	WarpOffChainMessages []hexutil.Bytes `json:"warp-off-chain-messages"`
+
+	// SubnetOnlyValidator is true if the node is a subnet-only validator.  When
+	// set, the node will use the primary network's validator set to verify
+	// incoming warp messages from the primary network (instead of the subnet's
+	// validator set).
+	SubnetOnlyValidator bool `json:"subnet-only-validator"`
 }
 
 // EthAPIs returns an array of strings representing the Eth APIs that should be enabled

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -844,8 +844,9 @@ func (vm *VM) buildBlockWithContext(ctx context.Context, proposerVMBlockCtx *blo
 		log.Debug("Building block without context")
 	}
 	predicateCtx := &precompileconfig.PredicateContext{
-		SnowCtx:            vm.ctx,
-		ProposerVMBlockCtx: proposerVMBlockCtx,
+		SnowCtx:             vm.ctx,
+		ProposerVMBlockCtx:  proposerVMBlockCtx,
+		SubnetOnlyValidator: vm.config.SubnetOnlyValidator,
 	}
 
 	block, err := vm.miner.GenerateBlock(predicateCtx)

--- a/precompile/contracts/warp/config.go
+++ b/precompile/contracts/warp/config.go
@@ -198,11 +198,16 @@ func (c *Config) VerifyPredicate(predicateContext *precompileconfig.PredicateCon
 	}
 
 	log.Debug("verifying warp message", "warpMsg", warpMsg, "quorumNum", quorumNumerator, "quorumDenom", WarpQuorumDenominator)
+	validatorState := predicateContext.SnowCtx.ValidatorState
+	if !predicateContext.SubnetOnlyValidator {
+		// Wrap validators.State on the chain snow context to special case the Primary Network
+		validatorState = warpValidators.NewState(predicateContext.SnowCtx)
+	}
 	err = warpMsg.Signature.Verify(
 		context.Background(),
 		&warpMsg.UnsignedMessage,
 		predicateContext.SnowCtx.NetworkID,
-		warpValidators.NewState(predicateContext.SnowCtx), // Wrap validators.State on the chain snow context to special case the Primary Network
+		validatorState,
 		predicateContext.ProposerVMBlockCtx.PChainHeight,
 		quorumNumerator,
 		WarpQuorumDenominator,

--- a/precompile/precompileconfig/config.go
+++ b/precompile/precompileconfig/config.go
@@ -38,6 +38,8 @@ type PredicateContext struct {
 	SnowCtx *snow.Context
 	// ProposerVMBlockCtx defines the ProposerVM context the predicate is verified within
 	ProposerVMBlockCtx *block.Context
+	// SubnetOnlyValidator is true if the predicate is being verified within a subnet-only validator
+	SubnetOnlyValidator bool
 }
 
 // Predicater is an optional interface for StatefulPrecompileContracts to implement.


### PR DESCRIPTION
## Why this should be merged
When running in SOV mode, incoming messages from the primary network cannot be verified with the subnet vdrs (since they are not primary network vdrs).

## How this works
Adds a flag that must be specified in the config (`"subnet-only-validator": "true"`)
Since this only disables an optimization it is not a behavior change for non SOV nodes.
TODO: Is there a way to know this in the VM so we don't need this config?

## How this was tested
CI

## How is this documented
Not yet.