### PR TITLE
bump to latest avago

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -140,7 +140,7 @@ jobs:
         shell: bash
         run: ./scripts/build.sh
       - name: Run Warp E2E Tests
-        uses: ava-labs/avalanchego/.github/actions/run-monitored-tmpnet-cmd@v1.11.11-monitoring-url
+        uses: ava-labs/avalanchego/.github/actions/run-monitored-tmpnet-cmd@v1.11.13
         with:
           run: AVALANCHEGO_BUILD_PATH=/tmp/e2e-test/avalanchego ./scripts/run_ginkgo_warp.sh
           prometheus_id: ${{ secrets.PROMETHEUS_ID || '' }}
@@ -172,7 +172,7 @@ jobs:
         shell: bash
         run: ./scripts/build.sh
       - name: Run E2E Load Tests
-        uses: ava-labs/avalanchego/.github/actions/run-monitored-tmpnet-cmd@v1.11.11-monitoring-url
+        uses: ava-labs/avalanchego/.github/actions/run-monitored-tmpnet-cmd@v1.11.13
         with:
           run: AVALANCHEGO_BUILD_PATH=/tmp/e2e-test/avalanchego ./scripts/run_ginkgo_load.sh
           prometheus_id: ${{ secrets.PROMETHEUS_ID || '' }}


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/tests.yml` file to ensure the use of a newer version of the `run-monitored-tmpnet-cmd` action.

Workflow updates:

* Updated the `run-monitored-tmpnet-cmd` action from version `v1.11.11-monitoring-url` to `v1.11.13` for the Warp E2E Tests job.
* Updated the `run-monitored-tmpnet-cmd` action from version `v1.11.11-monitoring-url` to `v1.11.13` for the E2E Load Tests job.