### PR TITLE
track env size

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -309,6 +309,7 @@ func (w *worker) commitTransaction(env *environment, tx *types.Transaction, coin
 	}
 	env.txs = append(env.txs, tx)
 	env.receipts = append(env.receipts, receipt)
+	env.size += tx.Size()
 	return receipt.Logs, nil
 }
 


### PR DESCRIPTION
## Why this should be merged

Fixes tracking env tx size. 

## How this works

Adds appended tx size to env.size

## How this was tested

We don't have any worker tests.

## How is this documented

no need
