### PR TITLE
avoid using verdb

### DIFF
--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -1255,8 +1255,7 @@ func (vm *VM) initializeDBs(avaDB database.Database) error {
 	// skip standalone database initialization if we are running in unit tests
 	if vm.ctx.NetworkID != avalancheconstants.UnitTestID {
 		// first initialize the accepted block database to check if we need to use a standalone database
-		verDB := versiondb.New(avaDB)
-		acceptedDB := prefixdb.New(acceptedPrefix, verDB)
+		acceptedDB := prefixdb.New(acceptedPrefix, avaDB)
 		useStandAloneDB, err := vm.useStandaloneDatabase(acceptedDB)
 		if err != nil {
 			return err
@@ -1279,8 +1278,8 @@ func (vm *VM) initializeDBs(avaDB database.Database) error {
 	// remains the same regardless of the provided baseDB type.
 	vm.chaindb = rawdb.NewDatabase(Database{prefixdb.NewNested(ethDBPrefix, db)})
 	vm.db = versiondb.New(db)
-	vm.acceptedBlockDB = prefixdb.New(acceptedPrefix, vm.db)
-	vm.metadataDB = prefixdb.New(metadataPrefix, vm.db)
+	vm.acceptedBlockDB = prefixdb.New(acceptedPrefix, db)
+	vm.metadataDB = prefixdb.New(metadataPrefix, db)
 	// Note warpDB is not part of versiondb because it is not necessary
 	// that warp signatures are committed to the database atomically with
 	// the last accepted block.


### PR DESCRIPTION
## Why this should be merged

`vm.db`  (versionDB) is flushed with `SharedMemory` to the SharedMemory's underlying db (avaDB). This prevents us persist acceptedBlockDB and metadataDB in the standalone db and leads to a corruption. This is not an ideal fix as this simply stops using verDB in both dbs.

## How this works

This pull request includes changes to the `initializeDBs` function in the `plugin/evm/vm.go` file to simplify the database initialization process by removing the use of `versiondb` for certain databases.

Changes to database initialization:

* Simplified the initialization of `acceptedDB` by directly using `avaDB` instead of wrapping it with `versiondb`. (`plugin/evm/vm.go`, [plugin/evm/vm.goL1258-R1258](diffhunk://#diff-3be5ea9687f8af021d9baaa6584d174a7975b181b604e1a759e4ad2e40136912L1258-R1258))
* Modified the initialization of `acceptedBlockDB` and `metadataDB` to use `db` directly instead of wrapping it with `versiondb`. (`plugin/evm/vm.go`, [plugin/evm/vm.goL1282-R1282](diffhunk://#diff-3be5ea9687f8af021d9baaa6584d174a7975b181b604e1a759e4ad2e40136912L1282-R1282))

## How this was tested

Locally tested to see if it fixes the issue

## Need to be documented?

No

## Need to update RELEASES.md?

No
