### PR TITLE
use ctx network upgrades

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -57,7 +57,7 @@ var (
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
 		MuirGlacierBlock:    big.NewInt(0),
-		NetworkUpgrades:     getDefaultNetworkUpgrades(constants.MainnetID), // This can be changed to correct network (local, test) via VM.
+		NetworkUpgrades:     getDefaultNetworkUpgrades(upgrade.GetConfig(constants.MainnetID)), // This can be changed to correct network (local, test) via VM.
 		GenesisPrecompiles:  Precompiles{},
 	}
 
@@ -76,7 +76,7 @@ var (
 		IstanbulBlock:       big.NewInt(0),
 		MuirGlacierBlock:    big.NewInt(0),
 		CancunTime:          utils.TimeToNewUint64(upgrade.GetConfig(constants.UnitTestID).EtnaTime),
-		NetworkUpgrades:     getDefaultNetworkUpgrades(constants.UnitTestID),
+		NetworkUpgrades:     getDefaultNetworkUpgrades(upgrade.GetConfig(constants.UnitTestID)), // This can be changed to correct network (local, test) via VM.
 		GenesisPrecompiles:  Precompiles{},
 		UpgradeConfig:       UpgradeConfig{},
 	}

--- a/params/config_extra.go
+++ b/params/config_extra.go
@@ -197,7 +197,7 @@ func (c *ChainConfig) Verify() error {
 	}
 
 	// Verify the network upgrades are internally consistent given the existing chainConfig.
-	if err := c.verifyNetworkUpgrades(c.SnowCtx.NetworkID); err != nil {
+	if err := c.verifyNetworkUpgrades(c.SnowCtx.NetworkUpgrades); err != nil {
 		return fmt.Errorf("invalid network upgrades: %w", err)
 	}
 
@@ -261,7 +261,7 @@ func (c *ChainConfig) SetNetworkUpgradeDefaults() {
 		c.MuirGlacierBlock = big.NewInt(0)
 	}
 
-	c.NetworkUpgrades.setDefaults(c.SnowCtx.NetworkID)
+	c.NetworkUpgrades.setDefaults(c.SnowCtx.NetworkUpgrades)
 }
 
 func (r *Rules) PredicatersExist() bool {

--- a/params/network_upgrades.go
+++ b/params/network_upgrades.go
@@ -55,8 +55,8 @@ func (n *NetworkUpgrades) forkOrder() []fork {
 
 // setDefaults sets the default values for the network upgrades.
 // This overrides deactivating the network upgrade by providing a timestamp of nil value.
-func (n *NetworkUpgrades) setDefaults(networkID uint32) {
-	defaults := getDefaultNetworkUpgrades(networkID)
+func (n *NetworkUpgrades) setDefaults(agoUpgrades upgrade.Config) {
+	defaults := getDefaultNetworkUpgrades(agoUpgrades)
 	// If the network upgrade is not set, set it to the default value.
 	// If the network upgrade is set to 0, we also treat it as nil and set it default.
 	// This is because in prior versions, upgrades were not modifiable and were directly set to their default values.
@@ -74,8 +74,8 @@ func (n *NetworkUpgrades) setDefaults(networkID uint32) {
 }
 
 // verifyNetworkUpgrades checks that the network upgrades are well formed.
-func (n *NetworkUpgrades) verifyNetworkUpgrades(networkID uint32) error {
-	defaults := getDefaultNetworkUpgrades(networkID)
+func (n *NetworkUpgrades) verifyNetworkUpgrades(agoUpgrades upgrade.Config) error {
+	defaults := getDefaultNetworkUpgrades(agoUpgrades)
 	if err := verifyWithDefault(n.SubnetEVMTimestamp, defaults.SubnetEVMTimestamp); err != nil {
 		return fmt.Errorf("SubnetEVM fork block timestamp is invalid: %w", err)
 	}
@@ -140,10 +140,9 @@ func (n *NetworkUpgrades) GetAvalancheRules(time uint64) AvalancheRules {
 	}
 }
 
-// getDefaultNetworkUpgrades returns the network upgrades for the specified network ID.
+// getDefaultNetworkUpgrades returns the network upgrades for the specified avalanchego upgrades.
 // These should not return nil values.
-func getDefaultNetworkUpgrades(networkID uint32) NetworkUpgrades {
-	agoUpgrade := upgrade.GetConfig(networkID)
+func getDefaultNetworkUpgrades(agoUpgrade upgrade.Config) NetworkUpgrades {
 	return NetworkUpgrades{
 		SubnetEVMTimestamp: utils.NewUint64(0),
 		DurangoTimestamp:   utils.TimeToNewUint64(agoUpgrade.DurangoTime),

--- a/params/network_upgrades_test.go
+++ b/params/network_upgrades_test.go
@@ -6,6 +6,7 @@ package params
 import (
 	"testing"
 
+	"github.com/ava-labs/avalanchego/upgrade"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/subnet-evm/utils"
 	"github.com/stretchr/testify/require"
@@ -172,20 +173,20 @@ func TestCheckNetworkUpgradesCompatible(t *testing.T) {
 
 func TestVerifyNetworkUpgrades(t *testing.T) {
 	testcases := []struct {
-		name      string
-		upgrades  *NetworkUpgrades
-		networkID uint32
-		expected  bool
+		name          string
+		upgrades      *NetworkUpgrades
+		avagoUpgrades upgrade.Config
+		expected      bool
 	}{
 		{
-			name: "ValidNetworkUpgrades",
+			name: "ValidNetworkUpgrades for custom network",
 			upgrades: &NetworkUpgrades{
 				SubnetEVMTimestamp: utils.NewUint64(0),
 				DurangoTimestamp:   utils.NewUint64(1607144400),
 				EtnaTimestamp:      utils.NewUint64(1607144400),
 			},
-			networkID: 1111,
-			expected:  true,
+			avagoUpgrades: upgrade.GetConfig(1111),
+			expected:      true,
 		},
 		{
 			name: "Invalid Durango nil upgrade",
@@ -193,8 +194,8 @@ func TestVerifyNetworkUpgrades(t *testing.T) {
 				SubnetEVMTimestamp: utils.NewUint64(1),
 				DurangoTimestamp:   nil,
 			},
-			networkID: 1,
-			expected:  false,
+			avagoUpgrades: upgrade.GetConfig(constants.MainnetID),
+			expected:      false,
 		},
 		{
 			name: "Invalid Subnet-EVM non-zero",
@@ -202,8 +203,8 @@ func TestVerifyNetworkUpgrades(t *testing.T) {
 				SubnetEVMTimestamp: utils.NewUint64(1),
 				DurangoTimestamp:   utils.NewUint64(2),
 			},
-			networkID: 1,
-			expected:  false,
+			avagoUpgrades: upgrade.GetConfig(constants.MainnetID),
+			expected:      false,
 		},
 		{
 			name: "Invalid Durango before default upgrade",
@@ -211,8 +212,26 @@ func TestVerifyNetworkUpgrades(t *testing.T) {
 				SubnetEVMTimestamp: utils.NewUint64(0),
 				DurangoTimestamp:   utils.NewUint64(1),
 			},
-			networkID: constants.MainnetID,
-			expected:  false,
+			avagoUpgrades: upgrade.GetConfig(constants.MainnetID),
+			expected:      false,
+		},
+		{
+			name: "Invalid Mainnet Durango reconfigured to Fuji",
+			upgrades: &NetworkUpgrades{
+				SubnetEVMTimestamp: utils.NewUint64(0),
+				DurangoTimestamp:   utils.TimeToNewUint64(upgrade.GetConfig(constants.FujiID).DurangoTime),
+			},
+			avagoUpgrades: upgrade.GetConfig(constants.MainnetID),
+			expected:      false,
+		},
+		{
+			name: "Valid Fuji Durango reconfigured to Mainnet",
+			upgrades: &NetworkUpgrades{
+				SubnetEVMTimestamp: utils.NewUint64(0),
+				DurangoTimestamp:   utils.TimeToNewUint64(upgrade.GetConfig(constants.MainnetID).DurangoTime),
+			},
+			avagoUpgrades: upgrade.GetConfig(constants.FujiID),
+			expected:      false,
 		},
 		{
 			name: "Invalid Etna nil",
@@ -221,8 +240,8 @@ func TestVerifyNetworkUpgrades(t *testing.T) {
 				DurangoTimestamp:   utils.NewUint64(2),
 				EtnaTimestamp:      nil,
 			},
-			networkID: 1,
-			expected:  false,
+			avagoUpgrades: upgrade.GetConfig(constants.MainnetID),
+			expected:      false,
 		},
 		{
 			name: "Invalid Etna before Durango",
@@ -231,13 +250,13 @@ func TestVerifyNetworkUpgrades(t *testing.T) {
 				DurangoTimestamp:   utils.NewUint64(2),
 				EtnaTimestamp:      utils.NewUint64(1),
 			},
-			networkID: 1,
-			expected:  false,
+			avagoUpgrades: upgrade.GetConfig(constants.MainnetID),
+			expected:      false,
 		},
 	}
 	for _, test := range testcases {
 		t.Run(test.name, func(t *testing.T) {
-			err := test.upgrades.verifyNetworkUpgrades(test.networkID)
+			err := test.upgrades.verifyNetworkUpgrades(test.avagoUpgrades)
 			if test.expected {
 				require.Nil(t, err)
 			} else {

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -83,7 +83,7 @@ var (
 		g := new(core.Genesis)
 		g.Difficulty = big.NewInt(0)
 		g.GasLimit = 8000000
-		g.Timestamp = 1607144400 // Sat Dec 05 2020 05:00:00 GMT+0000
+		g.Timestamp = uint64(upgrade.InitiallyActiveTime.Unix())
 
 		// Use chainId: 43111, so that it does not overlap with any Avalanche ChainIDs, which may have their
 		// config overridden in vm.Initialize.
@@ -145,6 +145,7 @@ func NewContext() *snow.Context {
 	ctx.ChainID = testCChainID
 	ctx.AVAXAssetID = testAvaxAssetID
 	ctx.XChainID = testXChainID
+	ctx.NetworkUpgrades = upgrade.GetConfig(testNetworkID)
 	aliaser := ctx.BCLookup.(ids.Aliaser)
 	_ = aliaser.Alias(testCChainID, "C")
 	_ = aliaser.Alias(testCChainID, testCChainID.String())

--- a/utils/snow.go
+++ b/utils/snow.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/snow/validators/validatorstest"
+	"github.com/ava-labs/avalanchego/upgrade"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
 	"github.com/ava-labs/avalanchego/utils/logging"
 )
@@ -19,15 +20,16 @@ func TestSnowContext() *snow.Context {
 	}
 	pk := bls.PublicFromSecretKey(sk)
 	return &snow.Context{
-		NetworkID:      0,
-		SubnetID:       ids.Empty,
-		ChainID:        ids.Empty,
-		NodeID:         ids.EmptyNodeID,
-		PublicKey:      pk,
-		Log:            logging.NoLog{},
-		BCLookup:       ids.NewAliaser(),
-		Metrics:        metrics.NewMultiGatherer(),
-		ChainDataDir:   "",
-		ValidatorState: &validatorstest.State{},
+		NetworkID:       0,
+		SubnetID:        ids.Empty,
+		ChainID:         ids.Empty,
+		NodeID:          ids.EmptyNodeID,
+		NetworkUpgrades: upgrade.Default,
+		PublicKey:       pk,
+		Log:             logging.NoLog{},
+		BCLookup:        ids.NewAliaser(),
+		Metrics:         metrics.NewPrefixGatherer(),
+		ChainDataDir:    "",
+		ValidatorState:  &validatorstest.State{},
 	}
 }


### PR DESCRIPTION
## Why this should be merged

Uses chainCtx.NetworkUpgrades to determine default values

## How this works

takes an avalanchego upgrade config to set defaults.

## How this was tested

UTs modified 

## How is this documented

the avalanchego flag is not documented yet. this PR honors that flag so the main flag doc should be sufficient. 
