### PR TITLE
blockchain: Fix blockCache for rejected blocks

### DIFF
--- a/core/test_blockchain.go
+++ b/core/test_blockchain.go
@@ -494,6 +494,7 @@ func TestAcceptNonCanonicalBlock(t *testing.T, create func(db ethdb.Database, gs
 		if err := blockchain.Reject(chain1[i]); err != nil {
 			t.Fatal(err)
 		}
+		require.False(t, blockchain.HasBlock(chain1[i].Hash(), chain1[i].NumberU64()))
 	}
 
 	lastAcceptedBlock := blockchain.LastConsensusAcceptedBlock()


### PR DESCRIPTION
## Why this should be merged
After calling Reject the block is removed from the db. So the return value of HasBlock should be consistent with the DB, so we should invalidate the cache entry when we reject a block.

Also removed some unused code

## How this works
See above

## How this was tested
CI (added check for expected HasBlock behavior to test with reject)

## How is this documented
N/A
