### PR TITLE
remove acceptor queue (part 1)

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -480,7 +480,7 @@ func (bc *BlockChain) flattenSnapshot(postAbortWork func() error, hash common.Ha
 func (bc *BlockChain) warmAcceptedCaches() {
 	var (
 		startTime       = time.Now()
-		lastAccepted    = bc.LastAcceptedBlock().NumberU64()
+		lastAccepted    = bc.lastAccepted.NumberU64()
 		startIndex      = uint64(1)
 		targetCacheSize = uint64(bc.cacheConfig.AcceptedCacheSize)
 	)
@@ -520,12 +520,12 @@ func (bc *BlockChain) accept(next *types.Block) error {
 	if err := bc.flattenSnapshot(func() error {
 		return bc.stateManager.AcceptTrie(next)
 	}, next.Hash()); err != nil {
-		log.Crit("unable to flatten snapshot from acceptor", "blockHash", next.Hash(), "err", err)
+		return fmt.Errorf("unable to flatten snapshot in accept for block (%v): %w", next.Hash(), err)
 	}
 
 	// Update last processed and transaction lookup index
 	if err := bc.writeBlockAcceptedIndices(next); err != nil {
-		log.Crit("failed to write accepted block effects", "err", err)
+		return fmt.Errorf("failed to write accepted block indices: %w", err)
 	}
 
 	// Ensure [hc.acceptedNumberCache] and [acceptedLogsCache] have latest content
@@ -900,22 +900,10 @@ func (bc *BlockChain) setPreference(block *types.Block) error {
 	return nil
 }
 
-// LastConsensusAcceptedBlock returns the last block to be marked as accepted. It may or
-// may not yet be processed.
-func (bc *BlockChain) LastConsensusAcceptedBlock() *types.Block {
-	bc.chainmu.Lock()
-	defer bc.chainmu.Unlock()
-
-	return bc.lastAccepted
-}
-
-// LastAcceptedBlock returns the last block to be marked as accepted and is
-// processed.
-//
-// Note: During initialization, [acceptorTip] is equal to [lastAccepted].
+// LastAcceptedBlock returns the last block that was marked as accepted.
 func (bc *BlockChain) LastAcceptedBlock() *types.Block {
-	bc.chainmu.Lock()
-	defer bc.chainmu.Unlock()
+	bc.chainmu.RLock()
+	defer bc.chainmu.RUnlock()
 
 	return bc.lastAccepted
 }
@@ -1825,7 +1813,7 @@ func (bc *BlockChain) populateMissingTries() error {
 	}
 
 	var (
-		lastAccepted = bc.LastAcceptedBlock().NumberU64()
+		lastAccepted = bc.lastAccepted.NumberU64()
 		startHeight  = *bc.cacheConfig.PopulateMissingTries
 		startTime    = time.Now()
 		logged       time.Time
@@ -1901,7 +1889,7 @@ func (bc *BlockChain) populateMissingTries() error {
 // as inaccessible and mirrors the handling of middle roots in the geth offline pruning implementation.
 // This is not strictly necessary, but maintains a soft assumption.
 func (bc *BlockChain) CleanBlockRootsAboveLastAccepted() error {
-	targetRoot := bc.LastAcceptedBlock().Root()
+	targetRoot := bc.lastAccepted.Root()
 
 	// Clean up any block roots above the last accepted block before we start pruning.
 	// Note: this takes the place of middleRoots in the geth implementation since we do not

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1888,30 +1888,33 @@ func (bc *BlockChain) populateMissingTries() error {
 // This is used prior to pruning to ensure that all of the tries that may still be in processing are marked
 // as inaccessible and mirrors the handling of middle roots in the geth offline pruning implementation.
 // This is not strictly necessary, but maintains a soft assumption.
-func (bc *BlockChain) CleanBlockRootsAboveLastAccepted() error {
-	targetRoot := bc.lastAccepted.Root()
+func (bc *BlockChain) CleanBlockRootsAboveLastAccepted() (common.Hash, error) {
+	bc.chainmu.Lock()
+	defer bc.chainmu.Unlock()
 
+	targetBlock := bc.lastAccepted
+	targetRoot := targetBlock.Root()
 	// Clean up any block roots above the last accepted block before we start pruning.
 	// Note: this takes the place of middleRoots in the geth implementation since we do not
 	// track processing block roots via snapshot journals in the same way.
-	processingRoots := bc.gatherBlockRootsAboveLastAccepted()
+	processingRoots := bc.gatherBlockRootsAbove(targetBlock.NumberU64())
 	// If there is a block above the last accepted block with an identical state root, we
 	// explicitly remove it from the set to ensure we do not corrupt the last accepted trie.
 	delete(processingRoots, targetRoot)
 	for processingRoot := range processingRoots {
 		// Delete the processing root from disk to mark the trie as inaccessible (no need to handle this in a batch).
 		if err := bc.db.Delete(processingRoot[:]); err != nil {
-			return fmt.Errorf("failed to remove processing root (%s) preparing for offline pruning: %w", processingRoot, err)
+			return common.Hash{}, fmt.Errorf("failed to remove processing root (%s) preparing for offline pruning: %w", processingRoot, err)
 		}
 	}
 
-	return nil
+	return targetRoot, nil
 }
 
 // gatherBlockRootsAboveLastAccepted iterates forward from the last accepted block and returns a list of all block roots
-// for any blocks that were inserted above the last accepted block.
+// for any blocks that were inserted above the [targetHeight].
 // Given that we never insert a block into the chain unless all of its ancestors have been inserted, this should gather
-// all of the block roots for blocks inserted above the last accepted block that may have been in processing at some point
+// all of the block roots for blocks inserted above the [targetHeight] that may have been in processing at some point
 // in the past and are therefore potentially still acceptable.
 // Note: there is an edge case where the node dies while the consensus engine is rejecting a branch of blocks since the
 // consensus engine will reject the lowest ancestor first. In this case, these blocks will not be considered acceptable in
@@ -1931,9 +1934,9 @@ func (bc *BlockChain) CleanBlockRootsAboveLastAccepted() error {
 // The consensus engine accepts block C and proceeds to reject the other branch in order (B, D, E, F).
 // If the consensus engine dies after rejecting block D, block D will be deleted, such that the forward iteration
 // may not find any blocks at this height and will not reach the previously processing blocks E and F.
-func (bc *BlockChain) gatherBlockRootsAboveLastAccepted() map[common.Hash]struct{} {
+func (bc *BlockChain) gatherBlockRootsAbove(targetHeight uint64) map[common.Hash]struct{} {
 	blockRoots := make(map[common.Hash]struct{})
-	for height := bc.lastAccepted.NumberU64() + 1; ; height++ {
+	for height := targetHeight + 1; ; height++ {
 		blockHashes := rawdb.ReadAllHashes(bc.db, height)
 		// If there are no block hashes at [height], then there should be no further acceptable blocks
 		// past this point.

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -520,7 +520,7 @@ func (bc *BlockChain) accept(next *types.Block) error {
 	if err := bc.flattenSnapshot(func() error {
 		return bc.stateManager.AcceptTrie(next)
 	}, next.Hash()); err != nil {
-		return fmt.Errorf("unable to flatten snapshot in accept for block (%v): %w", next.Hash(), err)
+		return fmt.Errorf("unable to flatten snapshot in accept for block (%): %w", next.Hash(), err)
 	}
 
 	// Update last processed and transaction lookup index

--- a/core/blockchain_log_test.go
+++ b/core/blockchain_log_test.go
@@ -91,7 +91,6 @@ func TestAcceptedLogsSubscription(t *testing.T) {
 		err := chain.Accept(block)
 		require.NoError(err)
 	}
-	chain.DrainAcceptorQueue()
 
 	logs := <-logsCh
 	require.Len(logs, 1)

--- a/core/blockchain_repair_test.go
+++ b/core/blockchain_repair_test.go
@@ -597,7 +597,6 @@ func testRepairWithScheme(t *testing.T, tt *rewindTest, snapshots bool, scheme s
 				}
 				lastAcceptedHash = canonblocks[i].Hash()
 			}
-			chain.DrainAcceptorQueue()
 		}
 	}
 	if _, err := chain.InsertChain(canonblocks[tt.commitBlock:]); err != nil {

--- a/core/blockchain_snapshot_test.go
+++ b/core/blockchain_snapshot_test.go
@@ -116,7 +116,6 @@ func (basic *snapshotTestBasic) prepare(t *testing.T) (*BlockChain, []*types.Blo
 				}
 				basic.lastAcceptedHash = blocks[i].Hash()
 			}
-			chain.DrainAcceptorQueue()
 
 			diskRoot, blockRoot := chain.snaps.DiskRoot(), blocks[point-1].Root()
 			if !bytes.Equal(diskRoot.Bytes(), blockRoot.Bytes()) {

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -336,7 +336,7 @@ func testRepopulateMissingTriesParallel(t *testing.T, parallelism int) {
 		}
 	}
 
-	lastAcceptedHash := blockchain.LastConsensusAcceptedBlock().Hash()
+	lastAcceptedHash := blockchain.LastAcceptedBlock().Hash()
 	blockchain.Stop()
 
 	blockchain, err = createBlockChain(chainDB, pruningConfig, gspec, lastAcceptedHash)

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -259,11 +259,11 @@ func TestBlockChainOfflinePruningUngracefulShutdown(t *testing.T) {
 			return blockchain, nil
 		}
 
-		if err := blockchain.CleanBlockRootsAboveLastAccepted(); err != nil {
+		targetRoot, err := blockchain.CleanBlockRootsAboveLastAccepted()
+		if err != nil {
 			return nil, err
 		}
 		// get the target root to prune to before stopping the blockchain
-		targetRoot := blockchain.LastAcceptedBlock().Root()
 		if targetRoot == types.EmptyRootHash {
 			return blockchain, nil
 		}

--- a/core/test_blockchain.go
+++ b/core/test_blockchain.go
@@ -148,7 +148,6 @@ func checkBlockChainState(
 			t.Fatalf("Failed to accept block %s:%d due to %s", block.Hash().Hex(), block.NumberU64(), err)
 		}
 	}
-	newBlockChain.DrainAcceptorQueue()
 
 	newLastAcceptedBlock := newBlockChain.LastConsensusAcceptedBlock()
 	if newLastAcceptedBlock.Hash() != lastAcceptedBlock.Hash() {
@@ -231,7 +230,6 @@ func TestInsertChainAcceptSingleBlock(t *testing.T, create func(db ethdb.Databas
 	if err := blockchain.Accept(chain[0]); err != nil {
 		t.Fatal(err)
 	}
-	blockchain.DrainAcceptorQueue()
 
 	// check the state of the last accepted block
 	checkState := func(sdb *state.StateDB) error {
@@ -349,7 +347,6 @@ func TestInsertLongForkedChain(t *testing.T, create func(db ethdb.Database, gspe
 	if err := blockchain.Accept(chain1[0]); err != nil {
 		t.Fatal(err)
 	}
-	blockchain.DrainAcceptorQueue()
 
 	if blockchain.snaps != nil {
 		// Snap layer count should be 1 fewer
@@ -381,7 +378,6 @@ func TestInsertLongForkedChain(t *testing.T, create func(db ethdb.Database, gspe
 		if err := blockchain.Accept(chain1[i]); err != nil {
 			t.Fatal(err)
 		}
-		blockchain.DrainAcceptorQueue()
 
 		if blockchain.snaps != nil {
 			// Snap layer count should decrease by 1 per Accept
@@ -491,7 +487,6 @@ func TestAcceptNonCanonicalBlock(t *testing.T, create func(db ethdb.Database, gs
 	if err := blockchain.Accept(chain2[0]); err != nil {
 		t.Fatal(err)
 	}
-	blockchain.DrainAcceptorQueue()
 
 	for i := 0; i < len(chain1); i++ {
 		if err := blockchain.Reject(chain1[i]); err != nil {
@@ -630,7 +625,6 @@ func TestSetPreferenceRewind(t *testing.T, create func(db ethdb.Database, gspec 
 	if err := blockchain.Accept(chain[0]); err != nil {
 		t.Fatal(err)
 	}
-	blockchain.DrainAcceptorQueue()
 
 	lastAcceptedBlock = blockchain.LastConsensusAcceptedBlock()
 	expectedLastAcceptedBlock = chain[0]
@@ -751,7 +745,6 @@ func TestBuildOnVariousStages(t *testing.T, create func(db ethdb.Database, gspec
 			t.Fatal(err)
 		}
 	}
-	blockchain.DrainAcceptorQueue()
 
 	// Insert the forked chain [chain2] which starts at the 10th
 	// block in [chain1] ie. a block that is still in processing.
@@ -768,7 +761,6 @@ func TestBuildOnVariousStages(t *testing.T, create func(db ethdb.Database, gspec
 	if err := blockchain.Accept(chain1[5]); err != nil {
 		t.Fatal(err)
 	}
-	blockchain.DrainAcceptorQueue()
 	for _, block := range chain3 {
 		if err := blockchain.Reject(block); err != nil {
 			t.Fatal(err)
@@ -780,14 +772,12 @@ func TestBuildOnVariousStages(t *testing.T, create func(db ethdb.Database, gspec
 			t.Fatal(err)
 		}
 	}
-	blockchain.DrainAcceptorQueue()
 
 	// Accept the first block in [chain2] and reject the
 	// subsequent blocks in [chain1] which would then be rejected.
 	if err := blockchain.Accept(chain2[0]); err != nil {
 		t.Fatal(err)
 	}
-	blockchain.DrainAcceptorQueue()
 
 	for _, block := range chain1[10:] {
 		if err := blockchain.Reject(block); err != nil {
@@ -863,7 +853,6 @@ func TestEmptyBlocks(t *testing.T, create func(db ethdb.Database, gspec *Genesis
 			t.Fatal(err)
 		}
 	}
-	blockchain.DrainAcceptorQueue()
 
 	// Nothing to assert about the state
 	checkState := func(sdb *state.StateDB) error {
@@ -937,7 +926,6 @@ func TestReorgReInsert(t *testing.T, create func(db ethdb.Database, gspec *Genes
 	if err := blockchain.Accept(chain[2]); err != nil {
 		t.Fatal(err)
 	}
-	blockchain.DrainAcceptorQueue()
 
 	// Nothing to assert about the state
 	checkState := func(sdb *state.StateDB) error {
@@ -1053,7 +1041,6 @@ func TestAcceptBlockIdenticalStateRoot(t *testing.T, create func(db ethdb.Databa
 	if err := blockchain.Accept(chain1[0]); err != nil {
 		t.Fatal(err)
 	}
-	blockchain.DrainAcceptorQueue()
 
 	for _, block := range chain2 {
 		if err := blockchain.Reject(block); err != nil {
@@ -1067,7 +1054,6 @@ func TestAcceptBlockIdenticalStateRoot(t *testing.T, create func(db ethdb.Databa
 	if err := blockchain.Accept(chain1[1]); err != nil {
 		t.Fatal(err)
 	}
-	blockchain.DrainAcceptorQueue()
 
 	lastAcceptedBlock := blockchain.LastConsensusAcceptedBlock()
 	expectedLastAcceptedBlock := chain1[1]
@@ -1081,7 +1067,6 @@ func TestAcceptBlockIdenticalStateRoot(t *testing.T, create func(db ethdb.Databa
 	if err := blockchain.Accept(chain1[2]); err != nil {
 		t.Fatal(err)
 	}
-	blockchain.DrainAcceptorQueue()
 
 	// check the state of the last accepted block
 	checkState := func(sdb *state.StateDB) error {
@@ -1221,7 +1206,6 @@ func TestReprocessAcceptBlockIdenticalStateRoot(t *testing.T, create func(db eth
 	if err := blockchain.Accept(chain1[0]); err != nil {
 		t.Fatal(err)
 	}
-	blockchain.DrainAcceptorQueue()
 
 	for _, block := range chain2 {
 		if err := blockchain.Reject(block); err != nil {
@@ -1235,7 +1219,6 @@ func TestReprocessAcceptBlockIdenticalStateRoot(t *testing.T, create func(db eth
 	if err := blockchain.Accept(chain1[1]); err != nil {
 		t.Fatal(err)
 	}
-	blockchain.DrainAcceptorQueue()
 
 	lastAcceptedBlock := blockchain.LastConsensusAcceptedBlock()
 	expectedLastAcceptedBlock := chain1[1]
@@ -1249,7 +1232,6 @@ func TestReprocessAcceptBlockIdenticalStateRoot(t *testing.T, create func(db eth
 	if err := blockchain.Accept(chain1[2]); err != nil {
 		t.Fatal(err)
 	}
-	blockchain.DrainAcceptorQueue()
 
 	// check the state of the last accepted block
 	checkState := func(sdb *state.StateDB) error {
@@ -1436,7 +1418,6 @@ func TestInsertChainValidBlockFee(t *testing.T, create func(db ethdb.Database, g
 	if err := blockchain.Accept(chain[0]); err != nil {
 		t.Fatal(err)
 	}
-	blockchain.DrainAcceptorQueue()
 
 	// check the state of the last accepted block
 	checkState := func(sdb *state.StateDB) error {
@@ -1634,7 +1615,6 @@ func TestStatefulPrecompiles(t *testing.T, create func(db ethdb.Database, gspec 
 	if err := blockchain.Accept(chain[0]); err != nil {
 		t.Fatal(err)
 	}
-	blockchain.DrainAcceptorQueue()
 
 	genesisState, err := blockchain.StateAt(blockchain.Genesis().Root())
 	if err != nil {

--- a/core/test_blockchain.go
+++ b/core/test_blockchain.go
@@ -118,7 +118,7 @@ func checkBlockChainState(
 	checkState func(sdb *state.StateDB) error,
 ) (*BlockChain, *BlockChain, *BlockChain) {
 	var (
-		lastAcceptedBlock = bc.LastConsensusAcceptedBlock()
+		lastAcceptedBlock = bc.LastAcceptedBlock()
 		newDB             = rawdb.NewMemoryDatabase()
 	)
 
@@ -149,7 +149,7 @@ func checkBlockChainState(
 		}
 	}
 
-	newLastAcceptedBlock := newBlockChain.LastConsensusAcceptedBlock()
+	newLastAcceptedBlock := newBlockChain.LastAcceptedBlock()
 	if newLastAcceptedBlock.Hash() != lastAcceptedBlock.Hash() {
 		t.Fatalf("Expected new blockchain to have last accepted block %s:%d, but found %s:%d", lastAcceptedBlock.Hash().Hex(), lastAcceptedBlock.NumberU64(), newLastAcceptedBlock.Hash().Hex(), newLastAcceptedBlock.NumberU64())
 	}
@@ -176,7 +176,7 @@ func checkBlockChainState(
 	if currentBlock := restartedChain.CurrentBlock(); currentBlock.Hash() != lastAcceptedBlock.Hash() {
 		t.Fatalf("Expected restarted chain to have current block %s:%d, but found %s:%d", lastAcceptedBlock.Hash().Hex(), lastAcceptedBlock.NumberU64(), currentBlock.Hash().Hex(), currentBlock.Number.Uint64())
 	}
-	if restartedLastAcceptedBlock := restartedChain.LastConsensusAcceptedBlock(); restartedLastAcceptedBlock.Hash() != lastAcceptedBlock.Hash() {
+	if restartedLastAcceptedBlock := restartedChain.LastAcceptedBlock(); restartedLastAcceptedBlock.Hash() != lastAcceptedBlock.Hash() {
 		t.Fatalf("Expected restarted chain to have current block %s:%d, but found %s:%d", lastAcceptedBlock.Hash().Hex(), lastAcceptedBlock.NumberU64(), restartedLastAcceptedBlock.Hash().Hex(), restartedLastAcceptedBlock.NumberU64())
 	}
 
@@ -387,7 +387,7 @@ func TestInsertLongForkedChain(t *testing.T, create func(db ethdb.Database, gspe
 		}
 	}
 
-	lastAcceptedBlock := blockchain.LastConsensusAcceptedBlock()
+	lastAcceptedBlock := blockchain.LastAcceptedBlock()
 	expectedLastAcceptedBlock := chain1[len(chain1)-1]
 	if lastAcceptedBlock.Hash() != expectedLastAcceptedBlock.Hash() {
 		t.Fatalf("Expected last accepted block to be %s:%d, but found %s%d", expectedLastAcceptedBlock.Hash().Hex(), expectedLastAcceptedBlock.NumberU64(), lastAcceptedBlock.Hash().Hex(), lastAcceptedBlock.NumberU64())
@@ -495,7 +495,7 @@ func TestAcceptNonCanonicalBlock(t *testing.T, create func(db ethdb.Database, gs
 		require.False(t, blockchain.HasBlock(chain1[i].Hash(), chain1[i].NumberU64()))
 	}
 
-	lastAcceptedBlock := blockchain.LastConsensusAcceptedBlock()
+	lastAcceptedBlock := blockchain.LastAcceptedBlock()
 	expectedLastAcceptedBlock := chain2[0]
 	if lastAcceptedBlock.Hash() != expectedLastAcceptedBlock.Hash() {
 		t.Fatalf("Expected last accepted block to be %s:%d, but found %s%d", expectedLastAcceptedBlock.Hash().Hex(), expectedLastAcceptedBlock.NumberU64(), lastAcceptedBlock.Hash().Hex(), lastAcceptedBlock.NumberU64())
@@ -591,7 +591,7 @@ func TestSetPreferenceRewind(t *testing.T, create func(db ethdb.Database, gspec 
 		t.Fatalf("Expected current block to be %s:%d, but found %s%d", expectedCurrentBlock.Hash().Hex(), expectedCurrentBlock.NumberU64(), currentBlock.Hash().Hex(), currentBlock.Number.Uint64())
 	}
 
-	lastAcceptedBlock := blockchain.LastConsensusAcceptedBlock()
+	lastAcceptedBlock := blockchain.LastAcceptedBlock()
 	expectedLastAcceptedBlock := blockchain.Genesis()
 	if lastAcceptedBlock.Hash() != expectedLastAcceptedBlock.Hash() {
 		t.Fatalf("Expected last accepted block to be %s:%d, but found %s%d", expectedLastAcceptedBlock.Hash().Hex(), expectedLastAcceptedBlock.NumberU64(), lastAcceptedBlock.Hash().Hex(), lastAcceptedBlock.NumberU64())
@@ -626,7 +626,7 @@ func TestSetPreferenceRewind(t *testing.T, create func(db ethdb.Database, gspec 
 		t.Fatal(err)
 	}
 
-	lastAcceptedBlock = blockchain.LastConsensusAcceptedBlock()
+	lastAcceptedBlock = blockchain.LastAcceptedBlock()
 	expectedLastAcceptedBlock = chain[0]
 	if lastAcceptedBlock.Hash() != expectedLastAcceptedBlock.Hash() {
 		t.Fatalf("Expected last accepted block to be %s:%d, but found %s%d", expectedLastAcceptedBlock.Hash().Hex(), expectedLastAcceptedBlock.NumberU64(), lastAcceptedBlock.Hash().Hex(), lastAcceptedBlock.NumberU64())
@@ -1055,7 +1055,7 @@ func TestAcceptBlockIdenticalStateRoot(t *testing.T, create func(db ethdb.Databa
 		t.Fatal(err)
 	}
 
-	lastAcceptedBlock := blockchain.LastConsensusAcceptedBlock()
+	lastAcceptedBlock := blockchain.LastAcceptedBlock()
 	expectedLastAcceptedBlock := chain1[1]
 	if lastAcceptedBlock.Hash() != expectedLastAcceptedBlock.Hash() {
 		t.Fatalf("Expected last accepted block to be %s:%d, but found %s%d", expectedLastAcceptedBlock.Hash().Hex(), expectedLastAcceptedBlock.NumberU64(), lastAcceptedBlock.Hash().Hex(), lastAcceptedBlock.NumberU64())
@@ -1220,7 +1220,7 @@ func TestReprocessAcceptBlockIdenticalStateRoot(t *testing.T, create func(db eth
 		t.Fatal(err)
 	}
 
-	lastAcceptedBlock := blockchain.LastConsensusAcceptedBlock()
+	lastAcceptedBlock := blockchain.LastAcceptedBlock()
 	expectedLastAcceptedBlock := chain1[1]
 	if lastAcceptedBlock.Hash() != expectedLastAcceptedBlock.Hash() {
 		t.Fatalf("Expected last accepted block to be %s:%d, but found %s%d", expectedLastAcceptedBlock.Hash().Hex(), expectedLastAcceptedBlock.NumberU64(), lastAcceptedBlock.Hash().Hex(), lastAcceptedBlock.NumberU64())

--- a/core/txindexer_test.go
+++ b/core/txindexer_test.go
@@ -71,7 +71,6 @@ func TestTransactionIndices(t *testing.T) {
 		CommitInterval:            4096,
 		SnapshotLimit:             256,
 		SnapshotNoBuild:           true, // Ensure the test errors if snapshot initialization fails
-		AcceptorQueueLimit:        64,
 	}
 
 	// Init block chain and check all needed indices has been indexed.
@@ -86,7 +85,6 @@ func TestTransactionIndices(t *testing.T) {
 		err := chain.Accept(block)
 		require.NoError(err)
 	}
-	chain.DrainAcceptorQueue()
 
 	lastAcceptedBlock := blocks[len(blocks)-1]
 	require.Equal(lastAcceptedBlock.Hash(), chain.CurrentHeader().Hash())
@@ -121,7 +119,6 @@ func TestTransactionIndices(t *testing.T) {
 			lastAcceptedBlock = newBlks[0]
 			err = chain.Accept(lastAcceptedBlock) // Accept the block to trigger indices updater.
 			require.NoError(err)
-			chain.DrainAcceptorQueue()
 
 			tail = getTail(l, lastAcceptedBlock.NumberU64())
 			// check if indices are updated correctly
@@ -182,7 +179,6 @@ func TestTransactionSkipIndexing(t *testing.T) {
 		CommitInterval:            4096,
 		SnapshotLimit:             256,
 		SnapshotNoBuild:           true, // Ensure the test errors if snapshot initialization fails
-		AcceptorQueueLimit:        64,
 		SkipTxIndexing:            true,
 	}
 
@@ -248,7 +244,6 @@ func createAndInsertChain(db ethdb.Database, cacheConfig *CacheConfig, gspec *Ge
 		if err != nil {
 			return nil, err
 		}
-		chain.DrainAcceptorQueue()
 		if accepted != nil {
 			accepted(block)
 		}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -210,7 +210,6 @@ func New(
 			TrieDirtyCommitTarget:           config.TrieDirtyCommitTarget,
 			TriePrefetcherParallelism:       config.TriePrefetcherParallelism,
 			Pruning:                         config.Pruning,
-			AcceptorQueueLimit:              config.AcceptorQueueLimit,
 			CommitInterval:                  config.CommitInterval,
 			PopulateMissingTries:            config.PopulateMissingTries,
 			PopulateMissingTriesParallelism: config.PopulateMissingTriesParallelism,

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -455,10 +455,10 @@ func (s *Ethereum) handleOfflinePruning(cacheConfig *core.CacheConfig, gspec *co
 	}
 
 	// Clean up middle roots
-	if err := s.blockchain.CleanBlockRootsAboveLastAccepted(); err != nil {
+	targetRoot, err := s.blockchain.CleanBlockRootsAboveLastAccepted()
+	if err != nil {
 		return err
 	}
-	targetRoot := s.blockchain.LastAcceptedBlock().Root()
 
 	// Allow the blockchain to be garbage collected immediately, since we will shut down the chain after offline pruning completes.
 	s.blockchain.Stop()

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -86,7 +86,6 @@ type Config struct {
 	NetworkId uint64
 
 	Pruning                         bool    // Whether to disable pruning and flush everything to disk
-	AcceptorQueueLimit              int     // Maximum blocks to queue before blocking during acceptance
 	CommitInterval                  uint64  // If pruning is enabled, specified the interval at which to commit an entire trie to disk.
 	PopulateMissingTries            *uint64 // Height at which to start re-populating missing tries on startup.
 	PopulateMissingTriesParallelism int     // Number of concurrent readers to use when re-populating missing tries on startup.

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -105,7 +105,6 @@ func newTestBackend(t *testing.T, n int, gspec *core.Genesis, generator func(i i
 		}
 	}
 	backend.chain = chain
-	chain.DrainAcceptorQueue()
 	return backend
 }
 

--- a/ethclient/simulated/backend.go
+++ b/ethclient/simulated/backend.go
@@ -185,7 +185,6 @@ func (n *Backend) buildBlock(accept bool, gap uint64) (common.Hash, error) {
 		if err := n.acceptAncestors(block); err != nil {
 			return common.Hash{}, err
 		}
-		chain.DrainAcceptorQueue()
 	}
 	return block.Hash(), nil
 }

--- a/ethclient/simulated/backend.go
+++ b/ethclient/simulated/backend.go
@@ -191,7 +191,7 @@ func (n *Backend) buildBlock(accept bool, gap uint64) (common.Hash, error) {
 
 func (n *Backend) acceptAncestors(block *types.Block) error {
 	chain := n.eth.BlockChain()
-	lastAccepted := chain.LastConsensusAcceptedBlock()
+	lastAccepted := chain.LastAcceptedBlock()
 
 	// Accept all ancestors of the block
 	toAccept := []*types.Block{block}

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -468,7 +468,6 @@ func newTestBackend(t *testing.T, n int, gspec *core.Genesis, engine consensus.E
 			t.Fatalf("block %d: failed to accept into chain: %v", block.NumberU64(), err)
 		}
 	}
-	chain.DrainAcceptorQueue()
 
 	backend := &testBackend{db: db, chain: chain, accman: accman, acc: acc}
 	return backend

--- a/plugin/evm/config.go
+++ b/plugin/evm/config.go
@@ -16,7 +16,6 @@ import (
 )
 
 const (
-	defaultAcceptorQueueLimit                     = 64 // Provides 2 minutes of buffer (2s block target) for a commit delay
 	defaultPruningEnabled                         = true
 	defaultCommitInterval                         = 4096
 	defaultTrieCleanCache                         = 512
@@ -119,7 +118,6 @@ type Config struct {
 
 	// Pruning Settings
 	Pruning                         bool    `json:"pruning-enabled"`                    // If enabled, trie roots are only persisted every 4096 blocks
-	AcceptorQueueLimit              int     `json:"accepted-queue-limit"`               // Maximum blocks to queue before blocking during acceptance
 	CommitInterval                  uint64  `json:"commit-interval"`                    // Specifies the commit interval at which to persist EVM and atomic tries.
 	AllowMissingTries               bool    `json:"allow-missing-tries"`                // If enabled, warnings preventing an incomplete trie index are suppressed
 	PopulateMissingTries            *uint64 `json:"populate-missing-tries,omitempty"`   // Sets the starting point for re-populating missing tries. Disables re-generation if nil.
@@ -262,7 +260,6 @@ func (c *Config) SetDefaults() {
 	c.TrieDirtyCommitTarget = defaultTrieDirtyCommitTarget
 	c.TriePrefetcherParallelism = defaultTriePrefetcherParallelism
 	c.SnapshotCache = defaultSnapshotCache
-	c.AcceptorQueueLimit = defaultAcceptorQueueLimit
 	c.CommitInterval = defaultCommitInterval
 	c.SnapshotWait = defaultSnapshotWait
 	c.PushGossipPercentStake = defaultPushGossipPercentStake

--- a/plugin/evm/service.go
+++ b/plugin/evm/service.go
@@ -23,7 +23,7 @@ type GetAcceptedFrontReply struct {
 
 // GetAcceptedFront returns the last accepted block's hash and height
 func (api *SnowmanAPI) GetAcceptedFront(ctx context.Context) (*GetAcceptedFrontReply, error) {
-	blk := api.vm.blockChain.LastConsensusAcceptedBlock()
+	blk := api.vm.blockChain.LastAcceptedBlock()
 	return &GetAcceptedFrontReply{
 		Hash:   blk.Hash(),
 		Number: blk.Number(),

--- a/plugin/evm/syncervm_test.go
+++ b/plugin/evm/syncervm_test.go
@@ -192,7 +192,6 @@ func TestStateSyncToggleEnabledToDisabled(t *testing.T) {
 	if err := syncDisabledVM.blockChain.Snapshots().Verify(lastRoot); err != nil {
 		t.Fatal(err)
 	}
-	syncDisabledVM.blockChain.DrainAcceptorQueue()
 
 	// Create a new VM from the same database with state sync enabled.
 	syncReEnabledVM := &VM{}
@@ -589,7 +588,6 @@ func generateAndAcceptBlocks(t *testing.T, vm *VM, numBlocks int, gen func(int, 
 	if err != nil {
 		t.Fatal(err)
 	}
-	vm.blockChain.DrainAcceptorQueue()
 }
 
 // assertSyncPerformedHeights iterates over all heights the VM has synced to and

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -417,7 +417,6 @@ func (vm *VM) Initialize(
 	vm.ethConfig.TrieDirtyCommitTarget = vm.config.TrieDirtyCommitTarget
 	vm.ethConfig.TriePrefetcherParallelism = vm.config.TriePrefetcherParallelism
 	vm.ethConfig.SnapshotCache = vm.config.SnapshotCache
-	vm.ethConfig.AcceptorQueueLimit = vm.config.AcceptorQueueLimit
 	vm.ethConfig.PopulateMissingTries = vm.config.PopulateMissingTries
 	vm.ethConfig.PopulateMissingTriesParallelism = vm.config.PopulateMissingTriesParallelism
 	vm.ethConfig.AllowMissingTries = vm.config.AllowMissingTries

--- a/plugin/evm/vm_warp_test.go
+++ b/plugin/evm/vm_warp_test.go
@@ -136,7 +136,6 @@ func TestSendWarpMessage(t *testing.T) {
 
 	require.NoError(vm.SetPreference(context.Background(), blk.ID()))
 	require.NoError(blk.Accept(context.Background()))
-	vm.blockChain.DrainAcceptorQueue()
 
 	// Verify the message signature after accepting the block.
 	rawSignatureBytes, err := vm.warpBackend.GetMessageSignature(unsignedMessageID)
@@ -389,7 +388,6 @@ func testWarpVMTransaction(t *testing.T, unsignedMessage *avalancheWarp.Unsigned
 	require.NoError(warpBlockVerifyWithCtx.VerifyWithContext(context.Background(), blockCtx))
 	require.NoError(vm.SetPreference(context.Background(), warpBlock.ID()))
 	require.NoError(warpBlock.Accept(context.Background()))
-	vm.blockChain.DrainAcceptorQueue()
 
 	ethBlock := warpBlock.(*chain.BlockWrapper).Block.(*Block).ethBlock
 	verifiedMessageReceipts := vm.blockChain.GetReceiptsByHash(ethBlock.Hash())
@@ -701,7 +699,6 @@ func testReceiveWarpMessage(
 
 	// Accept the block after performing multiple VerifyWithContext operations
 	require.NoError(block2.Accept(context.Background()))
-	vm.blockChain.DrainAcceptorQueue()
 
 	verifiedMessageReceipts := vm.blockChain.GetReceiptsByHash(ethBlock.Hash())
 	require.Len(verifiedMessageReceipts, 1)


### PR DESCRIPTION
## Why this should be merged
Reduces differences with upstream and simplifies code.
Note this does not completely remove the acceptorTip, to avoid issues in case of a version bump during an unclean shutdown. (We can discuss how to handle this case more, but this part can already be removed)

## How this works
Removes starting the acceptor queue as a goroutine, instead the same work is done inline during the call to Accept, as it was before the acceptor queue was added.

## How this was tested
CI

## How is this documented
TBD: remove the related config option from docs