### PR TITLE
use nodeID filter and uptimePerc

### DIFF
--- a/plugin/evm/client.go
+++ b/plugin/evm/client.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/exp/slog"
 
 	"github.com/ava-labs/avalanchego/api"
+	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/rpc"
 )
 
@@ -24,7 +25,7 @@ type Client interface {
 	LockProfile(ctx context.Context, options ...rpc.Option) error
 	SetLogLevel(ctx context.Context, level slog.Level, options ...rpc.Option) error
 	GetVMConfig(ctx context.Context, options ...rpc.Option) (*Config, error)
-	GetCurrentValidators(ctx context.Context, options ...rpc.Option) ([]CurrentValidator, error)
+	GetCurrentValidators(ctx context.Context, nodeIDs []ids.NodeID, options ...rpc.Option) ([]CurrentValidator, error)
 }
 
 // Client implementation for interacting with EVM [chain]
@@ -77,8 +78,10 @@ func (c *client) GetVMConfig(ctx context.Context, options ...rpc.Option) (*Confi
 }
 
 // GetCurrentValidators returns the current validators
-func (c *client) GetCurrentValidators(ctx context.Context, options ...rpc.Option) ([]CurrentValidator, error) {
+func (c *client) GetCurrentValidators(ctx context.Context, nodeIDs []ids.NodeID, options ...rpc.Option) ([]CurrentValidator, error) {
 	res := &GetCurrentValidatorsResponse{}
-	err := c.validatorsRequester.SendRequest(ctx, "validators.getCurrentValidators", struct{}{}, res, options...)
+	err := c.validatorsRequester.SendRequest(ctx, "validators.getCurrentValidators", &GetCurrentValidatorsRequest{
+		NodeIDs: nodeIDs,
+	}, res, options...)
 	return res.Validators, err
 }

--- a/plugin/evm/service.go
+++ b/plugin/evm/service.go
@@ -4,14 +4,19 @@
 package evm
 
 import (
+	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/set"
 )
 
 type ValidatorsAPI struct {
 	vm *VM
+}
+
+type GetCurrentValidatorsRequest struct {
+	NodeIDs []ids.NodeID `json:"nodeIDs"`
 }
 
 type GetCurrentValidatorsResponse struct {
@@ -19,46 +24,62 @@ type GetCurrentValidatorsResponse struct {
 }
 
 type CurrentValidator struct {
-	ValidationID   ids.ID        `json:"validationID"`
-	NodeID         ids.NodeID    `json:"nodeID"`
-	Weight         uint64        `json:"weight"`
-	StartTimestamp uint64        `json:"startTimestamp"`
-	IsActive       bool          `json:"isActive"`
-	IsL1Validator  bool          `json:"isL1Validator"`
-	IsConnected    bool          `json:"isConnected"`
-	Uptime         time.Duration `json:"uptime"`
+	ValidationID     ids.ID     `json:"validationID"`
+	NodeID           ids.NodeID `json:"nodeID"`
+	Weight           uint64     `json:"weight"`
+	StartTimestamp   uint64     `json:"startTimestamp"`
+	IsActive         bool       `json:"isActive"`
+	IsL1Validator    bool       `json:"isL1Validator"`
+	IsConnected      bool       `json:"isConnected"`
+	UptimePercentage float32    `json:"uptimePercentage"`
 }
 
-func (api *ValidatorsAPI) GetCurrentValidators(_ *http.Request, _ *struct{}, reply *GetCurrentValidatorsResponse) error {
+func (api *ValidatorsAPI) GetCurrentValidators(_ *http.Request, req *GetCurrentValidatorsRequest, reply *GetCurrentValidatorsResponse) error {
 	api.vm.ctx.Lock.RLock()
 	defer api.vm.ctx.Lock.RUnlock()
 
-	vIDs := api.vm.validatorsManager.GetValidationIDs()
+	var vIDs set.Set[ids.ID]
+	if len(req.NodeIDs) > 0 {
+		vIDs = set.NewSet[ids.ID](len(req.NodeIDs))
+		for _, nodeID := range req.NodeIDs {
+			vID, err := api.vm.validatorsManager.GetValidationID(nodeID)
+			if err != nil {
+				return fmt.Errorf("couldn't find validator with node ID %s", nodeID)
+			}
+			vIDs.Add(vID)
+		}
+	} else {
+		vIDs = api.vm.validatorsManager.GetValidationIDs()
+	}
 
 	reply.Validators = make([]CurrentValidator, 0, vIDs.Len())
 
 	for _, vID := range vIDs.List() {
 		validator, err := api.vm.validatorsManager.GetValidator(vID)
 		if err != nil {
-			return err
+			return fmt.Errorf("couldn't find validator with validation ID %s", vID)
 		}
 
 		isConnected := api.vm.validatorsManager.IsConnected(validator.NodeID)
 
-		uptime, _, err := api.vm.validatorsManager.CalculateUptime(validator.NodeID)
+		uptimeFloat, err := api.vm.validatorsManager.CalculateUptimePercent(validator.NodeID)
 		if err != nil {
-			return err
+			return fmt.Errorf("couldn't calculate uptime percentage for validation ID %s", vID)
 		}
 
+		// Transform this to a percentage (0-100) to make it consistent
+		// with currentValidators in PlatformVM API
+		uptimePercentage := float32(uptimeFloat * 100)
+
 		reply.Validators = append(reply.Validators, CurrentValidator{
-			ValidationID:   validator.ValidationID,
-			NodeID:         validator.NodeID,
-			StartTimestamp: validator.StartTimestamp,
-			Weight:         validator.Weight,
-			IsActive:       validator.IsActive,
-			IsL1Validator:  validator.IsL1Validator,
-			IsConnected:    isConnected,
-			Uptime:         time.Duration(uptime.Seconds()),
+			ValidationID:     validator.ValidationID,
+			NodeID:           validator.NodeID,
+			StartTimestamp:   validator.StartTimestamp,
+			Weight:           validator.Weight,
+			IsActive:         validator.IsActive,
+			IsL1Validator:    validator.IsL1Validator,
+			IsConnected:      isConnected,
+			UptimePercentage: uptimePercentage,
 		})
 	}
 	return nil

--- a/plugin/evm/validators/state/interfaces/state.go
+++ b/plugin/evm/validators/state/interfaces/state.go
@@ -16,6 +16,8 @@ type StateReader interface {
 	GetValidationIDs() set.Set[ids.ID]
 	// GetNodeIDs returns the validator node IDs in the state
 	GetNodeIDs() set.Set[ids.NodeID]
+	// GetValidationID returns the validation ID for the given node ID
+	GetValidationID(nodeID ids.NodeID) (ids.ID, error)
 }
 
 type State interface {

--- a/plugin/evm/validators/state/state.go
+++ b/plugin/evm/validators/state/state.go
@@ -239,6 +239,15 @@ func (s *state) GetNodeIDs() set.Set[ids.NodeID] {
 	return ids
 }
 
+// GetValidationID returns the validation ID for the given nodeID
+func (s *state) GetValidationID(nodeID ids.NodeID) (ids.ID, error) {
+	vID, exists := s.index[nodeID]
+	if !exists {
+		return ids.ID{}, database.ErrNotFound
+	}
+	return vID, nil
+}
+
 // GetValidator returns the validator data for the given validationID
 func (s *state) GetValidator(vID ids.ID) (interfaces.Validator, error) {
 	data, ok := s.data[vID]


### PR DESCRIPTION
## Why this should be merged

`getCurrentValidators` in Platform VM API returns uptime percentage. This PR changes the uptime seconds to uptime percentage in `GetCurrentValidators` API to keep the consistency between APIs. It also adds NodeID filtering.

## How this works

* [`plugin/evm/client.go`](diffhunk://#diff-f2ee9b6048cfd95ed277b400ea49d3ab7eaf30e8d033cdb0b6c7cfca9cae336cL27-R28): Modified the `GetCurrentValidators` method to accept `nodeIDs` as a parameter, allowing for filtered queries. [[1]](diffhunk://#diff-f2ee9b6048cfd95ed277b400ea49d3ab7eaf30e8d033cdb0b6c7cfca9cae336cL27-R28) [[2]](diffhunk://#diff-f2ee9b6048cfd95ed277b400ea49d3ab7eaf30e8d033cdb0b6c7cfca9cae336cL80-R85)
* [`plugin/evm/service.go`](diffhunk://#diff-42f3e9fd1f7cfff775643d1bad698671c0a34b8e3d3e5ab867626fcc0fa6fb8fR7-R21): Introduced `GetCurrentValidatorsRequest` to handle node ID filtering and updated the `GetCurrentValidators` method to use this request. Additionally, changed the `Uptime` field to `UptimePercentage` for consistency with the PlatformVM API. [[1]](diffhunk://#diff-42f3e9fd1f7cfff775643d1bad698671c0a34b8e3d3e5ab867626fcc0fa6fb8fR7-R21) [[2]](diffhunk://#diff-42f3e9fd1f7cfff775643d1bad698671c0a34b8e3d3e5ab867626fcc0fa6fb8fL29-R73) [[3]](diffhunk://#diff-42f3e9fd1f7cfff775643d1bad698671c0a34b8e3d3e5ab867626fcc0fa6fb8fL61-R82)

Support for new method in state interfaces:

* [`plugin/evm/validators/state/interfaces/state.go`](diffhunk://#diff-190cee8f203955ebb957f4da27c648c58fdb9363e70a4e7329303ae5dc58dd39R19-R20): Added `GetValidationID` method to the `StateReader` interface to retrieve validation IDs based on node IDs.
* [`plugin/evm/validators/state/state.go`](diffhunk://#diff-e46380917993bdd51b392434fa7a53079d569379714560baa561445319eacd1eR242-R250): Implemented the `GetValidationID` method in the `state` struct to support the new functionality.

## How this was tested

Locally

## Need to be documented?

Yes

## Need to update RELEASES.md?

Not since we have not captured the API.
