### PR TITLE
fix ci: linux ci doesn't have dos2unix

### DIFF
--- a/scripts/build_test.sh
+++ b/scripts/build_test.sh
@@ -45,7 +45,7 @@ do
     unexpected_failures=$(
         # First grep pattern corresponds to test failures, second pattern corresponds to test panics due to timeouts
         (grep "^--- FAIL" test.out | awk '{print $3}' || grep -E '^\s+Test.+ \(' test.out | awk '{print $1}') |
-        sort -u | comm -23 -  <(dos2unix < ./scripts/known_flakes.txt)
+        sort -u | comm -23 -  <(sed 's/\r$//' ./scripts/known_flakes.txt)
     )
     if [ -n "${unexpected_failures}" ]; then
         echo "Unexpected test failures: ${unexpected_failures}"

--- a/scripts/known_flakes.txt
+++ b/scripts/known_flakes.txt
@@ -9,5 +9,4 @@ TestResyncNewRootAfterDeletes
 TestTransactionSkipIndexing
 TestVMShutdownWhileSyncing
 TestWalletNotifications
-TestWalletNotifications
 TestWebsocketLargeRead


### PR DESCRIPTION
the ubuntu CI doesn't have `dos2unix` installed, so we can use sed instead