### PR TITLE
add NO_RACE so uts can run faster locally

### DIFF
--- a/scripts/build_test.sh
+++ b/scripts/build_test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -o erexit
+set -o errexit
 set -o nounset
 set -o pipefail
 # TODO(marun) Ensure the working directory is the repository root or a non-canonical set of tests may be executed

--- a/scripts/build_test.sh
+++ b/scripts/build_test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -o errexit
+set -o erexit
 set -o nounset
 set -o pipefail
 # TODO(marun) Ensure the working directory is the repository root or a non-canonical set of tests may be executed
@@ -20,5 +20,9 @@ source "$SUBNET_EVM_PATH"/scripts/constants.sh
 # We pass in the arguments to this script directly to enable easily passing parameters such as enabling race detection,
 # parallelism, and test coverage.
 # DO NOT RUN tests from the top level "tests" directory since they are run by ginkgo
+race="-race"
+if [[ -n "${NO_RACE:-}" ]]; then
+    race=""
+fi
 # shellcheck disable=SC2046
-go test -shuffle=on -race -timeout="${TIMEOUT:-600s}" -coverprofile=coverage.out -covermode=atomic "$@" $(go list ./... | grep -v github.com/ava-labs/subnet-evm/tests)
+go test -shuffle=on "${race}" -timeout="${TIMEOUT:-600s}" -coverprofile=coverage.out -covermode=atomic "$@" $(go list ./... | grep -v github.com/ava-labs/subnet-evm/tests)


### PR DESCRIPTION
I don't want to address whether the race detector should run on every CI right now, but I keep finding myself removing the `-race` option and sometimes it gets committed by mistake, then have to undo it, or keep stashing this change.

So this adds support for running tests like `NO_RACE=1 ./scripts/build_test.sh`