### PR TITLE
mark flaky: TestTimedUnlock

### DIFF
--- a/scripts/known_flakes.txt
+++ b/scripts/known_flakes.txt
@@ -6,6 +6,7 @@ TestGolangBindings
 TestMempoolEthTxsAppGossipHandling
 TestResumeSyncAccountsTrieInterrupted
 TestResyncNewRootAfterDeletes
+TestTimedUnlock
 TestTransactionSkipIndexing
 TestVMShutdownWhileSyncing
 TestWaitDeployedCornerCases


### PR DESCRIPTION
new test [flake](https://github.com/ava-labs/subnet-evm/actions/runs/12378892858/job/34551826104?pr=1395#step:7:258) observed (in keystore, not very surprising)