### PR TITLE
bump versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ The Subnet EVM runs in a separate process from the main AvalancheGo process and 
 [v0.6.6] AvalancheGo@v1.11.3-v1.11.9 (Protocol Version: 35)
 [v0.6.7] AvalancheGo@v1.11.3-v1.11.9 (Protocol Version: 35)
 [v0.6.8] AvalancheGo@v1.11.10 (Protocol Version: 36)
-[v0.6.9] AvalancheGo@v1.11.11 (Protocol Version: 37)
-[v0.6.10] AvalancheGo@v1.11.11 (Protocol Version: 37)
+[v0.6.9] AvalancheGo@v1.11.11-v1.11.12 (Protocol Version: 37)
+[v0.6.10] AvalancheGo@v1.11.11-v1.11.12 (Protocol Version: 37)
+[v0.6.11] AvalancheGo@v1.11.11-v1.11.12 (Protocol Version: 37)
 ```
 
 ## API

--- a/compatibility.json
+++ b/compatibility.json
@@ -1,5 +1,6 @@
 {
   "rpcChainVMProtocolVersion": {
+    "v0.6.11": 37,
     "v0.6.10": 37,
     "v0.6.9": 37,
     "v0.6.8": 36,

--- a/go.mod
+++ b/go.mod
@@ -5,14 +5,13 @@ go 1.22.8
 require (
 	github.com/VictoriaMetrics/fastcache v1.12.1
 	github.com/antithesishq/antithesis-sdk-go v0.3.8
-	github.com/ava-labs/avalanchego v1.11.12-rc.2.0.20241003220930-43d5b435a644
+	github.com/ava-labs/avalanchego v1.11.12
 	github.com/cespare/cp v0.1.0
 	github.com/crate-crypto/go-ipa v0.0.0-20231025140028-3c0104f4b233
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckarep/golang-set/v2 v2.1.0
 	github.com/dop251/goja v0.0.0-20230806174421-c933cf95e127
 	github.com/ethereum/go-ethereum v1.13.14
-	github.com/fjl/memsize v0.0.2
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/gballet/go-libpcsclite v0.0.0-20191108122812-4678299bea08
 	github.com/gballet/go-verkle v0.1.1-0.20231031103413-a67434b50f46

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax
 github.com/antithesishq/antithesis-sdk-go v0.3.8 h1:OvGoHxIcOXFJLyn9IJQ5DzByZ3YVAWNBc394ObzDRb8=
 github.com/antithesishq/antithesis-sdk-go v0.3.8/go.mod h1:IUpT2DPAKh6i/YhSbt6Gl3v2yvUZjmKncl7U91fup7E=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/ava-labs/avalanchego v1.11.12-rc.2.0.20241003220930-43d5b435a644 h1:F3SVwl0bmatEgtL7FeREoLOPGZkNCID6gQk94WmeCgY=
-github.com/ava-labs/avalanchego v1.11.12-rc.2.0.20241003220930-43d5b435a644/go.mod h1:qSHmog3wMVjo/ruIAQo0ppXAilyni07NIu5K88RyhWE=
+github.com/ava-labs/avalanchego v1.11.12 h1:fpGs7xsHYjswIik3tdlGcDaHXh22DLcuf5Ri5+u4RNM=
+github.com/ava-labs/avalanchego v1.11.12/go.mod h1:qSHmog3wMVjo/ruIAQo0ppXAilyni07NIu5K88RyhWE=
 github.com/ava-labs/coreth v0.13.8 h1:f14X3KgwHl9LwzfxlN6S4bbn5VA2rhEsNnHaRLSTo/8=
 github.com/ava-labs/coreth v0.13.8/go.mod h1:t3BSv/eQv0AlDPMfEDCMMoD/jq1RkUsbFzQAFg5qBcE=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
@@ -184,8 +184,6 @@ github.com/ethereum/go-ethereum v1.13.14 h1:EwiY3FZP94derMCIam1iW4HFVrSgIcpsu0Hw
 github.com/ethereum/go-ethereum v1.13.14/go.mod h1:TN8ZiHrdJwSe8Cb6x+p0hs5CxhJZPbqB7hHkaUXcmIU=
 github.com/fasthttp-contrib/websocket v0.0.0-20160511215533-1f3b11f56072/go.mod h1:duJ4Jxv5lDcvg4QuQr0oowTf7dz4/CR8NtyCooz9HL8=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
-github.com/fjl/memsize v0.0.2 h1:27txuSD9or+NZlnOWdKUxeBzTAUkWCVh+4Gf2dWFOzA=
-github.com/fjl/memsize v0.0.2/go.mod h1:VvhXpOYNQvB+uIk2RvXzuaQtkQJzzIx6lSBe1xv7hi0=
 github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=
 github.com/frankban/quicktest v1.14.4/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=

--- a/plugin/evm/version.go
+++ b/plugin/evm/version.go
@@ -11,7 +11,7 @@ var (
 	// GitCommit is set by the build script
 	GitCommit string
 	// Version is the version of Subnet EVM
-	Version string = "v0.6.10"
+	Version string = "v0.6.11"
 )
 
 func init() {

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -4,7 +4,7 @@
 # shellcheck disable=SC2034
 
 # Don't export them as they're used in the context of other calls
-AVALANCHE_VERSION=${AVALANCHE_VERSION:-'43d5b435'}
+AVALANCHE_VERSION=${AVALANCHE_VERSION:-'v1.11.12'}
 GINKGO_VERSION=${GINKGO_VERSION:-'v2.2.0'}
 
 # This won't be used, but it's here to make code syncs easier


### PR DESCRIPTION
This pull request includes updates to various files to support the new version `v0.6.11` of the Subnet EVM. The most important changes include updating version references, modifying compatibility information, and updating dependencies.

Version updates:
* [`plugin/evm/version.go`](diffhunk://#diff-596610e1fec3dd13ec0470efe3c181f0b9a636f258f8e8c6633577a03a85f352L14-R14): Updated the Subnet EVM version to `v0.6.11`.

Compatibility updates:
* [`compatibility.json`](diffhunk://#diff-bfec9cc0599ce232ecc4566d58db2fc1ffc6d783c8e469950d8020a4a99c4d2bR3): Added compatibility information for `v0.6.11`.

Dependency updates:
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L8-L15): Updated the AvalancheGo dependency to version `v1.11.12`.
* [`scripts/versions.sh`](diffhunk://#diff-c275e70e7b0f41a73996876c584ca0336077f3ce442f2a9b9088ca351f7d9a0eL7-R7): Updated the `AVALANCHE_VERSION` to `v1.11.12`.