### PR TITLE
add team alias to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,5 +6,5 @@
 
 # review whenever someone opens a pull request.
 
-* @ceyonur @darioush
+* @ceyonur @darioush @ava-labs/platform-evm
 


### PR DESCRIPTION
Adding the team alias to test.
If it works and others agree we can remove the individuals after