### PR TITLE
[ci] Validate image build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -197,6 +197,14 @@ jobs:
         run: scripts/mock.gen.sh
       - shell: bash
         run: .github/workflows/check-clean-branch.sh
+  test_build_image:
+    name: Image build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check image build
+        shell: bash
+        run: bash -x scripts/tests.build_docker_image.sh
   test_build_antithesis_images:
     name: Build Antithesis images
     runs-on: ubuntu-latest

--- a/scripts/build_docker_image.sh
+++ b/scripts/build_docker_image.sh
@@ -13,7 +13,6 @@ source "$SUBNET_EVM_PATH"/scripts/versions.sh
 
 # WARNING: this will use the most recent commit even if there are un-committed changes present
 BUILD_IMAGE_ID=${BUILD_IMAGE_ID:-"${CURRENT_BRANCH}"}
-DOCKERHUB_TAG=${SUBNET_EVM_COMMIT::8}
 
 VM_ID=${VM_ID:-"${DEFAULT_VM_ID}"}
 if [[ "${VM_ID}" != "${DEFAULT_VM_ID}"  ]]; then

--- a/scripts/constants.sh
+++ b/scripts/constants.sh
@@ -30,6 +30,9 @@ else
     SUBNET_EVM_COMMIT="$(git --git-dir="$SUBNET_EVM_PATH/.git" rev-parse HEAD || :)"
 fi
 
+# Shared between ./scripts/build_docker_image.sh and ./scripts/tests.build_docker_image.sh
+DOCKERHUB_TAG=${SUBNET_EVM_COMMIT::8}
+
 echo "Using branch: ${CURRENT_BRANCH}"
 
 # Static compilation

--- a/scripts/tests.build_docker_image.sh
+++ b/scripts/tests.build_docker_image.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Sanity check the image build by attempting to build and run the image without error.
+
+# Directory above this script
+SUBNET_EVM_PATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
+# Load the constants
+source "$SUBNET_EVM_PATH"/scripts/constants.sh
+
+# Build a local image
+"${SUBNET_EVM_PATH}"/scripts/build_docker_image.sh
+
+# Check that the image can be run and contains the plugin
+echo "Checking version of the plugin provided by the image"
+docker run -t --rm "${DOCKERHUB_REPO}:${DOCKERHUB_TAG}" /avalanchego/build/plugins/"${DEFAULT_VM_ID}" --version
+echo "" # --version output doesn't include a newline
+echo "Successfully checked image build"


### PR DESCRIPTION
## Why this should be merged

A recent failure of post-merge image build suggested the need for a pre-merge sanity check to avoid unintentionally merging changes that break the image build.

## How this works

Adds a new pre-merge CI job and test script to validate that the subnet-evm docker image can be built.

## How this was tested

Locally and CI

## How is this documented

N/A