### PR TITLE
wip: precompile config refactor (avoid import modules in params)

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -36,7 +36,6 @@ import (
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/version"
 	"github.com/ava-labs/subnet-evm/commontype"
-	"github.com/ava-labs/subnet-evm/precompile/modules"
 	"github.com/ava-labs/subnet-evm/precompile/precompileconfig"
 	"github.com/ava-labs/subnet-evm/utils"
 	"github.com/ethereum/go-ethereum/common"
@@ -374,7 +373,7 @@ func (r *Rules) PredicaterExists(addr common.Address) bool {
 
 // IsPrecompileEnabled returns whether precompile with [address] is enabled at [timestamp].
 func (c *ChainConfig) IsPrecompileEnabled(address common.Address, timestamp uint64) bool {
-	config := c.getActivePrecompileConfig(address, timestamp)
+	config := c.GetActivePrecompileConfig(address, timestamp)
 	return config != nil && !config.IsDisabled()
 }
 
@@ -759,8 +758,8 @@ func (c *ChainConfig) Rules(blockNum *big.Int, timestamp uint64) Rules {
 	rules.ActivePrecompiles = make(map[common.Address]precompileconfig.Config)
 	rules.Predicaters = make(map[common.Address]precompileconfig.Predicater)
 	rules.AccepterPrecompiles = make(map[common.Address]precompileconfig.Accepter)
-	for _, module := range modules.RegisteredModules() {
-		if config := c.getActivePrecompileConfig(module.Address, timestamp); config != nil && !config.IsDisabled() {
+	for _, module := range RegisteredModules() {
+		if config := c.GetActivePrecompileConfig(module.Address, timestamp); config != nil && !config.IsDisabled() {
 			rules.ActivePrecompiles[module.Address] = config
 			if predicater, ok := config.(precompileconfig.Predicater); ok {
 				rules.Predicaters[module.Address] = predicater

--- a/params/config_extra_test.go
+++ b/params/config_extra_test.go
@@ -1,0 +1,177 @@
+// (c) 2024 Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package params_test
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/ava-labs/subnet-evm/params"
+	"github.com/ava-labs/subnet-evm/precompile/contracts/nativeminter"
+	"github.com/ava-labs/subnet-evm/precompile/contracts/rewardmanager"
+	"github.com/ava-labs/subnet-evm/precompile/contracts/txallowlist"
+	"github.com/ava-labs/subnet-evm/utils"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigUnmarshalJSON(t *testing.T) {
+	require := require.New(t)
+
+	testRewardManagerConfig := rewardmanager.NewConfig(
+		utils.NewUint64(1671542573),
+		[]common.Address{common.HexToAddress("0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC")},
+		nil,
+		nil,
+		&rewardmanager.InitialRewardConfig{
+			AllowFeeRecipients: true,
+		})
+
+	testContractNativeMinterConfig := nativeminter.NewConfig(
+		utils.NewUint64(0),
+		[]common.Address{common.HexToAddress("0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC")},
+		nil,
+		nil,
+		nil,
+	)
+
+	config := []byte(`
+	{
+		"chainId": 43214,
+		"allowFeeRecipients": true,
+		"rewardManagerConfig": {
+			"blockTimestamp": 1671542573,
+			"adminAddresses": [
+				"0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC"
+			],
+			"initialRewardConfig": {
+				"allowFeeRecipients": true
+			}
+		},
+		"contractNativeMinterConfig": {
+			"blockTimestamp": 0,
+			"adminAddresses": [
+				"0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC"
+			]
+		}
+	}
+	`)
+	c := params.ChainConfig{}
+	err := json.Unmarshal(config, &c)
+	require.NoError(err)
+
+	require.Equal(c.ChainID, big.NewInt(43214))
+	require.Equal(c.AllowFeeRecipients, true)
+
+	rewardManagerConfig, ok := c.GenesisPrecompiles[rewardmanager.ConfigKey]
+	require.True(ok)
+	require.Equal(rewardManagerConfig.Key(), rewardmanager.ConfigKey)
+	require.True(rewardManagerConfig.Equal(testRewardManagerConfig))
+
+	nativeMinterConfig := c.GenesisPrecompiles[nativeminter.ConfigKey]
+	require.Equal(nativeMinterConfig.Key(), nativeminter.ConfigKey)
+	require.True(nativeMinterConfig.Equal(testContractNativeMinterConfig))
+
+	// Marshal and unmarshal again and check that the result is the same
+	marshaled, err := json.Marshal(c)
+	require.NoError(err)
+	c2 := params.ChainConfig{}
+	err = json.Unmarshal(marshaled, &c2)
+	require.NoError(err)
+	require.Equal(c, c2)
+}
+
+func TestActivePrecompiles(t *testing.T) {
+	config := params.ChainConfig{
+		UpgradeConfig: params.UpgradeConfig{
+			PrecompileUpgrades: []params.PrecompileUpgrade{
+				{
+					nativeminter.NewConfig(utils.NewUint64(0), nil, nil, nil, nil), // enable at genesis
+				},
+				{
+					nativeminter.NewDisableConfig(utils.NewUint64(1)), // disable at timestamp 1
+				},
+			},
+		},
+	}
+
+	rules0 := config.Rules(common.Big0, 0)
+	require.True(t, rules0.IsPrecompileEnabled(nativeminter.Module.Address))
+
+	rules1 := config.Rules(common.Big0, 1)
+	require.False(t, rules1.IsPrecompileEnabled(nativeminter.Module.Address))
+}
+
+func TestChainConfigMarshalWithUpgrades(t *testing.T) {
+	config := params.ChainConfigWithUpgradesJSON{
+		ChainConfig: params.ChainConfig{
+			ChainID:             big.NewInt(1),
+			FeeConfig:           params.DefaultFeeConfig,
+			AllowFeeRecipients:  false,
+			HomesteadBlock:      big.NewInt(0),
+			EIP150Block:         big.NewInt(0),
+			EIP155Block:         big.NewInt(0),
+			EIP158Block:         big.NewInt(0),
+			ByzantiumBlock:      big.NewInt(0),
+			ConstantinopleBlock: big.NewInt(0),
+			PetersburgBlock:     big.NewInt(0),
+			IstanbulBlock:       big.NewInt(0),
+			MuirGlacierBlock:    big.NewInt(0),
+			NetworkUpgrades: params.NetworkUpgrades{
+				SubnetEVMTimestamp: utils.NewUint64(0),
+				DurangoTimestamp:   utils.NewUint64(0),
+			},
+			GenesisPrecompiles: params.Precompiles{},
+		},
+		UpgradeConfig: params.UpgradeConfig{
+			PrecompileUpgrades: []params.PrecompileUpgrade{
+				{
+					Config: txallowlist.NewConfig(utils.NewUint64(100), nil, nil, nil),
+				},
+			},
+		},
+	}
+	result, err := json.Marshal(&config)
+	require.NoError(t, err)
+	expectedJSON := `{
+		"chainId": 1,
+		"feeConfig": {
+			"gasLimit": 8000000,
+			"targetBlockRate": 2,
+			"minBaseFee": 25000000000,
+			"targetGas": 15000000,
+			"baseFeeChangeDenominator": 36,
+			"minBlockGasCost": 0,
+			"maxBlockGasCost": 1000000,
+			"blockGasCostStep": 200000
+		},
+		"homesteadBlock": 0,
+		"eip150Block": 0,
+		"eip155Block": 0,
+		"eip158Block": 0,
+		"byzantiumBlock": 0,
+		"constantinopleBlock": 0,
+		"petersburgBlock": 0,
+		"istanbulBlock": 0,
+		"muirGlacierBlock": 0,
+		"subnetEVMTimestamp": 0,
+		"durangoTimestamp": 0,
+		"upgrades": {
+			"precompileUpgrades": [
+				{
+					"txAllowListConfig": {
+						"blockTimestamp": 100
+					}
+				}
+			]
+		}
+	}`
+	require.JSONEq(t, expectedJSON, string(result))
+
+	var unmarshalled params.ChainConfigWithUpgradesJSON
+	err = json.Unmarshal(result, &unmarshalled)
+	require.NoError(t, err)
+	require.Equal(t, config, unmarshalled)
+}

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -27,19 +27,13 @@
 package params
 
 import (
-	"encoding/json"
 	"math"
 	"math/big"
 	"reflect"
 	"testing"
 	"time"
 
-	"github.com/ava-labs/subnet-evm/precompile/contracts/nativeminter"
-	"github.com/ava-labs/subnet-evm/precompile/contracts/rewardmanager"
-	"github.com/ava-labs/subnet-evm/precompile/contracts/txallowlist"
 	"github.com/ava-labs/subnet-evm/utils"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/stretchr/testify/require"
 )
 
 func TestCheckCompatible(t *testing.T) {
@@ -168,163 +162,4 @@ func TestConfigRules(t *testing.T) {
 	if r := c.Rules(big.NewInt(0), stamp); !r.IsSubnetEVM {
 		t.Errorf("expected %v to be subnet-evm", stamp)
 	}
-}
-
-func TestConfigUnmarshalJSON(t *testing.T) {
-	require := require.New(t)
-
-	testRewardManagerConfig := rewardmanager.NewConfig(
-		utils.NewUint64(1671542573),
-		[]common.Address{common.HexToAddress("0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC")},
-		nil,
-		nil,
-		&rewardmanager.InitialRewardConfig{
-			AllowFeeRecipients: true,
-		})
-
-	testContractNativeMinterConfig := nativeminter.NewConfig(
-		utils.NewUint64(0),
-		[]common.Address{common.HexToAddress("0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC")},
-		nil,
-		nil,
-		nil,
-	)
-
-	config := []byte(`
-	{
-		"chainId": 43214,
-		"allowFeeRecipients": true,
-		"rewardManagerConfig": {
-			"blockTimestamp": 1671542573,
-			"adminAddresses": [
-				"0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC"
-			],
-			"initialRewardConfig": {
-				"allowFeeRecipients": true
-			}
-		},
-		"contractNativeMinterConfig": {
-			"blockTimestamp": 0,
-			"adminAddresses": [
-				"0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC"
-			]
-		}
-	}
-	`)
-	c := ChainConfig{}
-	err := json.Unmarshal(config, &c)
-	require.NoError(err)
-
-	require.Equal(c.ChainID, big.NewInt(43214))
-	require.Equal(c.AllowFeeRecipients, true)
-
-	rewardManagerConfig, ok := c.GenesisPrecompiles[rewardmanager.ConfigKey]
-	require.True(ok)
-	require.Equal(rewardManagerConfig.Key(), rewardmanager.ConfigKey)
-	require.True(rewardManagerConfig.Equal(testRewardManagerConfig))
-
-	nativeMinterConfig := c.GenesisPrecompiles[nativeminter.ConfigKey]
-	require.Equal(nativeMinterConfig.Key(), nativeminter.ConfigKey)
-	require.True(nativeMinterConfig.Equal(testContractNativeMinterConfig))
-
-	// Marshal and unmarshal again and check that the result is the same
-	marshaled, err := json.Marshal(c)
-	require.NoError(err)
-	c2 := ChainConfig{}
-	err = json.Unmarshal(marshaled, &c2)
-	require.NoError(err)
-	require.Equal(c, c2)
-}
-
-func TestActivePrecompiles(t *testing.T) {
-	config := ChainConfig{
-		UpgradeConfig: UpgradeConfig{
-			PrecompileUpgrades: []PrecompileUpgrade{
-				{
-					nativeminter.NewConfig(utils.NewUint64(0), nil, nil, nil, nil), // enable at genesis
-				},
-				{
-					nativeminter.NewDisableConfig(utils.NewUint64(1)), // disable at timestamp 1
-				},
-			},
-		},
-	}
-
-	rules0 := config.Rules(common.Big0, 0)
-	require.True(t, rules0.IsPrecompileEnabled(nativeminter.Module.Address))
-
-	rules1 := config.Rules(common.Big0, 1)
-	require.False(t, rules1.IsPrecompileEnabled(nativeminter.Module.Address))
-}
-
-func TestChainConfigMarshalWithUpgrades(t *testing.T) {
-	config := ChainConfigWithUpgradesJSON{
-		ChainConfig: ChainConfig{
-			ChainID:             big.NewInt(1),
-			FeeConfig:           DefaultFeeConfig,
-			AllowFeeRecipients:  false,
-			HomesteadBlock:      big.NewInt(0),
-			EIP150Block:         big.NewInt(0),
-			EIP155Block:         big.NewInt(0),
-			EIP158Block:         big.NewInt(0),
-			ByzantiumBlock:      big.NewInt(0),
-			ConstantinopleBlock: big.NewInt(0),
-			PetersburgBlock:     big.NewInt(0),
-			IstanbulBlock:       big.NewInt(0),
-			MuirGlacierBlock:    big.NewInt(0),
-			NetworkUpgrades: NetworkUpgrades{
-				SubnetEVMTimestamp: utils.NewUint64(0),
-				DurangoTimestamp:   utils.NewUint64(0),
-			},
-			GenesisPrecompiles: Precompiles{},
-		},
-		UpgradeConfig: UpgradeConfig{
-			PrecompileUpgrades: []PrecompileUpgrade{
-				{
-					Config: txallowlist.NewConfig(utils.NewUint64(100), nil, nil, nil),
-				},
-			},
-		},
-	}
-	result, err := json.Marshal(&config)
-	require.NoError(t, err)
-	expectedJSON := `{
-		"chainId": 1,
-		"feeConfig": {
-			"gasLimit": 8000000,
-			"targetBlockRate": 2,
-			"minBaseFee": 25000000000,
-			"targetGas": 15000000,
-			"baseFeeChangeDenominator": 36,
-			"minBlockGasCost": 0,
-			"maxBlockGasCost": 1000000,
-			"blockGasCostStep": 200000
-		},
-		"homesteadBlock": 0,
-		"eip150Block": 0,
-		"eip155Block": 0,
-		"eip158Block": 0,
-		"byzantiumBlock": 0,
-		"constantinopleBlock": 0,
-		"petersburgBlock": 0,
-		"istanbulBlock": 0,
-		"muirGlacierBlock": 0,
-		"subnetEVMTimestamp": 0,
-		"durangoTimestamp": 0,
-		"upgrades": {
-			"precompileUpgrades": [
-				{
-					"txAllowListConfig": {
-						"blockTimestamp": 100
-					}
-				}
-			]
-		}
-	}`
-	require.JSONEq(t, expectedJSON, string(result))
-
-	var unmarshalled ChainConfigWithUpgradesJSON
-	err = json.Unmarshal(result, &unmarshalled)
-	require.NoError(t, err)
-	require.Equal(t, config, unmarshalled)
 }

--- a/params/module.go
+++ b/params/module.go
@@ -1,0 +1,35 @@
+// (c) 2023 Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package params
+
+import (
+	"github.com/ava-labs/subnet-evm/precompile/precompileconfig"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+var RegisteredModules = func() []Module { return nil }
+
+type Module struct {
+	ConfigKey  string
+	Address    common.Address
+	MakeConfig func() precompileconfig.Config
+}
+
+func getPrecompileModule(key string) (Module, bool) {
+	for _, module := range RegisteredModules() {
+		if module.ConfigKey == key {
+			return module, true
+		}
+	}
+	return Module{}, false
+}
+
+func getPrecompileModuleByAddress(addr common.Address) (Module, bool) {
+	for _, module := range RegisteredModules() {
+		if module.Address == addr {
+			return module, true
+		}
+	}
+	return Module{}, false
+}

--- a/params/precompile_config_test.go
+++ b/params/precompile_config_test.go
@@ -1,7 +1,7 @@
 // (c) 2022 Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-package params
+package params_test
 
 import (
 	"encoding/json"
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/ava-labs/subnet-evm/commontype"
+	"github.com/ava-labs/subnet-evm/params"
 	"github.com/ava-labs/subnet-evm/precompile/contracts/deployerallowlist"
 	"github.com/ava-labs/subnet-evm/precompile/contracts/feemanager"
 	"github.com/ava-labs/subnet-evm/precompile/contracts/nativeminter"
@@ -21,12 +22,12 @@ import (
 
 func TestVerifyWithChainConfig(t *testing.T) {
 	admins := []common.Address{{1}}
-	baseConfig := *TestChainConfig
+	baseConfig := *params.TestChainConfig
 	config := &baseConfig
-	config.GenesisPrecompiles = Precompiles{
+	config.GenesisPrecompiles = params.Precompiles{
 		txallowlist.ConfigKey: txallowlist.NewConfig(utils.NewUint64(2), nil, nil, nil),
 	}
-	config.PrecompileUpgrades = []PrecompileUpgrade{
+	config.PrecompileUpgrades = []params.PrecompileUpgrade{
 		{
 			// disable TxAllowList at timestamp 4
 			txallowlist.NewDisableConfig(utils.NewUint64(4)),
@@ -45,7 +46,7 @@ func TestVerifyWithChainConfig(t *testing.T) {
 	badConfig := *config
 	badConfig.PrecompileUpgrades = append(
 		badConfig.PrecompileUpgrades,
-		PrecompileUpgrade{
+		params.PrecompileUpgrade{
 			Config: txallowlist.NewDisableConfig(utils.NewUint64(5)),
 		},
 	)
@@ -56,7 +57,7 @@ func TestVerifyWithChainConfig(t *testing.T) {
 	badConfig = *config
 	badConfig.PrecompileUpgrades = append(
 		badConfig.PrecompileUpgrades,
-		PrecompileUpgrade{
+		params.PrecompileUpgrade{
 			Config: txallowlist.NewConfig(utils.NewUint64(5), admins, nil, nil),
 		},
 	)
@@ -66,14 +67,14 @@ func TestVerifyWithChainConfig(t *testing.T) {
 
 func TestVerifyWithChainConfigAtNilTimestamp(t *testing.T) {
 	admins := []common.Address{{0}}
-	baseConfig := *TestChainConfig
+	baseConfig := *params.TestChainConfig
 	config := &baseConfig
-	config.PrecompileUpgrades = []PrecompileUpgrade{
+	config.PrecompileUpgrades = []params.PrecompileUpgrade{
 		// this does NOT enable the precompile, so it should be upgradeable.
 		{Config: txallowlist.NewConfig(nil, nil, nil, nil)},
 	}
 	require.False(t, config.IsPrecompileEnabled(txallowlist.ContractAddress, 0)) // check the precompile is not enabled.
-	config.PrecompileUpgrades = []PrecompileUpgrade{
+	config.PrecompileUpgrades = []params.PrecompileUpgrade{
 		{
 			// enable TxAllowList at timestamp 5
 			Config: txallowlist.NewConfig(utils.NewUint64(5), admins, nil, nil),
@@ -88,12 +89,12 @@ func TestVerifyPrecompileUpgrades(t *testing.T) {
 	admins := []common.Address{{1}}
 	tests := []struct {
 		name          string
-		upgrades      []PrecompileUpgrade
+		upgrades      []params.PrecompileUpgrade
 		expectedError string
 	}{
 		{
 			name: "enable and disable tx allow list",
-			upgrades: []PrecompileUpgrade{
+			upgrades: []params.PrecompileUpgrade{
 				{
 					Config: txallowlist.NewConfig(utils.NewUint64(1), admins, nil, nil),
 				},
@@ -105,7 +106,7 @@ func TestVerifyPrecompileUpgrades(t *testing.T) {
 		},
 		{
 			name: "invalid allow list config in tx allowlist",
-			upgrades: []PrecompileUpgrade{
+			upgrades: []params.PrecompileUpgrade{
 				{
 					Config: txallowlist.NewConfig(utils.NewUint64(1), admins, nil, nil),
 				},
@@ -120,11 +121,11 @@ func TestVerifyPrecompileUpgrades(t *testing.T) {
 		},
 		{
 			name: "invalid initial fee manager config",
-			upgrades: []PrecompileUpgrade{
+			upgrades: []params.PrecompileUpgrade{
 				{
 					Config: feemanager.NewConfig(utils.NewUint64(3), admins, nil, nil,
 						func() *commontype.FeeConfig {
-							feeConfig := DefaultFeeConfig
+							feeConfig := params.DefaultFeeConfig
 							feeConfig.GasLimit = big.NewInt(-1)
 							return &feeConfig
 						}()),
@@ -134,11 +135,11 @@ func TestVerifyPrecompileUpgrades(t *testing.T) {
 		},
 		{
 			name: "invalid initial fee manager config gas limit 0",
-			upgrades: []PrecompileUpgrade{
+			upgrades: []params.PrecompileUpgrade{
 				{
 					Config: feemanager.NewConfig(utils.NewUint64(3), admins, nil, nil,
 						func() *commontype.FeeConfig {
-							feeConfig := DefaultFeeConfig
+							feeConfig := params.DefaultFeeConfig
 							feeConfig.GasLimit = common.Big0
 							return &feeConfig
 						}()),
@@ -148,7 +149,7 @@ func TestVerifyPrecompileUpgrades(t *testing.T) {
 		},
 		{
 			name: "different upgrades are allowed to configure same timestamp for different precompiles",
-			upgrades: []PrecompileUpgrade{
+			upgrades: []params.PrecompileUpgrade{
 				{
 					Config: txallowlist.NewConfig(utils.NewUint64(1), admins, nil, nil),
 				},
@@ -160,7 +161,7 @@ func TestVerifyPrecompileUpgrades(t *testing.T) {
 		},
 		{
 			name: "different upgrades must be monotonically increasing",
-			upgrades: []PrecompileUpgrade{
+			upgrades: []params.PrecompileUpgrade{
 				{
 					Config: txallowlist.NewConfig(utils.NewUint64(2), admins, nil, nil),
 				},
@@ -172,7 +173,7 @@ func TestVerifyPrecompileUpgrades(t *testing.T) {
 		},
 		{
 			name: "upgrades with same keys are not allowed to configure same timestamp for same precompiles",
-			upgrades: []PrecompileUpgrade{
+			upgrades: []params.PrecompileUpgrade{
 				{
 					Config: txallowlist.NewConfig(utils.NewUint64(1), admins, nil, nil),
 				},
@@ -186,7 +187,7 @@ func TestVerifyPrecompileUpgrades(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
-			baseConfig := *TestChainConfig
+			baseConfig := *params.TestChainConfig
 			config := &baseConfig
 			config.PrecompileUpgrades = tt.upgrades
 
@@ -204,22 +205,22 @@ func TestVerifyPrecompiles(t *testing.T) {
 	admins := []common.Address{{1}}
 	tests := []struct {
 		name          string
-		precompiles   Precompiles
+		precompiles   params.Precompiles
 		expectedError string
 	}{
 		{
 			name: "invalid allow list config in tx allowlist",
-			precompiles: Precompiles{
+			precompiles: params.Precompiles{
 				txallowlist.ConfigKey: txallowlist.NewConfig(utils.NewUint64(3), admins, admins, admins),
 			},
 			expectedError: "cannot set address",
 		},
 		{
 			name: "invalid initial fee manager config",
-			precompiles: Precompiles{
+			precompiles: params.Precompiles{
 				feemanager.ConfigKey: feemanager.NewConfig(utils.NewUint64(3), admins, nil, nil,
 					func() *commontype.FeeConfig {
-						feeConfig := DefaultFeeConfig
+						feeConfig := params.DefaultFeeConfig
 						feeConfig.GasLimit = big.NewInt(-1)
 						return &feeConfig
 					}()),
@@ -230,7 +231,7 @@ func TestVerifyPrecompiles(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
-			baseConfig := *TestChainConfig
+			baseConfig := *params.TestChainConfig
 			config := &baseConfig
 			config.GenesisPrecompiles = tt.precompiles
 
@@ -246,9 +247,9 @@ func TestVerifyPrecompiles(t *testing.T) {
 
 func TestVerifyRequiresSortedTimestamps(t *testing.T) {
 	admins := []common.Address{{1}}
-	baseConfig := *TestChainConfig
+	baseConfig := *params.TestChainConfig
 	config := &baseConfig
-	config.PrecompileUpgrades = []PrecompileUpgrade{
+	config.PrecompileUpgrades = []params.PrecompileUpgrade{
 		{
 			Config: txallowlist.NewConfig(utils.NewUint64(2), admins, nil, nil),
 		},
@@ -264,22 +265,22 @@ func TestVerifyRequiresSortedTimestamps(t *testing.T) {
 
 func TestGetPrecompileConfig(t *testing.T) {
 	require := require.New(t)
-	baseConfig := *TestChainConfig
+	baseConfig := *params.TestChainConfig
 	config := &baseConfig
-	config.GenesisPrecompiles = Precompiles{
+	config.GenesisPrecompiles = params.Precompiles{
 		deployerallowlist.ConfigKey: deployerallowlist.NewConfig(utils.NewUint64(10), nil, nil, nil),
 	}
 
-	deployerConfig := config.getActivePrecompileConfig(deployerallowlist.ContractAddress, 0)
+	deployerConfig := config.GetActivePrecompileConfig(deployerallowlist.ContractAddress, 0)
 	require.Nil(deployerConfig)
 
-	deployerConfig = config.getActivePrecompileConfig(deployerallowlist.ContractAddress, 10)
+	deployerConfig = config.GetActivePrecompileConfig(deployerallowlist.ContractAddress, 10)
 	require.NotNil(deployerConfig)
 
-	deployerConfig = config.getActivePrecompileConfig(deployerallowlist.ContractAddress, 11)
+	deployerConfig = config.GetActivePrecompileConfig(deployerallowlist.ContractAddress, 11)
 	require.NotNil(deployerConfig)
 
-	txAllowListConfig := config.getActivePrecompileConfig(txallowlist.ContractAddress, 0)
+	txAllowListConfig := config.GetActivePrecompileConfig(txallowlist.ContractAddress, 0)
 	require.Nil(txAllowListConfig)
 }
 
@@ -310,7 +311,7 @@ func TestPrecompileUpgradeUnmarshalJSON(t *testing.T) {
 			}
 	`)
 
-	var upgradeConfig UpgradeConfig
+	var upgradeConfig params.UpgradeConfig
 	err := json.Unmarshal(upgradeBytes, &upgradeConfig)
 	require.NoError(err)
 
@@ -336,7 +337,7 @@ func TestPrecompileUpgradeUnmarshalJSON(t *testing.T) {
 	// Marshal and unmarshal again and check that the result is the same
 	upgradeBytes2, err := json.Marshal(upgradeConfig)
 	require.NoError(err)
-	var upgradeConfig2 UpgradeConfig
+	var upgradeConfig2 params.UpgradeConfig
 	err = json.Unmarshal(upgradeBytes2, &upgradeConfig2)
 	require.NoError(err)
 	require.Equal(upgradeConfig, upgradeConfig2)

--- a/params/precompile_upgrade.go
+++ b/params/precompile_upgrade.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/ava-labs/subnet-evm/precompile/modules"
 	"github.com/ava-labs/subnet-evm/precompile/precompileconfig"
 	"github.com/ava-labs/subnet-evm/utils"
 	"github.com/ethereum/go-ethereum/common"
@@ -40,7 +39,7 @@ func (u *PrecompileUpgrade) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("PrecompileUpgrade must have exactly one key, got %d", len(raw))
 	}
 	for key, value := range raw {
-		module, ok := modules.GetPrecompileModule(key)
+		module, ok := getPrecompileModule(key)
 		if !ok {
 			return fmt.Errorf("unknown precompile config: %s", key)
 		}
@@ -147,9 +146,9 @@ func (c *ChainConfig) verifyPrecompileUpgrades() error {
 	return nil
 }
 
-// getActivePrecompileConfig returns the most recent precompile config corresponding to [address].
+// GetActivePrecompileConfig returns the most recent precompile config corresponding to [address].
 // If none have occurred, returns nil.
-func (c *ChainConfig) getActivePrecompileConfig(address common.Address, timestamp uint64) precompileconfig.Config {
+func (c *ChainConfig) GetActivePrecompileConfig(address common.Address, timestamp uint64) precompileconfig.Config {
 	configs := c.GetActivatingPrecompileConfigs(address, nil, timestamp, c.PrecompileUpgrades)
 	if len(configs) == 0 {
 		return nil
@@ -161,7 +160,7 @@ func (c *ChainConfig) getActivePrecompileConfig(address common.Address, timestam
 // state transition from a block with timestamp [from] to a block with timestamp [to].
 func (c *ChainConfig) GetActivatingPrecompileConfigs(address common.Address, from *uint64, to uint64, upgrades []PrecompileUpgrade) []precompileconfig.Config {
 	// Get key from address.
-	module, ok := modules.GetPrecompileModuleByAddress(address)
+	module, ok := getPrecompileModuleByAddress(address)
 	if !ok {
 		return nil
 	}
@@ -194,7 +193,7 @@ func (c *ChainConfig) GetActivatingPrecompileConfigs(address common.Address, fro
 // This ensures that as long as the node has not accepted a block with a different rule set it will allow a
 // new upgrade to be applied as long as it activates after the last accepted block.
 func (c *ChainConfig) CheckPrecompilesCompatible(precompileUpgrades []PrecompileUpgrade, time uint64) *ConfigCompatError {
-	for _, module := range modules.RegisteredModules() {
+	for _, module := range RegisteredModules() {
 		if err := c.checkPrecompileCompatible(module.Address, precompileUpgrades, time); err != nil {
 			return err
 		}
@@ -247,8 +246,8 @@ func (c *ChainConfig) checkPrecompileCompatible(address common.Address, precompi
 // EnabledStatefulPrecompiles returns current stateful precompile configs that are enabled at [blockTimestamp].
 func (c *ChainConfig) EnabledStatefulPrecompiles(blockTimestamp uint64) Precompiles {
 	statefulPrecompileConfigs := make(Precompiles)
-	for _, module := range modules.RegisteredModules() {
-		if config := c.getActivePrecompileConfig(module.Address, blockTimestamp); config != nil && !config.IsDisabled() {
+	for _, module := range RegisteredModules() {
+		if config := c.GetActivePrecompileConfig(module.Address, blockTimestamp); config != nil && !config.IsDisabled() {
 			statefulPrecompileConfigs[module.ConfigKey] = config
 		}
 	}

--- a/params/precompile_upgrade_test.go
+++ b/params/precompile_upgrade_test.go
@@ -1,11 +1,12 @@
 // (c) 2022, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-package params
+package params_test
 
 import (
 	"testing"
 
+	"github.com/ava-labs/subnet-evm/params"
 	"github.com/ava-labs/subnet-evm/precompile/contracts/deployerallowlist"
 	"github.com/ava-labs/subnet-evm/precompile/contracts/txallowlist"
 	"github.com/ava-labs/subnet-evm/utils"
@@ -15,20 +16,20 @@ import (
 
 func TestVerifyUpgradeConfig(t *testing.T) {
 	admins := []common.Address{{1}}
-	chainConfig := *TestChainConfig
-	chainConfig.GenesisPrecompiles = Precompiles{
+	chainConfig := *params.TestChainConfig
+	chainConfig.GenesisPrecompiles = params.Precompiles{
 		txallowlist.ConfigKey: txallowlist.NewConfig(utils.NewUint64(1), admins, nil, nil),
 	}
 
 	type test struct {
-		upgrades            []PrecompileUpgrade
+		upgrades            []params.PrecompileUpgrade
 		expectedErrorString string
 	}
 
 	tests := map[string]test{
 		"upgrade bytes conflicts with genesis (re-enable without disable)": {
 			expectedErrorString: "disable should be [true]",
-			upgrades: []PrecompileUpgrade{
+			upgrades: []params.PrecompileUpgrade{
 				{
 					Config: txallowlist.NewConfig(utils.NewUint64(2), admins, nil, nil),
 				},
@@ -36,7 +37,7 @@ func TestVerifyUpgradeConfig(t *testing.T) {
 		},
 		"upgrade bytes conflicts with genesis (disable before enable)": {
 			expectedErrorString: "config block timestamp (0) <= previous timestamp (1) of same key",
-			upgrades: []PrecompileUpgrade{
+			upgrades: []params.PrecompileUpgrade{
 				{
 					Config: txallowlist.NewDisableConfig(utils.NewUint64(0)),
 				},
@@ -44,7 +45,7 @@ func TestVerifyUpgradeConfig(t *testing.T) {
 		},
 		"upgrade bytes conflicts with genesis (disable same time as enable)": {
 			expectedErrorString: "config block timestamp (1) <= previous timestamp (1) of same key",
-			upgrades: []PrecompileUpgrade{
+			upgrades: []params.PrecompileUpgrade{
 				{
 					Config: txallowlist.NewDisableConfig(utils.NewUint64(1)),
 				},
@@ -72,8 +73,8 @@ func TestVerifyUpgradeConfig(t *testing.T) {
 
 func TestCheckCompatibleUpgradeConfigs(t *testing.T) {
 	admins := []common.Address{{1}}
-	chainConfig := *TestChainConfig
-	chainConfig.GenesisPrecompiles = Precompiles{
+	chainConfig := *params.TestChainConfig
+	chainConfig.GenesisPrecompiles = params.Precompiles{
 		txallowlist.ConfigKey:       txallowlist.NewConfig(utils.NewUint64(1), admins, nil, nil),
 		deployerallowlist.ConfigKey: deployerallowlist.NewConfig(utils.NewUint64(10), admins, nil, nil),
 	}
@@ -81,9 +82,9 @@ func TestCheckCompatibleUpgradeConfigs(t *testing.T) {
 	tests := map[string]upgradeCompatibilityTest{
 		"disable and re-enable": {
 			startTimestamps: []uint64{5},
-			configs: []*UpgradeConfig{
+			configs: []*params.UpgradeConfig{
 				{
-					PrecompileUpgrades: []PrecompileUpgrade{
+					PrecompileUpgrades: []params.PrecompileUpgrade{
 						{
 							Config: txallowlist.NewDisableConfig(utils.NewUint64(6)),
 						},
@@ -96,9 +97,9 @@ func TestCheckCompatibleUpgradeConfigs(t *testing.T) {
 		},
 		"disable and re-enable, reschedule upgrade before it happens": {
 			startTimestamps: []uint64{5, 6},
-			configs: []*UpgradeConfig{
+			configs: []*params.UpgradeConfig{
 				{
-					PrecompileUpgrades: []PrecompileUpgrade{
+					PrecompileUpgrades: []params.PrecompileUpgrade{
 						{
 							Config: txallowlist.NewDisableConfig(utils.NewUint64(6)),
 						},
@@ -108,7 +109,7 @@ func TestCheckCompatibleUpgradeConfigs(t *testing.T) {
 					},
 				},
 				{
-					PrecompileUpgrades: []PrecompileUpgrade{
+					PrecompileUpgrades: []params.PrecompileUpgrade{
 						{
 							Config: txallowlist.NewDisableConfig(utils.NewUint64(6)),
 						},
@@ -122,9 +123,9 @@ func TestCheckCompatibleUpgradeConfigs(t *testing.T) {
 		"disable and re-enable, reschedule upgrade after it happens": {
 			expectedErrorString: "mismatching PrecompileUpgrade",
 			startTimestamps:     []uint64{5, 8},
-			configs: []*UpgradeConfig{
+			configs: []*params.UpgradeConfig{
 				{
-					PrecompileUpgrades: []PrecompileUpgrade{
+					PrecompileUpgrades: []params.PrecompileUpgrade{
 						{
 							Config: txallowlist.NewDisableConfig(utils.NewUint64(6)),
 						},
@@ -134,7 +135,7 @@ func TestCheckCompatibleUpgradeConfigs(t *testing.T) {
 					},
 				},
 				{
-					PrecompileUpgrades: []PrecompileUpgrade{
+					PrecompileUpgrades: []params.PrecompileUpgrade{
 						{
 							Config: txallowlist.NewDisableConfig(utils.NewUint64(6)),
 						},
@@ -147,9 +148,9 @@ func TestCheckCompatibleUpgradeConfigs(t *testing.T) {
 		},
 		"disable and re-enable, cancel upgrade before it happens": {
 			startTimestamps: []uint64{5, 6},
-			configs: []*UpgradeConfig{
+			configs: []*params.UpgradeConfig{
 				{
-					PrecompileUpgrades: []PrecompileUpgrade{
+					PrecompileUpgrades: []params.PrecompileUpgrade{
 						{
 							Config: txallowlist.NewDisableConfig(utils.NewUint64(6)),
 						},
@@ -159,7 +160,7 @@ func TestCheckCompatibleUpgradeConfigs(t *testing.T) {
 					},
 				},
 				{
-					PrecompileUpgrades: []PrecompileUpgrade{
+					PrecompileUpgrades: []params.PrecompileUpgrade{
 						{
 							Config: txallowlist.NewDisableConfig(utils.NewUint64(6)),
 						},
@@ -170,9 +171,9 @@ func TestCheckCompatibleUpgradeConfigs(t *testing.T) {
 		"disable and re-enable, cancel upgrade after it happens": {
 			expectedErrorString: "mismatching missing PrecompileUpgrade",
 			startTimestamps:     []uint64{5, 8},
-			configs: []*UpgradeConfig{
+			configs: []*params.UpgradeConfig{
 				{
-					PrecompileUpgrades: []PrecompileUpgrade{
+					PrecompileUpgrades: []params.PrecompileUpgrade{
 						{
 							Config: txallowlist.NewDisableConfig(utils.NewUint64(6)),
 						},
@@ -182,7 +183,7 @@ func TestCheckCompatibleUpgradeConfigs(t *testing.T) {
 					},
 				},
 				{
-					PrecompileUpgrades: []PrecompileUpgrade{
+					PrecompileUpgrades: []params.PrecompileUpgrade{
 						{
 							Config: txallowlist.NewDisableConfig(utils.NewUint64(6)),
 						},
@@ -193,9 +194,9 @@ func TestCheckCompatibleUpgradeConfigs(t *testing.T) {
 		"disable and re-enable, change upgrade config after upgrade not allowed": {
 			expectedErrorString: "mismatching PrecompileUpgrade",
 			startTimestamps:     []uint64{5, 8},
-			configs: []*UpgradeConfig{
+			configs: []*params.UpgradeConfig{
 				{
-					PrecompileUpgrades: []PrecompileUpgrade{
+					PrecompileUpgrades: []params.PrecompileUpgrade{
 						{
 							Config: txallowlist.NewDisableConfig(utils.NewUint64(6)),
 						},
@@ -205,7 +206,7 @@ func TestCheckCompatibleUpgradeConfigs(t *testing.T) {
 					},
 				},
 				{
-					PrecompileUpgrades: []PrecompileUpgrade{
+					PrecompileUpgrades: []params.PrecompileUpgrade{
 						{
 							Config: txallowlist.NewDisableConfig(utils.NewUint64(6)),
 						},
@@ -219,9 +220,9 @@ func TestCheckCompatibleUpgradeConfigs(t *testing.T) {
 		},
 		"disable and re-enable, identical upgrade config should be accepted": {
 			startTimestamps: []uint64{5, 8},
-			configs: []*UpgradeConfig{
+			configs: []*params.UpgradeConfig{
 				{
-					PrecompileUpgrades: []PrecompileUpgrade{
+					PrecompileUpgrades: []params.PrecompileUpgrade{
 						{
 							Config: txallowlist.NewDisableConfig(utils.NewUint64(6)),
 						},
@@ -231,7 +232,7 @@ func TestCheckCompatibleUpgradeConfigs(t *testing.T) {
 					},
 				},
 				{
-					PrecompileUpgrades: []PrecompileUpgrade{
+					PrecompileUpgrades: []params.PrecompileUpgrade{
 						{
 							Config: txallowlist.NewDisableConfig(utils.NewUint64(6)),
 						},
@@ -245,9 +246,9 @@ func TestCheckCompatibleUpgradeConfigs(t *testing.T) {
 		"retroactively enabling upgrades is not allowed": {
 			expectedErrorString: "cannot retroactively enable PrecompileUpgrade[1] in database (have timestamp nil, want timestamp 5, rewindto timestamp 4)",
 			startTimestamps:     []uint64{6},
-			configs: []*UpgradeConfig{
+			configs: []*params.UpgradeConfig{
 				{
-					PrecompileUpgrades: []PrecompileUpgrade{
+					PrecompileUpgrades: []params.PrecompileUpgrade{
 						{
 							Config: txallowlist.NewDisableConfig(utils.NewUint64(5)),
 						},
@@ -268,18 +269,18 @@ func TestCheckCompatibleUpgradeConfigs(t *testing.T) {
 }
 
 type upgradeCompatibilityTest struct {
-	configs             []*UpgradeConfig
+	configs             []*params.UpgradeConfig
 	startTimestamps     []uint64
 	expectedErrorString string
 }
 
-func (tt *upgradeCompatibilityTest) run(t *testing.T, chainConfig ChainConfig) {
+func (tt *upgradeCompatibilityTest) run(t *testing.T, chainConfig params.ChainConfig) {
 	// apply all the upgrade bytes specified in order
 	for i, upgrade := range tt.configs {
 		newCfg := chainConfig
 		newCfg.UpgradeConfig = *upgrade
 
-		err := chainConfig.checkCompatible(&newCfg, nil, tt.startTimestamps[i])
+		err := chainConfig.CheckCompatible(&newCfg, 0, tt.startTimestamps[i])
 
 		// if this is not the final upgradeBytes, continue applying
 		// the next upgradeBytes. (only check the result on the last apply)

--- a/params/precompiles.go
+++ b/params/precompiles.go
@@ -6,7 +6,6 @@ package params
 import (
 	"encoding/json"
 
-	"github.com/ava-labs/subnet-evm/precompile/modules"
 	"github.com/ava-labs/subnet-evm/precompile/precompileconfig"
 )
 
@@ -22,7 +21,7 @@ func (ccp *Precompiles) UnmarshalJSON(data []byte) error {
 	}
 
 	*ccp = make(Precompiles)
-	for _, module := range modules.RegisteredModules() {
+	for _, module := range RegisteredModules() {
 		key := module.ConfigKey
 		if value, ok := raw[key]; ok {
 			conf := module.MakeConfig()

--- a/params/state_upgrade_test.go
+++ b/params/state_upgrade_test.go
@@ -1,13 +1,14 @@
 // (c) 2022, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-package params
+package params_test
 
 import (
 	"encoding/json"
 	"math/big"
 	"testing"
 
+	"github.com/ava-labs/subnet-evm/params"
 	"github.com/ava-labs/subnet-evm/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
@@ -15,26 +16,26 @@ import (
 )
 
 func TestVerifyStateUpgrades(t *testing.T) {
-	modifiedAccounts := map[common.Address]StateUpgradeAccount{
+	modifiedAccounts := map[common.Address]params.StateUpgradeAccount{
 		{1}: {
 			BalanceChange: (*math.HexOrDecimal256)(common.Big1),
 		},
 	}
 	tests := []struct {
 		name          string
-		upgrades      []StateUpgrade
+		upgrades      []params.StateUpgrade
 		expectedError string
 	}{
 		{
 			name: "valid upgrade",
-			upgrades: []StateUpgrade{
+			upgrades: []params.StateUpgrade{
 				{BlockTimestamp: utils.NewUint64(1), StateUpgradeAccounts: modifiedAccounts},
 				{BlockTimestamp: utils.NewUint64(2), StateUpgradeAccounts: modifiedAccounts},
 			},
 		},
 		{
 			name: "upgrade block timestamp is not strictly increasing",
-			upgrades: []StateUpgrade{
+			upgrades: []params.StateUpgrade{
 				{BlockTimestamp: utils.NewUint64(1), StateUpgradeAccounts: modifiedAccounts},
 				{BlockTimestamp: utils.NewUint64(1), StateUpgradeAccounts: modifiedAccounts},
 			},
@@ -42,7 +43,7 @@ func TestVerifyStateUpgrades(t *testing.T) {
 		},
 		{
 			name: "upgrade block timestamp decreases",
-			upgrades: []StateUpgrade{
+			upgrades: []params.StateUpgrade{
 				{BlockTimestamp: utils.NewUint64(2), StateUpgradeAccounts: modifiedAccounts},
 				{BlockTimestamp: utils.NewUint64(1), StateUpgradeAccounts: modifiedAccounts},
 			},
@@ -50,7 +51,7 @@ func TestVerifyStateUpgrades(t *testing.T) {
 		},
 		{
 			name: "upgrade block timestamp is zero",
-			upgrades: []StateUpgrade{
+			upgrades: []params.StateUpgrade{
 				{BlockTimestamp: utils.NewUint64(0), StateUpgradeAccounts: modifiedAccounts},
 			},
 			expectedError: "config block timestamp (0) must be greater than 0",
@@ -59,7 +60,7 @@ func TestVerifyStateUpgrades(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
-			baseConfig := *TestChainConfig
+			baseConfig := *params.TestChainConfig
 			config := &baseConfig
 			config.StateUpgrades = tt.upgrades
 
@@ -74,25 +75,25 @@ func TestVerifyStateUpgrades(t *testing.T) {
 }
 
 func TestCheckCompatibleStateUpgrades(t *testing.T) {
-	chainConfig := *TestChainConfig
-	stateUpgrade := map[common.Address]StateUpgradeAccount{
+	chainConfig := *params.TestChainConfig
+	stateUpgrade := map[common.Address]params.StateUpgradeAccount{
 		{1}: {BalanceChange: (*math.HexOrDecimal256)(common.Big1)},
 	}
-	differentStateUpgrade := map[common.Address]StateUpgradeAccount{
+	differentStateUpgrade := map[common.Address]params.StateUpgradeAccount{
 		{2}: {BalanceChange: (*math.HexOrDecimal256)(common.Big1)},
 	}
 
 	tests := map[string]upgradeCompatibilityTest{
 		"reschedule upgrade before it happens": {
 			startTimestamps: []uint64{5, 6},
-			configs: []*UpgradeConfig{
+			configs: []*params.UpgradeConfig{
 				{
-					StateUpgrades: []StateUpgrade{
+					StateUpgrades: []params.StateUpgrade{
 						{BlockTimestamp: utils.NewUint64(6), StateUpgradeAccounts: stateUpgrade},
 					},
 				},
 				{
-					StateUpgrades: []StateUpgrade{
+					StateUpgrades: []params.StateUpgrade{
 						{BlockTimestamp: utils.NewUint64(6), StateUpgradeAccounts: stateUpgrade},
 					},
 				},
@@ -101,15 +102,15 @@ func TestCheckCompatibleStateUpgrades(t *testing.T) {
 		"modify upgrade after it happens not allowed": {
 			expectedErrorString: "mismatching StateUpgrade",
 			startTimestamps:     []uint64{5, 8},
-			configs: []*UpgradeConfig{
+			configs: []*params.UpgradeConfig{
 				{
-					StateUpgrades: []StateUpgrade{
+					StateUpgrades: []params.StateUpgrade{
 						{BlockTimestamp: utils.NewUint64(6), StateUpgradeAccounts: stateUpgrade},
 						{BlockTimestamp: utils.NewUint64(7), StateUpgradeAccounts: stateUpgrade},
 					},
 				},
 				{
-					StateUpgrades: []StateUpgrade{
+					StateUpgrades: []params.StateUpgrade{
 						{BlockTimestamp: utils.NewUint64(6), StateUpgradeAccounts: stateUpgrade},
 						{BlockTimestamp: utils.NewUint64(7), StateUpgradeAccounts: differentStateUpgrade},
 					},
@@ -118,15 +119,15 @@ func TestCheckCompatibleStateUpgrades(t *testing.T) {
 		},
 		"cancel upgrade before it happens": {
 			startTimestamps: []uint64{5, 6},
-			configs: []*UpgradeConfig{
+			configs: []*params.UpgradeConfig{
 				{
-					StateUpgrades: []StateUpgrade{
+					StateUpgrades: []params.StateUpgrade{
 						{BlockTimestamp: utils.NewUint64(6), StateUpgradeAccounts: stateUpgrade},
 						{BlockTimestamp: utils.NewUint64(7), StateUpgradeAccounts: stateUpgrade},
 					},
 				},
 				{
-					StateUpgrades: []StateUpgrade{
+					StateUpgrades: []params.StateUpgrade{
 						{BlockTimestamp: utils.NewUint64(6), StateUpgradeAccounts: stateUpgrade},
 					},
 				},
@@ -135,9 +136,9 @@ func TestCheckCompatibleStateUpgrades(t *testing.T) {
 		"retroactively enabling upgrades is not allowed": {
 			expectedErrorString: "cannot retroactively enable StateUpgrade[0] in database (have timestamp nil, want timestamp 5, rewindto timestamp 4)",
 			startTimestamps:     []uint64{6},
-			configs: []*UpgradeConfig{
+			configs: []*params.UpgradeConfig{
 				{
-					StateUpgrades: []StateUpgrade{
+					StateUpgrades: []params.StateUpgrade{
 						{BlockTimestamp: utils.NewUint64(5), StateUpgradeAccounts: stateUpgrade},
 					},
 				},
@@ -168,11 +169,11 @@ func TestUnmarshalStateUpgradeJSON(t *testing.T) {
 		}`,
 	)
 
-	upgradeConfig := UpgradeConfig{
-		StateUpgrades: []StateUpgrade{
+	upgradeConfig := params.UpgradeConfig{
+		StateUpgrades: []params.StateUpgrade{
 			{
 				BlockTimestamp: utils.NewUint64(1677608400),
-				StateUpgradeAccounts: map[common.Address]StateUpgradeAccount{
+				StateUpgradeAccounts: map[common.Address]params.StateUpgradeAccount{
 					common.HexToAddress("0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC"): {
 						BalanceChange: (*math.HexOrDecimal256)(big.NewInt(100)),
 					},
@@ -180,7 +181,7 @@ func TestUnmarshalStateUpgradeJSON(t *testing.T) {
 			},
 		},
 	}
-	var unmarshaledConfig UpgradeConfig
+	var unmarshaledConfig params.UpgradeConfig
 	err := json.Unmarshal(jsonBytes, &unmarshaledConfig)
 	require.NoError(t, err)
 	require.Equal(t, upgradeConfig, unmarshaledConfig)

--- a/precompile/contract/interfaces.go
+++ b/precompile/contract/interfaces.go
@@ -8,9 +8,12 @@ import (
 	"math/big"
 
 	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/subnet-evm/core/types"
 	"github.com/ava-labs/subnet-evm/precompile/precompileconfig"
 	"github.com/ethereum/go-ethereum/common"
 )
+
+type Log = types.Log
 
 // StatefulPrecompiledContract is the interface for executing a precompiled contract
 type StatefulPrecompiledContract interface {

--- a/precompile/modules/registerer.go
+++ b/precompile/modules/registerer.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 
 	"github.com/ava-labs/subnet-evm/constants"
+	"github.com/ava-labs/subnet-evm/params"
 	"github.com/ava-labs/subnet-evm/utils"
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -32,6 +33,20 @@ var (
 		},
 	}
 )
+
+func init() {
+	params.RegisteredModules = func() []params.Module {
+		modules := make([]params.Module, len(registeredModules))
+		for i, stm := range registeredModules {
+			modules[i] = params.Module{
+				ConfigKey:  stm.ConfigKey,
+				Address:    stm.Address,
+				MakeConfig: stm.MakeConfig,
+			}
+		}
+		return modules
+	}
+}
 
 // ReservedAddress returns true if [addr] is in a reserved range for custom precompiles
 func ReservedAddress(addr common.Address) bool {


### PR DESCRIPTION
## Why this should be merged
avoid import precompiles/modules in params

## How this works
makes it a global variable in params, so the direction of the dependency is reversed.

## How this was tested

## How is this documented
