### PR TITLE
bump avago to v1.11.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The Subnet EVM runs in a separate process from the main AvalancheGo process and 
 [v0.6.9] AvalancheGo@v1.11.11-v1.11.12 (Protocol Version: 37)
 [v0.6.10] AvalancheGo@v1.11.11-v1.11.12 (Protocol Version: 37)
 [v0.6.11] AvalancheGo@v1.11.11-v1.11.12 (Protocol Version: 37)
-[v0.6.12] AvalancheGo@v1.11.13 (Protocol Version: 38)
+[v0.6.12] AvalancheGo@v1.11.13/v1.12.0-fuji (Protocol Version: 38)
 ```
 
 ## API

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.8
 require (
 	github.com/VictoriaMetrics/fastcache v1.12.1
 	github.com/antithesishq/antithesis-sdk-go v0.3.8
-	github.com/ava-labs/avalanchego v1.11.13-rc.1
+	github.com/ava-labs/avalanchego v1.11.13
 	github.com/cespare/cp v0.1.0
 	github.com/crate-crypto/go-ipa v0.0.0-20231025140028-3c0104f4b233
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,8 @@ github.com/antithesishq/antithesis-sdk-go v0.3.8/go.mod h1:IUpT2DPAKh6i/YhSbt6Gl
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/ava-labs/avalanchego v1.11.13-rc.1 h1:lHAkvMo98y/4xvsRKZ4GUTEj0yPnRbGC4U68rC06/rs=
-github.com/ava-labs/avalanchego v1.11.13-rc.1/go.mod h1:yhD5dpZyStIVbxQ550EDi5w5SL7DQ/xGE6TIxosb7U0=
+github.com/ava-labs/avalanchego v1.11.13 h1:1lcDZ9ILZgeiv7IwL4TuFTyglgZMr9QBOnpLHX+Qy5k=
+github.com/ava-labs/avalanchego v1.11.13/go.mod h1:yhD5dpZyStIVbxQ550EDi5w5SL7DQ/xGE6TIxosb7U0=
 github.com/ava-labs/coreth v0.13.9-rc.1 h1:qIICpC/OZGYUP37QnLgIqqwGmxnLwLpZaUlqJNI85vU=
 github.com/ava-labs/coreth v0.13.9-rc.1/go.mod h1:7aMsRIo/3GBE44qWZMjnfqdqfcfZ5yShTTm2LObLaYo=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -4,7 +4,7 @@
 # shellcheck disable=SC2034
 
 # Don't export them as they're used in the context of other calls
-AVALANCHE_VERSION=${AVALANCHE_VERSION:-'v1.11.13-rc.1'}
+AVALANCHE_VERSION=${AVALANCHE_VERSION:-'v1.11.13'}
 GINKGO_VERSION=${GINKGO_VERSION:-'v2.2.0'}
 
 # This won't be used, but it's here to make code syncs easier


### PR DESCRIPTION
This pull request includes updates to version references in multiple files to ensure consistency and correctness across the project.

Version updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L33-R33): Updated the version reference for `v0.6.12` to include `v1.12.0-fuji` alongside `v1.11.13` for better clarity.
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L8-R8): Changed the version of `github.com/ava-labs/avalanchego` from `v1.11.13-rc.1` to `v1.11.13` to reflect the stable release.
* [`scripts/versions.sh`](diffhunk://#diff-c275e70e7b0f41a73996876c584ca0336077f3ce442f2a9b9088ca351f7d9a0eL7-R7): Updated the `AVALANCHE_VERSION` from `v1.11.13-rc.1` to `v1.11.13` to match the stable release version.