### PR TITLE
nit: peer/network.go: remove refs to cross chain in comments

### DIFF
--- a/peer/network.go
+++ b/peer/network.go
@@ -303,7 +303,7 @@ func (n *network) AppRequestFailed(ctx context.Context, nodeID ids.NodeID, reque
 }
 
 // calculateTimeUntilDeadline calculates the time until deadline and drops it if we missed he deadline to response.
-// This function updates metrics for both app requests and cross chain requests.
+// This function updates metrics for app requests.
 // This is called by [AppRequest].
 func calculateTimeUntilDeadline(deadline time.Time, stats stats.RequestHandlerStats) (time.Time, error) {
 	// calculate how much time is left until the deadline

--- a/peer/stats/stats.go
+++ b/peer/stats/stats.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ava-labs/subnet-evm/metrics"
 )
 
-// RequestHandlerStats provides the interface for metrics for both app requests and cross chain requests.
+// RequestHandlerStats provides the interface for metrics for app requests.
 type RequestHandlerStats interface {
 	UpdateTimeUntilDeadline(duration time.Duration)
 	IncDeadlineDroppedRequest()


### PR DESCRIPTION
The code is already removed so let's also remove it from the comments.