### PR TITLE
Add observed flakes

### DIFF
--- a/scripts/known_flakes.txt
+++ b/scripts/known_flakes.txt
@@ -2,6 +2,7 @@ TestClientCancelWebsocket
 TestExpDecaySampleNanosecondRegression
 TestGolangBindings
 TestMempoolEthTxsAppGossipHandling
+TestResyncNewRootAfterDeletes
 TestTransactionSkipIndexing
 TestVMShutdownWhileSyncing
 TestWalletNotifications

--- a/scripts/known_flakes.txt
+++ b/scripts/known_flakes.txt
@@ -2,7 +2,9 @@ TestClientCancelWebsocket
 TestExpDecaySampleNanosecondRegression
 TestGolangBindings
 TestMempoolEthTxsAppGossipHandling
+TestResumeSyncAccountsTrieInterrupted
 TestResyncNewRootAfterDeletes
+TestT8n
 TestTransactionSkipIndexing
 TestVMShutdownWhileSyncing
 TestWalletNotifications

--- a/scripts/known_flakes.txt
+++ b/scripts/known_flakes.txt
@@ -4,7 +4,6 @@ TestGolangBindings
 TestMempoolEthTxsAppGossipHandling
 TestResumeSyncAccountsTrieInterrupted
 TestResyncNewRootAfterDeletes
-TestT8n
 TestTransactionSkipIndexing
 TestVMShutdownWhileSyncing
 TestWalletNotifications


### PR DESCRIPTION
Adds unrelated test failures from https://github.com/ava-labs/subnet-evm/actions/runs/10570009056/job/29283789250?pr=1311

Not sure if we should also add TestT8n from that run, but it seems the timeout in the other test is causing that so I didn't add it for now.