### PR TITLE
handle accepted/pending tx subs separately

### DIFF
--- a/eth/filters/filter_system.go
+++ b/eth/filters/filter_system.go
@@ -526,7 +526,7 @@ func (es *EventSystem) handleTxsEvent(filters filterIndex, ev core.NewTxsEvent) 
 	}
 }
 
-func (es *EventSystem) handleAcceptedTxsEvent(filters filterIndex, ev core.NewTxsEvent) {
+func (es *EventSystem) handleTxsAcceptedEvent(filters filterIndex, ev core.NewTxsEvent) {
 	for _, f := range filters[AcceptedTransactionsSubscription] {
 		f.txs <- ev.Txs
 	}
@@ -580,7 +580,7 @@ func (es *EventSystem) eventLoop() {
 		case ev := <-es.chainAcceptedCh:
 			es.handleChainAcceptedEvent(index, ev)
 		case ev := <-es.txsAcceptedCh:
-			es.handleAcceptedTxsEvent(index, ev)
+			es.handleTxsAcceptedEvent(index, ev)
 
 		case f := <-es.install:
 			if f.typ == MinedAndPendingLogsSubscription {

--- a/eth/filters/filter_system.go
+++ b/eth/filters/filter_system.go
@@ -520,14 +520,15 @@ func (es *EventSystem) handlePendingLogs(filters filterIndex, ev []*types.Log) {
 	}
 }
 
-func (es *EventSystem) handleTxsEvent(filters filterIndex, ev core.NewTxsEvent, accepted bool) {
+func (es *EventSystem) handleTxsEvent(filters filterIndex, ev core.NewTxsEvent) {
 	for _, f := range filters[PendingTransactionsSubscription] {
 		f.txs <- ev.Txs
 	}
-	if accepted {
-		for _, f := range filters[AcceptedTransactionsSubscription] {
-			f.txs <- ev.Txs
-		}
+}
+
+func (es *EventSystem) handleAcceptedTxsEvent(filters filterIndex, ev core.NewTxsEvent) {
+	for _, f := range filters[AcceptedTransactionsSubscription] {
+		f.txs <- ev.Txs
 	}
 }
 
@@ -565,7 +566,7 @@ func (es *EventSystem) eventLoop() {
 	for {
 		select {
 		case ev := <-es.txsCh:
-			es.handleTxsEvent(index, ev, false)
+			es.handleTxsEvent(index, ev)
 		case ev := <-es.logsCh:
 			es.handleLogs(index, ev)
 		case ev := <-es.logsAcceptedCh:
@@ -579,7 +580,7 @@ func (es *EventSystem) eventLoop() {
 		case ev := <-es.chainAcceptedCh:
 			es.handleChainAcceptedEvent(index, ev)
 		case ev := <-es.txsAcceptedCh:
-			es.handleTxsEvent(index, ev, true)
+			es.handleAcceptedTxsEvent(index, ev)
 
 		case f := <-es.install:
 			if f.typ == MinedAndPendingLogsSubscription {


### PR DESCRIPTION
## Why this should be merged
Current code seems to mix the handling of pending/accepted txs.
As is the `accepted` bool doesn't impact whether or not the tx is published to the pending feed.

## How this works
Separate code paths

## How this was tested
CI (maybe needs a ut)

## How is this documented
N/A