### PR TITLE
chore(ci): remove `check-latest: true` to ensure the specified Go version

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -12,7 +12,6 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: "~1.22.8"
-          check-latest: true
       - run: go mod download
         shell: bash
       - run: ./scripts/build_bench_precompiles.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "~1.22.8"
-          check-latest: true
       - name: Set up arm64 cross compiler
         run: |
           sudo apt-get -y update

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.min_go_version }}
-          check-latest: true
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
@@ -49,7 +48,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.min_go_version }}
-          check-latest: true
       - name: Set timeout on Windows # Windows UT run slower and need a longer timeout
         shell: bash
         if: matrix.os == 'windows-latest'
@@ -77,7 +75,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.min_go_version }}
-          check-latest: true
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
@@ -119,7 +116,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.min_go_version }}
-          check-latest: true
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
@@ -164,7 +160,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.min_go_version }}
-          check-latest: true
       - name: Install AvalancheGo Release
         shell: bash
         run: BASEDIR=/tmp/e2e-test AVALANCHEGO_BUILD_PATH=/tmp/e2e-test/avalanchego ./scripts/install_avalanchego_release.sh
@@ -192,7 +187,6 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.min_go_version }}
-          check-latest: true
       - shell: bash
         run: scripts/mock.gen.sh
       - shell: bash
@@ -213,7 +207,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.min_go_version }}
-          check-latest: true
       - name: Install AvalancheGo Release
         shell: bash
         run: BASEDIR=/tmp/e2e-test AVALANCHEGO_BUILD_PATH=/tmp/e2e-test/avalanchego ./scripts/install_avalanchego_release.sh


### PR DESCRIPTION
## Why this should be merged

So we use the Go version specified, not the latest one.
See https://github.com/actions/setup-go?tab=readme-ov-file#check-latest-version

Sibling version of https://github.com/ava-labs/coreth/pull/722

## How this works

Removed `check-latest: true` in Go setup action

## How this was tested

CI passing

## Need to be documented?

No

## Need to update RELEASES.md?

No