### PR TITLE
Uptime validation nits

### DIFF
--- a/examples/sign-uptime-message/main.go
+++ b/examples/sign-uptime-message/main.go
@@ -1,0 +1,118 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package main
+
+import (
+	"context"
+	"log"
+	"net/netip"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/ava-labs/avalanchego/api/info"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/network/p2p"
+	"github.com/ava-labs/avalanchego/network/peer"
+	"github.com/ava-labs/avalanchego/proto/pb/sdk"
+	"github.com/ava-labs/avalanchego/snow/networking/router"
+	"github.com/ava-labs/avalanchego/utils/compression"
+	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/avalanchego/vms/platformvm/warp"
+	"github.com/ava-labs/avalanchego/vms/platformvm/warp/payload"
+	"github.com/ava-labs/avalanchego/wallet/subnet/primary"
+	"github.com/ava-labs/subnet-evm/warp/messages"
+
+	p2pmessage "github.com/ava-labs/avalanchego/message"
+)
+
+func main() {
+	uri := primary.LocalAPIURI
+	validationID := ids.FromStringOrPanic("p3NUAY4PbcAnyCyvUTjGVjezNEQCdnVdfAbJcZScvKpxP5tJr")
+	sourceChainID := ids.FromStringOrPanic("2UZWB4xjNadRcHSpXarQoCryiVdcGWoT5w1dUztNfMKkAd2hJX")
+	reqUptime := uint64(3486)
+	infoClient := info.NewClient(uri)
+	networkID, err := infoClient.GetNetworkID(context.Background())
+	if err != nil {
+		log.Fatalf("failed to fetch network ID: %s\n", err)
+	}
+
+	validatorUptime, err := messages.NewValidatorUptime(validationID, reqUptime)
+	if err != nil {
+		log.Fatalf("failed to create validatorUptime message: %s\n", err)
+	}
+
+	addressedCall, err := payload.NewAddressedCall(
+		nil,
+		validatorUptime.Bytes(),
+	)
+	if err != nil {
+		log.Fatalf("failed to create AddressedCall message: %s\n", err)
+	}
+
+	unsignedWarp, err := warp.NewUnsignedMessage(
+		networkID,
+		sourceChainID,
+		addressedCall.Bytes(),
+	)
+	if err != nil {
+		log.Fatalf("failed to create unsigned Warp message: %s\n", err)
+	}
+
+	p, err := peer.StartTestPeer(
+		context.Background(),
+		netip.AddrPortFrom(
+			netip.AddrFrom4([4]byte{127, 0, 0, 1}),
+			9651,
+		),
+		networkID,
+		router.InboundHandlerFunc(func(_ context.Context, msg p2pmessage.InboundMessage) {
+			log.Printf("received %s: %s", msg.Op(), msg.Message())
+		}),
+	)
+	if err != nil {
+		log.Fatalf("failed to start peer: %s\n", err)
+	}
+
+	messageBuilder, err := p2pmessage.NewCreator(
+		logging.NoLog{},
+		prometheus.NewRegistry(),
+		compression.TypeZstd,
+		time.Hour,
+	)
+	if err != nil {
+		log.Fatalf("failed to create message builder: %s\n", err)
+	}
+
+	appRequestPayload, err := proto.Marshal(&sdk.SignatureRequest{
+		Message: unsignedWarp.Bytes(),
+	})
+	if err != nil {
+		log.Fatalf("failed to marshal SignatureRequest: %s\n", err)
+	}
+
+	appRequest, err := messageBuilder.AppRequest(
+		sourceChainID,
+		0,
+		time.Hour,
+		p2p.PrefixMessage(
+			p2p.ProtocolPrefix(p2p.SignatureRequestHandlerID),
+			appRequestPayload,
+		),
+	)
+	if err != nil {
+		log.Fatalf("failed to create AppRequest: %s\n", err)
+	}
+
+	p.Send(context.Background(), appRequest)
+
+	time.Sleep(5 * time.Second)
+
+	p.StartClose()
+	err = p.AwaitClosed(context.Background())
+	if err != nil {
+		log.Fatalf("failed to close peer: %s\n", err)
+	}
+}

--- a/examples/sign-uptime-message/main.go
+++ b/examples/sign-uptime-message/main.go
@@ -30,7 +30,11 @@ import (
 
 func main() {
 	uri := primary.LocalAPIURI
+	// The following IDs are placeholders and should be replaced with real values
+	// before running the code.
+	// The validationID is for the validation period that the uptime message is signed for.
 	validationID := ids.FromStringOrPanic("p3NUAY4PbcAnyCyvUTjGVjezNEQCdnVdfAbJcZScvKpxP5tJr")
+	// The sourceChainID is the ID of the chain.
 	sourceChainID := ids.FromStringOrPanic("2UZWB4xjNadRcHSpXarQoCryiVdcGWoT5w1dUztNfMKkAd2hJX")
 	reqUptime := uint64(3486)
 	infoClient := info.NewClient(uri)

--- a/plugin/evm/service.go
+++ b/plugin/evm/service.go
@@ -27,8 +27,10 @@ type GetCurrentValidatorsResponse struct {
 type CurrentValidator struct {
 	ValidationID ids.ID        `json:"validationID"`
 	NodeID       ids.NodeID    `json:"nodeID"`
+	Weight       uint64        `json:"weight"`
 	StartTime    time.Time     `json:"startTime"`
 	IsActive     bool          `json:"isActive"`
+	IsSoV        bool          `json:"isSoV"`
 	IsConnected  bool          `json:"isConnected"`
 	Uptime       time.Duration `json:"uptime"`
 }
@@ -64,7 +66,9 @@ func (api *ValidatorsAPI) GetCurrentValidators(_ *http.Request, args *GetCurrent
 			ValidationID: validator.ValidationID,
 			NodeID:       nodeID,
 			StartTime:    validator.StartTime,
+			Weight:       validator.Weight,
 			IsActive:     validator.IsActive,
+			IsSoV:        validator.IsSoV,
 			IsConnected:  isConnected,
 			Uptime:       time.Duration(uptime.Seconds()),
 		})

--- a/plugin/evm/service.go
+++ b/plugin/evm/service.go
@@ -65,7 +65,7 @@ func (api *ValidatorsAPI) GetCurrentValidators(_ *http.Request, args *GetCurrent
 		reply.Validators = append(reply.Validators, CurrentValidator{
 			ValidationID: validator.ValidationID,
 			NodeID:       nodeID,
-			StartTime:    validator.StartTime,
+			StartTime:    validator.StartTime(),
 			Weight:       validator.Weight,
 			IsActive:     validator.IsActive,
 			IsSoV:        validator.IsSoV,

--- a/plugin/evm/validators/locked_state_reader.go
+++ b/plugin/evm/validators/locked_state_reader.go
@@ -40,7 +40,7 @@ func (s *lockedStateReader) GetNodeIDs() set.Set[ids.NodeID] {
 	return s.s.GetNodeIDs()
 }
 
-func (s *lockedStateReader) GetValidator(nodeID ids.NodeID) (*ValidatorOutput, error) {
+func (s *lockedStateReader) GetValidator(nodeID ids.NodeID) (*Validator, error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 

--- a/plugin/evm/validators/noop_state.go
+++ b/plugin/evm/validators/noop_state.go
@@ -17,7 +17,7 @@ func (n *noOpState) GetValidationIDs() set.Set[ids.ID] { return set.NewSet[ids.I
 
 func (n *noOpState) GetNodeIDs() set.Set[ids.NodeID] { return set.NewSet[ids.NodeID](0) }
 
-func (n *noOpState) GetValidator(nodeID ids.NodeID) (*ValidatorOutput, error) {
+func (n *noOpState) GetValidator(nodeID ids.NodeID) (*Validator, error) {
 	return nil, nil
 }
 
@@ -45,7 +45,7 @@ func (n *noOpState) GetStartTime(
 	return time.Time{}, nil
 }
 
-func (n *noOpState) AddValidator(vID ids.ID, nodeID ids.NodeID, startTimestamp uint64, isActive bool) error {
+func (n *noOpState) AddValidator(vID ids.ID, nodeID ids.NodeID, weight uint64, startTimestamp uint64, isActive bool, isSoV bool) error {
 	return nil
 }
 

--- a/plugin/evm/validators/noop_state.go
+++ b/plugin/evm/validators/noop_state.go
@@ -45,7 +45,7 @@ func (n *noOpState) GetStartTime(
 	return time.Time{}, nil
 }
 
-func (n *noOpState) AddValidator(vID ids.ID, nodeID ids.NodeID, weight uint64, startTimestamp uint64, isActive bool, isSoV bool) error {
+func (n *noOpState) AddValidator(vdr Validator) error {
 	return nil
 }
 

--- a/plugin/evm/validators/state_test.go
+++ b/plugin/evm/validators/state_test.go
@@ -35,13 +35,13 @@ func TestState(t *testing.T) {
 	require.ErrorIs(err, database.ErrNotFound)
 
 	// add new validator
-	state.AddValidator(vID, nodeID, uint64(startTime.Unix()), true)
+	state.AddValidator(vID, nodeID, 1, uint64(startTime.Unix()), true, true)
 
 	// adding the same validator should fail
-	err = state.AddValidator(vID, ids.GenerateTestNodeID(), uint64(startTime.Unix()), true)
+	err = state.AddValidator(vID, ids.GenerateTestNodeID(), 1, uint64(startTime.Unix()), true, true)
 	require.ErrorIs(err, ErrAlreadyExists)
 	// adding the same nodeID should fail
-	err = state.AddValidator(ids.GenerateTestID(), nodeID, uint64(startTime.Unix()), true)
+	err = state.AddValidator(ids.GenerateTestID(), nodeID, 1, uint64(startTime.Unix()), true, true)
 	require.ErrorIs(err, ErrAlreadyExists)
 
 	// get uptime
@@ -87,7 +87,7 @@ func TestWriteValidator(t *testing.T) {
 	nodeID := ids.GenerateTestNodeID()
 	vID := ids.GenerateTestID()
 	startTime := time.Now()
-	require.NoError(state.AddValidator(vID, nodeID, uint64(startTime.Unix()), true))
+	require.NoError(state.AddValidator(vID, nodeID, uint64(startTime.Unix()), 1, true, true))
 
 	// write state, should reflect to DB
 	require.NoError(state.WriteState())
@@ -230,7 +230,7 @@ func TestStateListener(t *testing.T) {
 	initialStartTime := time.Now()
 
 	// add initial validator
-	require.NoError(state.AddValidator(initialvID, initialNodeID, uint64(initialStartTime.Unix()), true))
+	require.NoError(state.AddValidator(initialvID, initialNodeID, 1, uint64(initialStartTime.Unix()), true, true))
 
 	// register listener
 	mockListener.EXPECT().OnValidatorAdded(initialvID, initialNodeID, uint64(initialStartTime.Unix()), true)
@@ -238,7 +238,7 @@ func TestStateListener(t *testing.T) {
 
 	// add new validator
 	mockListener.EXPECT().OnValidatorAdded(expectedvID, expectedNodeID, uint64(expectedStartTime.Unix()), true)
-	require.NoError(state.AddValidator(expectedvID, expectedNodeID, uint64(expectedStartTime.Unix()), true))
+	require.NoError(state.AddValidator(expectedvID, expectedNodeID, 1, uint64(expectedStartTime.Unix()), true, true))
 
 	// set status
 	mockListener.EXPECT().OnValidatorStatusUpdated(expectedvID, expectedNodeID, false)

--- a/plugin/evm/validators/state_test.go
+++ b/plugin/evm/validators/state_test.go
@@ -159,8 +159,14 @@ func TestParseValidator(t *testing.T) {
 			name:  "nil",
 			bytes: nil,
 			expected: &validatorData{
-				LastUpdated: 0,
-				StartTime:   0,
+				LastUpdated:  0,
+				StartTime:    0,
+				validationID: ids.Empty,
+				NodeID:       ids.EmptyNodeID,
+				UpDuration:   0,
+				Weight:       0,
+				IsActive:     false,
+				IsSoV:        false,
 			},
 			expectedErr: nil,
 		},
@@ -168,8 +174,14 @@ func TestParseValidator(t *testing.T) {
 			name:  "empty",
 			bytes: []byte{},
 			expected: &validatorData{
-				LastUpdated: 0,
-				StartTime:   0,
+				LastUpdated:  0,
+				StartTime:    0,
+				validationID: ids.Empty,
+				NodeID:       ids.EmptyNodeID,
+				UpDuration:   0,
+				Weight:       0,
+				IsActive:     false,
+				IsSoV:        false,
 			},
 			expectedErr: nil,
 		},
@@ -186,9 +198,13 @@ func TestParseValidator(t *testing.T) {
 				0x7e, 0xef, 0xe8, 0x8a, 0x45, 0xfb, 0x7a, 0xc4,
 				0xb0, 0x59, 0xc9, 0x33, 0x71, 0x0a, 0x57, 0x33,
 				0xff, 0x9f, 0x4b, 0xab,
+				// weight
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
 				// start time
 				0x00, 0x00, 0x00, 0x00, 0x00, 0x5B, 0x8D, 0x80,
 				// status
+				0x01,
+				// is SoV
 				0x01,
 			},
 			expected: &validatorData{
@@ -197,6 +213,8 @@ func TestParseValidator(t *testing.T) {
 				NodeID:      testNodeID,
 				StartTime:   6000000,
 				IsActive:    true,
+				Weight:      1,
+				IsSoV:       true,
 			},
 		},
 		{

--- a/plugin/evm/validators/state_test.go
+++ b/plugin/evm/validators/state_test.go
@@ -35,13 +35,34 @@ func TestState(t *testing.T) {
 	require.ErrorIs(err, database.ErrNotFound)
 
 	// add new validator
-	state.AddValidator(vID, nodeID, 1, uint64(startTime.Unix()), true, true)
+	state.AddValidator(Validator{
+		ValidationID:   vID,
+		NodeID:         nodeID,
+		Weight:         1,
+		StartTimestamp: uint64(startTime.Unix()),
+		IsActive:       true,
+		IsSoV:          true,
+	})
 
 	// adding the same validator should fail
-	err = state.AddValidator(vID, ids.GenerateTestNodeID(), 1, uint64(startTime.Unix()), true, true)
+	err = state.AddValidator(Validator{
+		ValidationID:   vID,
+		NodeID:         ids.GenerateTestNodeID(),
+		Weight:         1,
+		StartTimestamp: uint64(startTime.Unix()),
+		IsActive:       true,
+		IsSoV:          true,
+	})
 	require.ErrorIs(err, ErrAlreadyExists)
 	// adding the same nodeID should fail
-	err = state.AddValidator(ids.GenerateTestID(), nodeID, 1, uint64(startTime.Unix()), true, true)
+	err = state.AddValidator(Validator{
+		ValidationID:   ids.GenerateTestID(),
+		NodeID:         nodeID,
+		Weight:         1,
+		StartTimestamp: uint64(startTime.Unix()),
+		IsActive:       true,
+		IsSoV:          true,
+	})
 	require.ErrorIs(err, ErrAlreadyExists)
 
 	// get uptime
@@ -87,7 +108,14 @@ func TestWriteValidator(t *testing.T) {
 	nodeID := ids.GenerateTestNodeID()
 	vID := ids.GenerateTestID()
 	startTime := time.Now()
-	require.NoError(state.AddValidator(vID, nodeID, uint64(startTime.Unix()), 1, true, true))
+	require.NoError(state.AddValidator(Validator{
+		ValidationID:   vID,
+		NodeID:         nodeID,
+		Weight:         1,
+		StartTimestamp: uint64(startTime.Unix()),
+		IsActive:       true,
+		IsSoV:          true,
+	}))
 
 	// write state, should reflect to DB
 	require.NoError(state.WriteState())
@@ -230,7 +258,14 @@ func TestStateListener(t *testing.T) {
 	initialStartTime := time.Now()
 
 	// add initial validator
-	require.NoError(state.AddValidator(initialvID, initialNodeID, 1, uint64(initialStartTime.Unix()), true, true))
+	require.NoError(state.AddValidator(Validator{
+		ValidationID:   initialvID,
+		NodeID:         initialNodeID,
+		Weight:         1,
+		StartTimestamp: uint64(initialStartTime.Unix()),
+		IsActive:       true,
+		IsSoV:          true,
+	}))
 
 	// register listener
 	mockListener.EXPECT().OnValidatorAdded(initialvID, initialNodeID, uint64(initialStartTime.Unix()), true)
@@ -238,7 +273,14 @@ func TestStateListener(t *testing.T) {
 
 	// add new validator
 	mockListener.EXPECT().OnValidatorAdded(expectedvID, expectedNodeID, uint64(expectedStartTime.Unix()), true)
-	require.NoError(state.AddValidator(expectedvID, expectedNodeID, 1, uint64(expectedStartTime.Unix()), true, true))
+	require.NoError(state.AddValidator(Validator{
+		ValidationID:   expectedvID,
+		NodeID:         expectedNodeID,
+		Weight:         1,
+		StartTimestamp: uint64(expectedStartTime.Unix()),
+		IsActive:       true,
+		IsSoV:          true,
+	}))
 
 	// set status
 	mockListener.EXPECT().OnValidatorStatusUpdated(expectedvID, expectedNodeID, false)

--- a/plugin/evm/validators/validator.go
+++ b/plugin/evm/validators/validator.go
@@ -1,0 +1,21 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package validators
+
+import (
+	"time"
+
+	ids "github.com/ava-labs/avalanchego/ids"
+)
+
+type Validator struct {
+	ValidationID   ids.ID     `json:"validationID"`
+	NodeID         ids.NodeID `json:"nodeID"`
+	Weight         uint64     `json:"weight"`
+	StartTimestamp uint64     `json:"startTimestamp"`
+	IsActive       bool       `json:"isActive"`
+	IsSoV          bool       `json:"isSoV"`
+}
+
+func (v *Validator) StartTime() time.Time { return time.Unix(int64(v.StartTimestamp), 0) }

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -1461,8 +1461,6 @@ func (vm *VM) performValidatorUpdate(ctx context.Context) error {
 		return fmt.Errorf("failed to get current validator set: %w", err)
 	}
 
-	log.Info("updating validators", "validatorSet", currentValidatorSet)
-
 	// load the current validator set into the validator state
 	if err := loadValidators(vm.validatorState, currentValidatorSet); err != nil {
 		return fmt.Errorf("failed to load current validators: %w", err)
@@ -1504,7 +1502,7 @@ func loadValidators(validatorState validators.State, validators map[ids.ID]*aval
 				}
 			}
 		} else {
-			if err := validatorState.AddValidator(vID, vdr.NodeID, vdr.StartTime, vdr.IsActive); err != nil {
+			if err := validatorState.AddValidator(vID, vdr.NodeID, vdr.Weight, vdr.StartTime, vdr.IsActive, vdr.IsSoV); err != nil {
 				return err
 			}
 		}

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -1477,19 +1477,19 @@ func (vm *VM) performValidatorUpdate(ctx context.Context) error {
 }
 
 // loadValidators loads the [validators] into the validator state [validatorState]
-func loadValidators(validatorState validators.State, validators map[ids.ID]*avalancheValidators.GetCurrentValidatorOutput) error {
+func loadValidators(validatorState validators.State, vdrs map[ids.ID]*avalancheValidators.GetCurrentValidatorOutput) error {
 	currentValidationIDs := validatorState.GetValidationIDs()
 	// first check if we need to delete any existing validators
 	for vID := range currentValidationIDs {
 		// if the validator is not in the new set of validators
 		// delete the validator
-		if _, exists := validators[vID]; !exists {
+		if _, exists := vdrs[vID]; !exists {
 			validatorState.DeleteValidator(vID)
 		}
 	}
 
 	// then load the new validators
-	for vID, vdr := range validators {
+	for vID, vdr := range vdrs {
 		if currentValidationIDs.Contains(vID) {
 			// Check if IsActive has changed
 			isActive, err := validatorState.GetStatus(vID)
@@ -1502,7 +1502,14 @@ func loadValidators(validatorState validators.State, validators map[ids.ID]*aval
 				}
 			}
 		} else {
-			if err := validatorState.AddValidator(vID, vdr.NodeID, vdr.Weight, vdr.StartTime, vdr.IsActive, vdr.IsSoV); err != nil {
+			if err := validatorState.AddValidator(validators.Validator{
+				ValidationID:   vID,
+				NodeID:         vdr.NodeID,
+				Weight:         vdr.Weight,
+				StartTimestamp: vdr.StartTime,
+				IsActive:       vdr.IsActive,
+				IsSoV:          vdr.IsSoV,
+			}); err != nil {
 				return err
 			}
 		}

--- a/plugin/evm/vm_validators_state_test.go
+++ b/plugin/evm/vm_validators_state_test.go
@@ -318,7 +318,14 @@ func TestLoadNewValidators(t *testing.T) {
 
 			// set initial validators
 			for vID, validator := range test.initialValidators {
-				err := validatorState.AddValidator(vID, validator.NodeID, validator.Weight, validator.StartTime, validator.IsActive, validator.IsSoV)
+				err := validatorState.AddValidator(validators.Validator{
+					ValidationID:   vID,
+					NodeID:         validator.NodeID,
+					Weight:         validator.Weight,
+					StartTimestamp: validator.StartTime,
+					IsActive:       validator.IsActive,
+					IsSoV:          validator.IsSoV,
+				})
 				require.NoError(err)
 			}
 			// enable mock listener

--- a/plugin/evm/vm_validators_state_test.go
+++ b/plugin/evm/vm_validators_state_test.go
@@ -318,7 +318,7 @@ func TestLoadNewValidators(t *testing.T) {
 
 			// set initial validators
 			for vID, validator := range test.initialValidators {
-				err := validatorState.AddValidator(vID, validator.NodeID, validator.StartTime, validator.IsActive)
+				err := validatorState.AddValidator(vID, validator.NodeID, validator.Weight, validator.StartTime, validator.IsActive, validator.IsSoV)
 				require.NoError(err)
 			}
 			// enable mock listener

--- a/warp/messages/payload.go
+++ b/warp/messages/payload.go
@@ -20,12 +20,6 @@ type Payload interface {
 	initialize(b []byte)
 }
 
-// Signable is an optional interface that payloads can implement to allow
-// on-the-fly signing of incoming messages by the warp backend.
-type Signable interface {
-	VerifyMesssage(sourceAddress []byte) error
-}
-
 func Parse(bytes []byte) (Payload, error) {
 	var payload Payload
 	if _, err := Codec.Unmarshal(bytes, &payload); err != nil {

--- a/warp/verifier_backend_test.go
+++ b/warp/verifier_backend_test.go
@@ -307,7 +307,14 @@ func TestUptimeSignatures(t *testing.T) {
 		// uptime is less than requested (not connected)
 		validationID := ids.GenerateTestID()
 		nodeID := ids.GenerateTestNodeID()
-		require.NoError(t, state.AddValidator(validationID, nodeID, 1, clk.Unix(), true, true))
+		require.NoError(t, state.AddValidator(validators.Validator{
+			ValidationID:   validationID,
+			NodeID:         nodeID,
+			Weight:         1,
+			StartTimestamp: clk.Unix(),
+			IsActive:       true,
+			IsSoV:          true,
+		}))
 		protoBytes, _ = getUptimeMessageBytes(validationID, 80)
 		_, appErr = handler.AppRequest(context.Background(), nodeID, time.Time{}, protoBytes)
 		require.ErrorIs(t, appErr, &common.AppError{Code: VerifyErrCode})

--- a/warp/verifier_backend_test.go
+++ b/warp/verifier_backend_test.go
@@ -307,7 +307,7 @@ func TestUptimeSignatures(t *testing.T) {
 		// uptime is less than requested (not connected)
 		validationID := ids.GenerateTestID()
 		nodeID := ids.GenerateTestNodeID()
-		require.NoError(t, state.AddValidator(validationID, nodeID, clk.Unix(), true))
+		require.NoError(t, state.AddValidator(validationID, nodeID, 1, clk.Unix(), true, true))
 		protoBytes, _ = getUptimeMessageBytes(validationID, 80)
 		_, appErr = handler.AppRequest(context.Background(), nodeID, time.Time{}, protoBytes)
 		require.ErrorIs(t, appErr, &common.AppError{Code: VerifyErrCode})

--- a/warp/verifier_backend_test.go
+++ b/warp/verifier_backend_test.go
@@ -321,7 +321,7 @@ func TestUptimeSignatures(t *testing.T) {
 			IsActive:       true,
 			IsSoV:          true,
 		}))
-		protoBytes, _ = getUptimeMessageBytes(validationID, 80)
+		protoBytes, _ = getUptimeMessageBytes([]byte{}, validationID, 80)
 		_, appErr = handler.AppRequest(context.Background(), nodeID, time.Time{}, protoBytes)
 		require.ErrorIs(t, appErr, &common.AppError{Code: VerifyErrCode})
 		require.Contains(t, appErr.Error(), "current uptime 0 is less than queried uptime 80")


### PR DESCRIPTION
## Why this should be merged

* Adds a example for uptime warp msg signing
* Adds `IsSoV` and `weight` fields to validators 


## How this was tested

Added e2e test

## How is this documented

should document whole `GetCurrentValidators` API
