### PR TITLE
specify arm64 version in goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser
-          version: 'v2.4.6'
+          version: latest
           args: release --clean
           workdir: ./subnet-evm/
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,6 @@ jobs:
           fetch-depth: 0
           path: subnet-evm
           ref: ${{ github.event.inputs.tag }}
-      - name: Patch .goreleaser.yml
-        run: |
-          git -C subnet-evm fetch origin try
-          git -C subnet-evm show origin/try:.goreleaser.yml > .goreleaser.yml
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -52,7 +48,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --clean --config ../.goreleaser.yml
+          args: release --clean
           workdir: ./subnet-evm/
         env:
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
           ref: ${{ github.event.inputs.tag }}
       - name: Patch .goreleaser.yml
         run: |
-          git -C subnet-evm fetch try
+          git -C subnet-evm fetch origin try
           git -C subnet-evm checkout try -- .goreleaser.yml
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser
-          version: latest
+          version: 'v2.4.6'
           args: release --clean
           workdir: ./subnet-evm/
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Patch .goreleaser.yml
         run: |
           git -C subnet-evm fetch origin try
-          git -C subnet-evm checkout try -- .goreleaser.yml
+          git -C subnet-evm checkout origin/try -- .goreleaser.yml
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
           ref: ${{ github.event.inputs.tag }}
       - name: Patch .goreleaser.yml
         run: |
+          git -C subnet-evm fetch try
           git -C subnet-evm checkout try -- .goreleaser.yml
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
         run: |
           git -C subnet-evm fetch origin try
           git -C subnet-evm checkout origin/try -- .goreleaser.yml
+          echo ".goreleaser.yml" >> subnet-evm/.gitignore
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to include in artifact name"
+        description: "Tag to checkout & release"
         required: true
   push:
     tags:
@@ -20,6 +20,10 @@ jobs:
         with:
           fetch-depth: 0
           path: subnet-evm
+          ref: ${{ github.event.inputs.tag }}
+      - name: Patch .goreleaser.yml
+        run: |
+          git -C subnet-evm checkout try -- .goreleaser.yml
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,7 @@ jobs:
       - name: Patch .goreleaser.yml
         run: |
           git -C subnet-evm fetch origin try
-          git -C subnet-evm checkout origin/try -- .goreleaser.yml
-          echo ".goreleaser.yml" >> subnet-evm/.gitignore
+          git -C subnet-evm show origin/try:.goreleaser.yml > .goreleaser.yml
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -53,7 +52,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --clean
+          args: release --clean --config ../.goreleaser.yml
           workdir: ./subnet-evm/
         env:
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,10 +18,12 @@ builds:
     overrides:
       - goos: linux
         goarch: arm64
+        goarm64: v8.0
         env:
           - CC=aarch64-linux-gnu-gcc
       - goos: darwin
         goarch: arm64
+        goarm64: v8.0
         env:
           - CC=oa64-clang
       - goos: darwin


### PR DESCRIPTION
Seems goreleaser made some breaking changes or something in our builders changed.
In any case the new way seems to succeed.