### PR TITLE
[tmpnet] Update to use new monitoring urls (*-poc)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -140,7 +140,7 @@ jobs:
         shell: bash
         run: ./scripts/build.sh
       - name: Run Warp E2E Tests
-        uses: ava-labs/avalanchego/.github/actions/run-monitored-tmpnet-cmd@v1-actions
+        uses: ava-labs/avalanchego/.github/actions/run-monitored-tmpnet-cmd@v1.11.11-monitoring-url
         with:
           run: AVALANCHEGO_BUILD_PATH=/tmp/e2e-test/avalanchego ./scripts/run_ginkgo_warp.sh
           prometheus_id: ${{ secrets.PROMETHEUS_ID || '' }}
@@ -172,7 +172,7 @@ jobs:
         shell: bash
         run: ./scripts/build.sh
       - name: Run E2E Load Tests
-        uses: ava-labs/avalanchego/.github/actions/run-monitored-tmpnet-cmd@v1-actions
+        uses: ava-labs/avalanchego/.github/actions/run-monitored-tmpnet-cmd@v1.11.11-monitoring-url
         with:
           run: AVALANCHEGO_BUILD_PATH=/tmp/e2e-test/avalanchego ./scripts/run_ginkgo_load.sh
           prometheus_id: ${{ secrets.PROMETHEUS_ID || '' }}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21.12
 require (
 	github.com/VictoriaMetrics/fastcache v1.12.1
 	github.com/antithesishq/antithesis-sdk-go v0.3.8
-	github.com/ava-labs/avalanchego v1.11.11-0.20240819192939-df91c2f4ab99
+	github.com/ava-labs/avalanchego v1.11.11-0.20240821175119-35c66e33f0dc
 	github.com/cespare/cp v0.1.0
 	github.com/crate-crypto/go-ipa v0.0.0-20231025140028-3c0104f4b233
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax
 github.com/antithesishq/antithesis-sdk-go v0.3.8 h1:OvGoHxIcOXFJLyn9IJQ5DzByZ3YVAWNBc394ObzDRb8=
 github.com/antithesishq/antithesis-sdk-go v0.3.8/go.mod h1:IUpT2DPAKh6i/YhSbt6Gl3v2yvUZjmKncl7U91fup7E=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/ava-labs/avalanchego v1.11.11-0.20240819192939-df91c2f4ab99 h1:fPWpINk7O1W4w5thqa8CGMRJ/kvycHvehBEiWwMjezI=
-github.com/ava-labs/avalanchego v1.11.11-0.20240819192939-df91c2f4ab99/go.mod h1:UkyrRDXK2E15Lq2abyae2Pt+JsWvgsg1pe0/AtoMyAM=
+github.com/ava-labs/avalanchego v1.11.11-0.20240821175119-35c66e33f0dc h1:cUz1N+LJIeQAR0Z6zTBiuZ7s8GqIE5QQbRWs423VFRA=
+github.com/ava-labs/avalanchego v1.11.11-0.20240821175119-35c66e33f0dc/go.mod h1:UkyrRDXK2E15Lq2abyae2Pt+JsWvgsg1pe0/AtoMyAM=
 github.com/ava-labs/coreth v0.13.8-fixed-genesis-upgrade.0.20240813194342-7635a96aa180 h1:6aIHp7wbyGVYdhHVQUbG7BEcbCMEQ5SYopPPJyipyvk=
 github.com/ava-labs/coreth v0.13.8-fixed-genesis-upgrade.0.20240813194342-7635a96aa180/go.mod h1:/wNBVq7J7wlC2Kbov7kk6LV5xZvau7VF9zwTVOeyAjY=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=

--- a/scripts/run_prometheus.sh
+++ b/scripts/run_prometheus.sh
@@ -31,7 +31,7 @@ if pgrep --pidfile="${PIDFILE}" -f 'prometheus.*enable-feature=agent' &> /dev/nu
   exit 0
 fi
 
-PROMETHEUS_URL="${PROMETHEUS_URL:-https://prometheus-experimental.avax-dev.network}"
+PROMETHEUS_URL="${PROMETHEUS_URL:-https://prometheus-poc.avax-dev.network}"
 if [[ -z "${PROMETHEUS_URL}" ]]; then
   echo "Please provide a value for PROMETHEUS_URL"
   exit 1

--- a/scripts/run_promtail.sh
+++ b/scripts/run_promtail.sh
@@ -30,7 +30,7 @@ if pgrep --pidfile="${PIDFILE}" &> /dev/null; then
   exit 0
 fi
 
-LOKI_URL="${LOKI_URL:-https://loki-experimental.avax-dev.network}"
+LOKI_URL="${LOKI_URL:-https://loki-poc.avax-dev.network}"
 if [[ -z "${LOKI_URL}" ]]; then
   echo "Please provide a value for LOKI_URL"
   exit 1

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -4,7 +4,7 @@
 # shellcheck disable=SC2034
 
 # Don't export them as they're used in the context of other calls
-AVALANCHE_VERSION=${AVALANCHE_VERSION:-'df91c2f4a'}
+AVALANCHE_VERSION=${AVALANCHE_VERSION:-'35c66e33f'}
 GINKGO_VERSION=${GINKGO_VERSION:-'v2.2.0'}
 
 # This won't be used, but it's here to make code syncs easier


### PR DESCRIPTION
## Why this should be merged

The new monitoring stack is located at different URLs.

## How this works

 - [x] Updated to avalanchego version containing https://github.com/ava-labs/avalanchego/pull/3306
 - [x] Updated loki and prometheus scripts to use the new URLs
 - [x] Updated action usage to use a tag using the new URLs

## How this was tested

 - [x] Load and warp jobs are emitting the new URLs
 - [x] New URLs are populated with data.

## How is this documented

- N/A