### PR TITLE
fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN [ -d ./build ] && rm -rf ./build/* || true
 ARG SUBNET_EVM_COMMIT
 ARG CURRENT_BRANCH
 
-RUN export SUBNET_EVM_COMMIT=$SUBNET_EVM_COMMIT && export CURRENT_BRANCH=$CURRENT_BRANCH && ./scripts/build.sh
+RUN export SUBNET_EVM_COMMIT=$SUBNET_EVM_COMMIT && export CURRENT_BRANCH=$CURRENT_BRANCH && ./scripts/build.sh build/subnet-evm
 
 # ============= Cleanup Stage ================
 FROM avaplatform/avalanchego:$AVALANCHE_VERSION AS builtImage

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -4,7 +4,7 @@
 # shellcheck disable=SC2034
 
 # Don't export them as they're used in the context of other calls
-AVALANCHE_VERSION=${AVALANCHE_VERSION:-'479145a6602dfc6263c3d7842d26d7c7be7d5991'}
+AVALANCHE_VERSION=${AVALANCHE_VERSION:-'479145a6'}
 GINKGO_VERSION=${GINKGO_VERSION:-'v2.2.0'}
 
 # This won't be used, but it's here to make code syncs easier


### PR DESCRIPTION
- the next lines in the dockerfile are looking for the binary at build/subnet-evm so build it there
- the shorter commit matches a dockerhub tag so it's possible to use that to build a subnet-evm docker image, but not the full commit. for this reason I think we should prefer the shorter commit refs for avalanchego version.