### PR TITLE
use default path to build, remove symlinking

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -19,7 +19,7 @@ source "$SUBNET_EVM_PATH"/scripts/constants.sh
 if [[ $# -eq 1 ]]; then
     BINARY_PATH=$1
 elif [[ $# -eq 0 ]]; then
-    BINARY_PATH="${SUBNET_EVM_PATH}/build/subnet-evm"
+    BINARY_PATH="$DEFAULT_PLUGIN_DIR/$DEFAULT_VM_ID"
 else
     echo "Invalid arguments to build subnet-evm. Requires zero (default binary path) or one argument to specify the binary path."
     exit 1
@@ -28,8 +28,3 @@ fi
 # Build Subnet EVM, which is run as a subprocess
 echo "Building Subnet EVM @ GitCommit: $SUBNET_EVM_COMMIT at $BINARY_PATH"
 go build -ldflags "-X github.com/ava-labs/subnet-evm/plugin/evm.GitCommit=$SUBNET_EVM_COMMIT $STATIC_LD_FLAGS" -o "$BINARY_PATH" "plugin/"*.go
-
-PLUGIN_PATH="${DEFAULT_PLUGIN_DIR}/srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy"
-echo "Symlinking ${BINARY_PATH} to ${PLUGIN_PATH}"
-mkdir -p "${DEFAULT_PLUGIN_DIR}"
-ln -sf "${BINARY_PATH}" "${PLUGIN_PATH}"

--- a/scripts/constants.sh
+++ b/scripts/constants.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 # Set the PATHS
 GOPATH="$(go env GOPATH)"
 DEFAULT_PLUGIN_DIR="${HOME}/.avalanchego/plugins"
+DEFAULT_VM_ID="srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy"
 
 # Avalabs docker hub
 # avaplatform/avalanchego - defaults to local as to avoid unintentional pushes


### PR DESCRIPTION
## Why this should be merged

VMIDs are not constant for repos but per-chain, thus plugin binaries can be created with any name. 

## How this works

If no parameter is provided, defaults to avalanchego plugin folder path
Removes symlinking with constant VM ID.

## How this was tested

Locally

## How is this documented

No need
