### PR TITLE
Fix Typos in Documentation

### DIFF
--- a/consensus/dummy/README.md
+++ b/consensus/dummy/README.md
@@ -18,7 +18,7 @@ The dynamic fee algorithm aims to adjust the base fee to handle network congesti
 
 - EIP-1559 is intended for Ethereum where a block is produced roughly every 10s
 - The dynamic fee algorithm needs to handle the case that the network quiesces and there are no blocks for a long period of time
-- Since Subnet-EVM produces blocks at a different cadence, it adapts EIP-1559 to sum the amount of gas consumed within a 10 second interval instead of using only the amount of gas consumed in the parent block
+- Since Subnet-EVM produces blocks at a different cadence, it adapts EIP-1559 to sum the amount of gas consumed within a 10-second interval instead of using only the amount of gas consumed in the parent block
 
 ## Consensus Engine Callbacks
 

--- a/precompile/contracts/warp/README.md
+++ b/precompile/contracts/warp/README.md
@@ -57,7 +57,7 @@ To use this function, the transaction must include the signed Avalanche Warp Mes
 This leads to the following advantages:
 
 1. The EVM execution does not need to verify the Warp Message at runtime (no signature verification or external calls to the P-Chain)
-2. The EVM can deterministically re-execute and re-verify blocks assuming the predicate was verified by the network (eg., in bootstrapping)
+2. The EVM can deterministically re-execute and re-verify blocks assuming the predicate was verified by the network (e.g., in bootstrapping)
 
 This pre-verification is performed using the ProposerVM Block header during [block verification](../../../plugin/evm/block.go#L220) and [block building](../../../miner/worker.go#L200).
 


### PR DESCRIPTION
This PR addresses minor typographical issues in the documentation, improving clarity and adherence to grammatical standards.

## How this works

- **File: `consensus/dummy/README.md`**
  - Added a hyphen to correctly format "10-second interval."

- **File: `precompile/contracts/warp/README.md`**
  - Updated "eg." to the proper abbreviation "e.g." (for example).

## How this was tested

These are documentation changes that do not impact code execution. The changes were reviewed for correctness and clarity.

## Need to be documented?

No additional documentation is needed.

## Need to update RELEASES.md?

No updates to `RELEASES.md` are required as this PR does not introduce functional changes.
