### PR TITLE
refactor: make `Role` type a `uint64` and use constants

### DIFF
--- a/precompile/allowlist/allowlist.go
+++ b/precompile/allowlist/allowlist.go
@@ -41,7 +41,11 @@ var (
 func GetAllowListStatus(state contract.StateDB, precompileAddr common.Address, address common.Address) Role {
 	// Generate the state key for [address]
 	addressKey := common.BytesToHash(address.Bytes())
-	return Role(state.GetState(precompileAddr, addressKey))
+	r, err := RoleFromHash(state.GetState(precompileAddr, addressKey))
+	if err != nil {
+		panic(err) // DO NOT MERGE
+	}
+	return r
 }
 
 // SetAllowListRole sets the permissions of [address] to [role] for the precompile

--- a/precompile/allowlist/event.go
+++ b/precompile/allowlist/event.go
@@ -31,7 +31,7 @@ func UnpackRoleSetEventData(dataBytes []byte) (Role, error) {
 	}{}
 	err := AllowListABI.UnpackIntoInterface(&eventData, "RoleSet", dataBytes)
 	if err != nil {
-		return Role{}, err
+		return 0, err
 	}
-	return FromBig(eventData.OldRole)
+	return RoleFromBig(eventData.OldRole)
 }

--- a/precompile/allowlist/role_test.go
+++ b/precompile/allowlist/role_test.go
@@ -10,35 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestIsNoRole(t *testing.T) {
-	tests := []struct {
-		role     Role
-		expected bool
-	}{
-		{
-			role:     ManagerRole,
-			expected: false,
-		},
-		{
-			role:     AdminRole,
-			expected: false,
-		},
-		{
-			role:     EnabledRole,
-			expected: false,
-		},
-		{
-			role:     NoRole,
-			expected: true,
-		},
-	}
-
-	for index, test := range tests {
-		isNoRole := test.role.IsNoRole()
-		require.Equal(t, test.expected, isNoRole, fmt.Sprintf("test index: %d", index))
-	}
-}
-
 func TestIsEnabled(t *testing.T) {
 	tests := []struct {
 		role     Role
@@ -58,6 +29,10 @@ func TestIsEnabled(t *testing.T) {
 		},
 		{
 			role:     NoRole,
+			expected: false,
+		},
+		{
+			role:     firstInvalidRole,
 			expected: false,
 		},
 	}

--- a/precompile/allowlist/test_allowlist.go
+++ b/precompile/allowlist/test_allowlist.go
@@ -499,7 +499,7 @@ func AllowListTests(t testing.TB, module modules.Module) map[string]testutils.Pr
 			},
 			SuppliedGas: ReadAllowListGasCost,
 			ReadOnly:    false,
-			ExpectedRes: common.Hash(NoRole).Bytes(),
+			ExpectedRes: NoRole.Bytes(),
 		},
 		"admin role read allow list": {
 			Caller:     TestAdminAddr,
@@ -511,7 +511,7 @@ func AllowListTests(t testing.TB, module modules.Module) map[string]testutils.Pr
 				return input
 			}, SuppliedGas: ReadAllowListGasCost,
 			ReadOnly:    false,
-			ExpectedRes: common.Hash(AdminRole).Bytes(),
+			ExpectedRes: AdminRole.Bytes(),
 		},
 		"admin read allow list with readOnly enabled": {
 			Caller:     TestAdminAddr,
@@ -523,7 +523,7 @@ func AllowListTests(t testing.TB, module modules.Module) map[string]testutils.Pr
 				return input
 			}, SuppliedGas: ReadAllowListGasCost,
 			ReadOnly:    true,
-			ExpectedRes: common.Hash(NoRole).Bytes(),
+			ExpectedRes: NoRole.Bytes(),
 		},
 		"radmin read allow list out of gas": {
 			Caller:     TestAdminAddr,


### PR DESCRIPTION
## Why this should be merged

## How this works

## How this was tested

## How is this documented
