### PR TITLE
undo refactor

### DIFF
--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -44,6 +44,7 @@ import (
 	"github.com/ava-labs/subnet-evm/trie"
 	"github.com/ava-labs/subnet-evm/warp"
 	"github.com/ava-labs/subnet-evm/warp/handlers"
+	warpValidators "github.com/ava-labs/subnet-evm/warp/validators"
 
 	// Force-load tracer engine to trigger registration
 	//
@@ -1019,7 +1020,8 @@ func (vm *VM) CreateHandlers(context.Context) (map[string]http.Handler, error) {
 	}
 
 	if vm.config.WarpAPIEnabled {
-		if err := handler.RegisterName("warp", warp.NewAPI(vm.ctx.NetworkID, vm.ctx.SubnetID, vm.ctx.ChainID, vm.ctx.ValidatorState, vm.warpBackend, vm.client, vm.requirePrimaryNetworkSigners)); err != nil {
+		validatorsState := warpValidators.NewState(vm.ctx, vm.requirePrimaryNetworkSigners)
+		if err := handler.RegisterName("warp", warp.NewAPI(vm.ctx.NetworkID, vm.ctx.SubnetID, vm.ctx.ChainID, validatorsState, vm.warpBackend, vm.client)); err != nil {
 			return nil, err
 		}
 		enabledAPIs = append(enabledAPIs, "warp")

--- a/precompile/contracts/warp/config.go
+++ b/precompile/contracts/warp/config.go
@@ -200,19 +200,11 @@ func (c *Config) VerifyPredicate(predicateContext *precompileconfig.PredicateCon
 	}
 
 	log.Debug("verifying warp message", "warpMsg", warpMsg, "quorumNum", quorumNumerator, "quorumDenom", WarpQuorumDenominator)
-
-	// Wrap validators.State on the chain snow context to special case the Primary Network
-	state := warpValidators.NewState(
-		predicateContext.SnowCtx.ValidatorState,
-		predicateContext.SnowCtx.SubnetID,
-		warpMsg.SourceChainID,
-		c.RequirePrimaryNetworkSigners,
-	)
 	err = warpMsg.Signature.Verify(
 		context.Background(),
 		&warpMsg.UnsignedMessage,
 		predicateContext.SnowCtx.NetworkID,
-		state,
+		warpValidators.NewState(predicateContext.SnowCtx, func() bool { return c.RequirePrimaryNetworkSigners }), // Wrap validators.State on the chain snow context to special case the Primary Network
 		predicateContext.ProposerVMBlockCtx.PChainHeight,
 		quorumNumerator,
 		WarpQuorumDenominator,

--- a/warp/validators/state.go
+++ b/warp/validators/state.go
@@ -28,12 +28,23 @@ type State struct {
 //
 // The wrapped state will return the chainContext's Subnet validator set instead of the Primary Network when
 // the Primary Network SubnetID is passed in.
+// Additionally, it will return the chainContext's Subnet instead of the P-Chain, so that messages from the
+// P-Chains are verified against the Subnet's validator set.
 func NewState(chainContext *snow.Context, requirePrimaryNetworkSigners func() bool) *State {
 	return &State{
 		State:                        chainContext.ValidatorState,
 		chainContext:                 chainContext,
 		requirePrimaryNetworkSigners: requirePrimaryNetworkSigners,
 	}
+}
+
+func (s *State) GetSubnetID(ctx context.Context, chainID ids.ID) (ids.ID, error) {
+	// Messages from the P-Chain should be verified against the Subnet's validator set
+	if chainID == constants.PlatformChainID {
+		return s.chainContext.SubnetID, nil
+	}
+
+	return s.State.GetSubnetID(ctx, chainID)
 }
 
 func (s *State) GetValidatorSet(

--- a/warp/validators/state_test.go
+++ b/warp/validators/state_test.go
@@ -26,7 +26,7 @@ func TestGetValidatorSetPrimaryNetwork(t *testing.T) {
 	snowCtx := utils.TestSnowContext()
 	snowCtx.SubnetID = mySubnetID
 	snowCtx.ValidatorState = mockState
-	state := NewState(snowCtx.ValidatorState, snowCtx.SubnetID, snowCtx.ChainID, false)
+	state := NewState(snowCtx, func() bool { return false })
 	// Expect that requesting my validator set returns my validator set
 	mockState.EXPECT().GetValidatorSet(gomock.Any(), gomock.Any(), mySubnetID).Return(make(map[ids.NodeID]*validators.GetValidatorOutput), nil)
 	output, err := state.GetValidatorSet(context.Background(), 10, mySubnetID)

--- a/warp/validators/state_test.go
+++ b/warp/validators/state_test.go
@@ -44,4 +44,15 @@ func TestGetValidatorSetPrimaryNetwork(t *testing.T) {
 	output, err = state.GetValidatorSet(context.Background(), 10, otherSubnetID)
 	require.NoError(err)
 	require.Len(output, 0)
+
+	// Requesting P-Chain's subnet should return mySubnetID
+	subnetID, err := state.GetSubnetID(context.Background(), constants.PlatformChainID)
+	require.NoError(err)
+	require.Equal(mySubnetID, subnetID)
+
+	// Requesting other chain's subnet should pass through
+	mockState.EXPECT().GetSubnetID(gomock.Any(), gomock.Any()).Return(otherSubnetID, nil)
+	subnetID, err = state.GetSubnetID(context.Background(), ids.GenerateTestID())
+	require.NoError(err)
+	require.Equal(otherSubnetID, subnetID)
 }


### PR DESCRIPTION
This is an alternate implementation which wraps the GetSubnetID call in the validator state.

- This is less of a structural modification
- However it adds more "magic" happening in the `wrappers.State` behavior (aka it relies that the output of GetSubnetID would be fed into GetValidatorSet)