### PR TITLE
[testing] Fix image build validation for unmerged avalanchego commit

### DIFF
--- a/scripts/build_docker_image.sh
+++ b/scripts/build_docker_image.sh
@@ -20,7 +20,7 @@ if [[ "${VM_ID}" != "${DEFAULT_VM_ID}"  ]]; then
 fi
 
 # Default to the release image. Will need to be overridden when testing against unreleased versions.
-AVALANCHEGO_NODE_IMAGE=${AVALANCHEGO_NODE_IMAGE:-"avaplatform/avalanchego:${AVALANCHE_VERSION}"}
+AVALANCHEGO_NODE_IMAGE="${AVALANCHEGO_NODE_IMAGE:-${AVALANCHEGO_IMAGE_NAME}:${AVALANCHE_VERSION}}"
 
 echo "Building Docker Image: $DOCKERHUB_REPO:$BUILD_IMAGE_ID based of AvalancheGo@$AVALANCHE_VERSION"
 docker build -t "$DOCKERHUB_REPO:$BUILD_IMAGE_ID" -t "$DOCKERHUB_REPO:${DOCKERHUB_TAG}" \

--- a/scripts/constants.sh
+++ b/scripts/constants.sh
@@ -15,6 +15,9 @@ DEFAULT_VM_ID="srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy"
 # You should probably set it - export DOCKER_REPO='avaplatform/subnet-evm'
 DOCKERHUB_REPO=${DOCKER_REPO:-"subnet-evm"}
 
+# Shared between ./scripts/build_docker_image.sh and ./scripts/tests.build_docker_image.sh
+AVALANCHEGO_IMAGE_NAME="${AVALANCHEGO_IMAGE_NAME:-avaplatform/avalanchego}"
+
 # if this isn't a git repository (say building from a release), don't set our git constants.
 if [ ! -d .git ]; then
     CURRENT_BRANCH=""

--- a/scripts/lib_avalanchego_clone.sh
+++ b/scripts/lib_avalanchego_clone.sh
@@ -15,7 +15,7 @@ export AVALANCHEGO_CLONE_PATH=${AVALANCHEGO_CLONE_PATH:-${SUBNET_EVM_PATH}/avala
 function clone_avalanchego {
   local avalanche_version="$1"
 
-  echo "checking out target avalanchego version ${avalanche_version} to ${AVALANCHE_CLONE_PATH}"
+  echo "checking out target avalanchego version ${avalanche_version} to ${AVALANCHEGO_CLONE_PATH}"
   if [[ -d "${AVALANCHEGO_CLONE_PATH}" ]]; then
     echo "updating existing clone"
     cd "${AVALANCHEGO_CLONE_PATH}"
@@ -32,6 +32,7 @@ function clone_avalanchego {
 
 # Derives an image tag from the current state of the avalanchego clone
 function avalanchego_image_tag_from_clone {
-  local commit_hash="$(git --git-dir="${AVALANCHEGO_CLONE_PATH}/.git" rev-parse HEAD)"
+  local commit_hash
+  commit_hash="$(git --git-dir="${AVALANCHEGO_CLONE_PATH}/.git" rev-parse HEAD)"
   echo "${commit_hash::8}"
 }

--- a/scripts/lib_avalanchego_clone.sh
+++ b/scripts/lib_avalanchego_clone.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Defines functions for interacting with git clones of the avalanchego repo.
+
+if [[ -z "${SUBNET_EVM_PATH}" ]]; then
+  echo "SUBNET_EVM_PATH must be set"
+  exit 1
+fi
+
+export AVALANCHEGO_CLONE_PATH=${AVALANCHEGO_CLONE_PATH:-${SUBNET_EVM_PATH}/avalanchego}
+
+# Clones the avalanchego repo to the configured path and checks out the specified version.
+function clone_avalanchego {
+  local avalanche_version="$1"
+
+  echo "checking out target avalanchego version ${avalanche_version} to ${AVALANCHE_CLONE_PATH}"
+  if [[ -d "${AVALANCHEGO_CLONE_PATH}" ]]; then
+    echo "updating existing clone"
+    cd "${AVALANCHEGO_CLONE_PATH}"
+    git fetch
+  else
+    echo "creating new clone"
+    git clone https://github.com/ava-labs/avalanchego.git "${AVALANCHEGO_CLONE_PATH}"
+    cd "${AVALANCHEGO_CLONE_PATH}"
+  fi
+  # Branch will be reset to $avalanche_version if it already exists
+  git checkout -B "test-${avalanche_version}" "${avalanche_version}"
+  cd "${SUBNET_EVM_PATH}"
+}
+
+# Derives an image tag from the current state of the avalanchego clone
+function avalanchego_image_tag_from_clone {
+  local commit_hash="$(git --git-dir="${AVALANCHEGO_CLONE_PATH}/.git" rev-parse HEAD)"
+  echo "${commit_hash::8}"
+}

--- a/scripts/tests.build_docker_image.sh
+++ b/scripts/tests.build_docker_image.sh
@@ -9,8 +9,27 @@ SUBNET_EVM_PATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
 # Load the constants
 source "$SUBNET_EVM_PATH"/scripts/constants.sh
 
+# Load the versions
+source "$SUBNET_EVM_PATH"/scripts/versions.sh
+
+# Use the default node image
+AVALANCHEGO_NODE_IMAGE="${AVALANCHEGO_IMAGE_NAME}:${AVALANCHE_VERSION}"
+
+# Build the avalanchego image if it cannot be pulled. This will usually be due to
+# AVALANCHE_VERSION being not yet merged since the image is published post-merge.
+if ! docker pull "${AVALANCHEGO_NODE_IMAGE}"; then
+  # Use a image name without a repository (i.e. without 'avaplatform/' prefix ) to build a
+  # local image that will not be pushed.
+  export AVALANCHEGO_IMAGE_NAME="avalanchego"
+  echo "Building ${AVALANCHEGO_IMAGE_NAME}:${AVALANCHE_VERSION} locally"
+
+  source "${SUBNET_EVM_PATH}"/scripts/lib_avalanchego_clone.sh
+  clone_avalanchego "${AVALANCHE_VERSION}"
+  SKIP_BUILD_RACE=1 DOCKER_IMAGE="${AVALANCHEGO_IMAGE_NAME}" "${AVALANCHEGO_CLONE_PATH}"/scripts/build_image.sh
+fi
+
 # Build a local image
-"${SUBNET_EVM_PATH}"/scripts/build_docker_image.sh
+bash -x "${SUBNET_EVM_PATH}"/scripts/build_docker_image.sh
 
 # Check that the image can be run and contains the plugin
 echo "Checking version of the plugin provided by the image"


### PR DESCRIPTION
## Why this should be merged

https://github.com/ava-labs/subnet-evm/pull/1318 added image build validation, but only included support for testing against published avalanchego versions. Since subnet-evm CI frequently needs to target unmerged avalanchego commits, this oversight can break CI for version bump PRs. 

## How this works

Updates the test to build the avalanchego image locally if it cannot be pulled. The logic that maintained the local avalanchego clone was extracted from the antithesis test script for reuse in the image build test script.

## How this was tested

CI validates against regression, and the changes in this PR were validated by rebasing the changes against [the latest bump PR](https://github.com/ava-labs/subnet-evm/pull/1348) that targets an unmerged avalanchego commit and confirming that the test still passed.

## How is this documented

Code comments.