### PR TITLE
Tail lock revisited

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2187,8 +2187,8 @@ func (bc *BlockChain) repairTxIndexTail(newTail uint64) error {
 	bc.txIndexTailLock.Lock()
 	defer bc.txIndexTailLock.Unlock()
 
-	if currentTail := rawdb.ReadTxIndexTail(bc.db); currentTail == nil || newTail > *currentTail {
-		log.Info("Repairing tx index tail", "old", currentTail, "new", newTail)
+	if curr := rawdb.ReadTxIndexTail(bc.db); curr == nil || *curr < newTail {
+		log.Info("Repairing tx index tail", "old", curr, "new", newTail)
 		rawdb.WriteTxIndexTail(bc.db, newTail)
 	}
 	return nil

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -506,7 +506,10 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		st.state.SetNonce(msg.From, st.state.GetNonce(sender.Address())+1)
 		ret, st.gasRemaining, vmerr = st.evm.Call(sender, st.to(), msg.Data, st.gasRemaining, value)
 	}
-	price, _ := uint256.FromBig(msg.GasPrice)
+	price, overflow := uint256.FromBig(msg.GasPrice)
+	if overflow {
+		return nil, ErrGasUintOverflow
+	}
 	gasRefund := st.refundGas(rules.IsSubnetEVM)
 	fee := new(uint256.Int).SetUint64(st.gasUsed())
 	fee.Mul(fee, price)


### PR DESCRIPTION
## Why this should be merged

There is a potential race between txindexer and state sync (ResetToStateSyncedBlock/repairTxIndexTail), where reading can occur before repairTxIndexTail (which can increment the tail) and txindexer can work on an outdate tail (less than actual). 

## How this works

Uses txindexer's `run` function after grabbing lock and then do the actual db read for tail for `run`. 

## How this was tested

Not sure how to test this race

## How is this documented

no need
