### PR TITLE
Use startimestamp

### DIFF
--- a/plugin/evm/client.go
+++ b/plugin/evm/client.go
@@ -24,24 +24,26 @@ type Client interface {
 	LockProfile(ctx context.Context, options ...rpc.Option) error
 	SetLogLevel(ctx context.Context, level slog.Level, options ...rpc.Option) error
 	GetVMConfig(ctx context.Context, options ...rpc.Option) (*Config, error)
+	GetCurrentValidators(ctx context.Context, options ...rpc.Option) ([]CurrentValidator, error)
 }
 
 // Client implementation for interacting with EVM [chain]
 type client struct {
-	adminRequester rpc.EndpointRequester
+	adminRequester      rpc.EndpointRequester
+	validatorsRequester rpc.EndpointRequester
 }
 
 // NewClient returns a Client for interacting with EVM [chain]
 func NewClient(uri, chain string) Client {
+	requestUri := fmt.Sprintf("%s/ext/bc/%s", uri, chain)
 	return &client{
-		adminRequester: rpc.NewEndpointRequester(fmt.Sprintf("%s/ext/bc/%s/admin", uri, chain)),
+		adminRequester: rpc.NewEndpointRequester(
+			requestUri + "/admin",
+		),
+		validatorsRequester: rpc.NewEndpointRequester(
+			requestUri + "/validators",
+		),
 	}
-}
-
-// NewCChainClient returns a Client for interacting with the C Chain
-func NewCChainClient(uri string) Client {
-	// TODO: Update for Subnet-EVM compatibility
-	return NewClient(uri, "C")
 }
 
 func (c *client) StartCPUProfiler(ctx context.Context, options ...rpc.Option) error {
@@ -72,4 +74,11 @@ func (c *client) GetVMConfig(ctx context.Context, options ...rpc.Option) (*Confi
 	res := &ConfigReply{}
 	err := c.adminRequester.SendRequest(ctx, "admin.getVMConfig", struct{}{}, res, options...)
 	return res.Config, err
+}
+
+// GetCurrentValidators returns the current validators
+func (c *client) GetCurrentValidators(ctx context.Context, options ...rpc.Option) ([]CurrentValidator, error) {
+	res := &GetCurrentValidatorsResponse{}
+	err := c.validatorsRequester.SendRequest(ctx, "validators.getCurrentValidators", struct{}{}, res, options...)
+	return res.Validators, err
 }

--- a/plugin/evm/service.go
+++ b/plugin/evm/service.go
@@ -14,23 +14,19 @@ type ValidatorsAPI struct {
 	vm *VM
 }
 
-type GetCurrentValidatorsRequest struct {
-	NodeIDs []ids.NodeID `json:"nodeIDs"`
-}
-
 type GetCurrentValidatorsResponse struct {
 	Validators []CurrentValidator `json:"validators"`
 }
 
 type CurrentValidator struct {
-	ValidationID ids.ID        `json:"validationID"`
-	NodeID       ids.NodeID    `json:"nodeID"`
-	Weight       uint64        `json:"weight"`
-	StartTime    time.Time     `json:"startTime"`
-	IsActive     bool          `json:"isActive"`
-	IsSoV        bool          `json:"isSoV"`
-	IsConnected  bool          `json:"isConnected"`
-	Uptime       time.Duration `json:"uptime"`
+	ValidationID   ids.ID        `json:"validationID"`
+	NodeID         ids.NodeID    `json:"nodeID"`
+	Weight         uint64        `json:"weight"`
+	StartTimestamp uint64        `json:"startTimestamp"`
+	IsActive       bool          `json:"isActive"`
+	IsSoV          bool          `json:"isSoV"`
+	IsConnected    bool          `json:"isConnected"`
+	Uptime         time.Duration `json:"uptime"`
 }
 
 func (api *ValidatorsAPI) GetCurrentValidators(_ *http.Request, _ *struct{}, reply *GetCurrentValidatorsResponse) error {
@@ -55,14 +51,14 @@ func (api *ValidatorsAPI) GetCurrentValidators(_ *http.Request, _ *struct{}, rep
 		}
 
 		reply.Validators = append(reply.Validators, CurrentValidator{
-			ValidationID: validator.ValidationID,
-			NodeID:       validator.NodeID,
-			StartTime:    validator.StartTime(),
-			Weight:       validator.Weight,
-			IsActive:     validator.IsActive,
-			IsSoV:        validator.IsSoV,
-			IsConnected:  isConnected,
-			Uptime:       time.Duration(uptime.Seconds()),
+			ValidationID:   validator.ValidationID,
+			NodeID:         validator.NodeID,
+			StartTimestamp: validator.StartTimestamp,
+			Weight:         validator.Weight,
+			IsActive:       validator.IsActive,
+			IsSoV:          validator.IsSoV,
+			IsConnected:    isConnected,
+			Uptime:         time.Duration(uptime.Seconds()),
 		})
 	}
 	return nil


### PR DESCRIPTION
## Why this should be merged

This pull request introduces several changes to the `plugin/evm` package, primarily focusing on adding support for retrieving current validators and modifying the structure of the `CurrentValidator` type. The key changes are grouped into two themes: adding functionality and modifying data structures.

## How this works

### Adding Functionality:

* Added the `GetCurrentValidators` method to the `Client` interface and its implementation in the `client` struct in `plugin/evm/client.go`. This method allows fetching the current validators. [[1]](diffhunk://#diff-f2ee9b6048cfd95ed277b400ea49d3ab7eaf30e8d033cdb0b6c7cfca9cae336cR27-L46) [[2]](diffhunk://#diff-f2ee9b6048cfd95ed277b400ea49d3ab7eaf30e8d033cdb0b6c7cfca9cae336cR78-R84)

### Modifying Data Structures:

* Updated the `CurrentValidator` struct in `plugin/evm/service.go` to replace `StartTime` with `StartTimestamp` as a `uint64`. This change reflects a shift from using `time.Time` to a simpler timestamp format. [[1]](diffhunk://#diff-42f3e9fd1f7cfff775643d1bad698671c0a34b8e3d3e5ab867626fcc0fa6fb8fL29-R25) [[2]](diffhunk://#diff-42f3e9fd1f7cfff775643d1bad698671c0a34b8e3d3e5ab867626fcc0fa6fb8fL60-R56)
* Removed the `GetCurrentValidatorsRequest` struct from `plugin/evm/service.go` as it was not being used.

## How this was tested

locally

## Need to be documented?

yes along with other changes

## Need to update RELEASES.md?

related changes are not captured yet
