### PR TITLE
suggested for ci: re-run tests if failures are flakes

### DIFF
--- a/accounts/keystore/keystore_test.go
+++ b/accounts/keystore/keystore_test.go
@@ -293,9 +293,6 @@ type walletEvent struct {
 // Tests that wallet notifications and correctly fired when accounts are added
 // or deleted from the keystore.
 func TestWalletNotifications(t *testing.T) {
-	if os.Getenv("RUN_FLAKY_TESTS") != "true" {
-		t.Skip("FLAKY")
-	}
 	t.Parallel()
 	_, ks := tmpKeyStore(t, false)
 

--- a/metrics/sample_test.go
+++ b/metrics/sample_test.go
@@ -3,7 +3,6 @@ package metrics
 import (
 	"math"
 	"math/rand"
-	"os"
 	"runtime"
 	"testing"
 	"time"
@@ -133,9 +132,6 @@ func TestExpDecaySample(t *testing.T) {
 // The priority becomes +Inf quickly after starting if this is done,
 // effectively freezing the set of samples until a rescale step happens.
 func TestExpDecaySampleNanosecondRegression(t *testing.T) {
-	if os.Getenv("RUN_FLAKY_TESTS") != "true" {
-		t.Skip("FLAKY")
-	}
 	sw := NewExpDecaySample(100, 0.99)
 	for i := 0; i < 100; i++ {
 		sw.Update(10)

--- a/plugin/evm/gossiper_eth_gossiping_test.go
+++ b/plugin/evm/gossiper_eth_gossiping_test.go
@@ -8,7 +8,6 @@ import (
 	"crypto/ecdsa"
 	"encoding/json"
 	"math/big"
-	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -74,9 +73,6 @@ func getValidEthTxs(key *ecdsa.PrivateKey, count int, gasPrice *big.Int) []*type
 // show that a geth tx discovered from gossip is requested to the same node that
 // gossiped it
 func TestMempoolEthTxsAppGossipHandling(t *testing.T) {
-	if os.Getenv("RUN_FLAKY_TESTS") != "true" {
-		t.Skip("FLAKY")
-	}
 	assert := assert.New(t)
 
 	key, err := crypto.GenerateKey()

--- a/plugin/evm/syncervm_test.go
+++ b/plugin/evm/syncervm_test.go
@@ -241,7 +241,6 @@ func TestStateSyncToggleEnabledToDisabled(t *testing.T) {
 }
 
 func TestVMShutdownWhileSyncing(t *testing.T) {
-	t.Skip("FLAKY")
 	var (
 		lock    sync.Mutex
 		vmSetup *syncVMSetup

--- a/scripts/build_test.sh
+++ b/scripts/build_test.sh
@@ -24,5 +24,33 @@ race="-race"
 if [[ -n "${NO_RACE:-}" ]]; then
     race=""
 fi
-# shellcheck disable=SC2046
-go test -shuffle=on ${race:-} -timeout="${TIMEOUT:-600s}" -coverprofile=coverage.out -covermode=atomic "$@" $(go list ./... | grep -v github.com/ava-labs/subnet-evm/tests)
+
+# MAX_RUNS bounds the attempts to retry the tests before giving up
+# This is useful for flaky tests
+MAX_RUNS=4
+for ((i = 1; i <= MAX_RUNS; i++));
+do
+    # shellcheck disable=SC2046
+    go test -shuffle=on ${race:-} -timeout="${TIMEOUT:-600s}" -coverprofile=coverage.out -covermode=atomic "$@" $(go list ./... | grep -v github.com/ava-labs/subnet-evm/tests) | tee test.out || command_status=$?
+
+    # If the test passed, exit
+    if [[ ${command_status:0} == 0 ]]; then
+        rm test.out
+        exit 0
+    fi
+
+    # If the test failed, print the output
+    unexpected_failures=$(grep "^--- FAIL" test.out | awk '{print $3}' | sort -u | comm -23 - ./scripts/known_flakes.txt)
+    if [ -n "${unexpected_failures}" ]; then
+        echo "Unexpected test failures: ${unexpected_failures}"
+        exit 1
+    fi
+
+    # Note the absence of unexpected failures cannot be indicative that we only need to run the tests that failed,
+    # for example a test may panic and cause subsequent tests in that package to not run.
+    # So we loop here.
+    echo "Test run $i failed with known flakes, retrying..."
+done
+
+# If we reach here, we have failed all retries
+exit 1

--- a/scripts/build_test.sh
+++ b/scripts/build_test.sh
@@ -34,7 +34,7 @@ do
     go test -shuffle=on ${race:-} -timeout="${TIMEOUT:-600s}" -coverprofile=coverage.out -covermode=atomic "$@" $(go list ./... | grep -v github.com/ava-labs/subnet-evm/tests) | tee test.out || command_status=$?
 
     # If the test passed, exit
-    if [[ ${command_status:0} == 0 ]]; then
+    if [[ ${command_status:-0} == 0 ]]; then
         rm test.out
         exit 0
     fi

--- a/scripts/build_test.sh
+++ b/scripts/build_test.sh
@@ -37,6 +37,8 @@ do
     if [[ ${command_status:-0} == 0 ]]; then
         rm test.out
         exit 0
+    else 
+        unset command_status # Clear the error code for the next run
     fi
 
     # If the test failed, print the output

--- a/scripts/known_flakes.txt
+++ b/scripts/known_flakes.txt
@@ -1,1 +1,5 @@
+TestExpDecaySampleNanosecondRegression
+TestMempoolEthTxsAppGossipHandling
 TestTransactionSkipIndexing
+TestVMShutdownWhileSyncing
+TestWalletNotifications

--- a/scripts/known_flakes.txt
+++ b/scripts/known_flakes.txt
@@ -1,5 +1,7 @@
 TestExpDecaySampleNanosecondRegression
+TestGolangBindings
 TestMempoolEthTxsAppGossipHandling
 TestTransactionSkipIndexing
 TestVMShutdownWhileSyncing
 TestWalletNotifications
+TestWebsocketLargeRead

--- a/scripts/known_flakes.txt
+++ b/scripts/known_flakes.txt
@@ -1,0 +1,1 @@
+TestTransactionSkipIndexing


### PR DESCRIPTION
I suggest that we take this approach to handling flakey tests.
I dislike our current situation:
- We have some tests that are important and we don't want to disable them, so we re-run the CI,
- We have some tests that we previously disabled and then subsequently they degraded from flakey -> failing tests without us noticing.

One downside of this PR is that CI may sometimes take longer (20m instead of 10m), as this runs tests that we know are flakey more often. So I am open to a smaller change, leaving the skipped tests as such, which would at least fix the first issue described above.

Example of the retry happening (this PR):
https://github.com/ava-labs/subnet-evm/actions/runs/10517836822/job/29142677042?pr=1305
