### PR TITLE
refactor: params/extras (coreth a7f7061)

### DIFF
--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ava-labs/subnet-evm/core/state/pruner"
 	"github.com/ava-labs/subnet-evm/core/types"
 	"github.com/ava-labs/subnet-evm/params"
+	"github.com/ava-labs/subnet-evm/params/extras"
 	"github.com/holiman/uint256"
 )
 
@@ -315,7 +316,7 @@ func testRepopulateMissingTriesParallel(t *testing.T, parallelism int) {
 	gspec := &Genesis{
 		Config: params.WithExtra(
 			&params.ChainConfig{HomesteadBlock: new(big.Int)},
-			&params.ChainConfigExtra{FeeConfig: params.DefaultFeeConfig},
+			&extras.ChainConfig{FeeConfig: params.DefaultFeeConfig},
 		),
 		Alloc: types.GenesisAlloc{addr1: {Balance: genesisBalance}},
 	}
@@ -431,7 +432,7 @@ func TestUngracefulAsyncShutdown(t *testing.T) {
 	gspec := &Genesis{
 		Config: params.WithExtra(
 			&params.ChainConfig{HomesteadBlock: new(big.Int)},
-			&params.ChainConfigExtra{FeeConfig: params.DefaultFeeConfig},
+			&extras.ChainConfig{FeeConfig: params.DefaultFeeConfig},
 		),
 		Alloc: types.GenesisAlloc{addr1: {Balance: genesisBalance}},
 	}

--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/ava-labs/subnet-evm/core/state"
 	"github.com/ava-labs/subnet-evm/core/types"
 	"github.com/ava-labs/subnet-evm/params"
+	"github.com/ava-labs/subnet-evm/params/extras"
 	"github.com/ava-labs/subnet-evm/precompile/allowlist"
 	"github.com/ava-labs/subnet-evm/precompile/contracts/deployerallowlist"
 	"github.com/ava-labs/subnet-evm/triedb/pathdb"
@@ -209,7 +210,7 @@ func TestStatefulPrecompilesConfigure(t *testing.T) {
 		"allow list enabled in genesis": {
 			getConfig: func() *params.ChainConfig {
 				config := params.Copy(params.TestChainConfig)
-				params.GetExtra(&config).GenesisPrecompiles = params.Precompiles{
+				params.GetExtra(&config).GenesisPrecompiles = extras.Precompiles{
 					deployerallowlist.ConfigKey: deployerallowlist.NewConfig(utils.NewUint64(0), []common.Address{addr}, nil, nil),
 				}
 				return &config
@@ -285,7 +286,7 @@ func TestPrecompileActivationAfterHeaderBlock(t *testing.T) {
 
 	activatedGenesisConfig := params.Copy(customg.Config)
 	contractDeployerConfig := deployerallowlist.NewConfig(utils.NewUint64(51), nil, nil, nil)
-	params.GetExtra(&activatedGenesisConfig).UpgradeConfig.PrecompileUpgrades = []params.PrecompileUpgrade{
+	params.GetExtra(&activatedGenesisConfig).UpgradeConfig.PrecompileUpgrades = []extras.PrecompileUpgrade{
 		{
 			Config: contractDeployerConfig,
 		},
@@ -323,7 +324,7 @@ func TestGenesisWriteUpgradesRegression(t *testing.T) {
 	_, _, err := SetupGenesisBlock(db, trieDB, genesis, genesisBlock.Hash(), false)
 	require.NoError(err)
 
-	params.GetExtra(genesis.Config).UpgradeConfig.PrecompileUpgrades = []params.PrecompileUpgrade{
+	params.GetExtra(genesis.Config).UpgradeConfig.PrecompileUpgrades = []extras.PrecompileUpgrade{
 		{
 			Config: deployerallowlist.NewConfig(utils.NewUint64(51), nil, nil, nil),
 		},

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/ava-labs/subnet-evm/core/rawdb"
 	"github.com/ava-labs/subnet-evm/core/types"
 	"github.com/ava-labs/subnet-evm/params"
+	"github.com/ava-labs/subnet-evm/params/extras"
 	"github.com/ava-labs/subnet-evm/precompile/contracts/txallowlist"
 	"github.com/ava-labs/subnet-evm/utils"
 	"github.com/holiman/uint256"
@@ -271,7 +272,7 @@ func TestStateProcessorErrors(t *testing.T) {
 						IstanbulBlock:       big.NewInt(0),
 						MuirGlacierBlock:    big.NewInt(0),
 					},
-					&params.ChainConfigExtra{FeeConfig: params.DefaultFeeConfig},
+					&extras.ChainConfig{FeeConfig: params.DefaultFeeConfig},
 				),
 				Alloc: types.GenesisAlloc{
 					common.HexToAddress("0x71562b71999873DB5b286dF957af199Ec94617F7"): types.Account{
@@ -370,12 +371,12 @@ func TestBadTxAllowListBlock(t *testing.T) {
 				BerlinBlock:         big.NewInt(0),
 				LondonBlock:         big.NewInt(0),
 			},
-			&params.ChainConfigExtra{
+			&extras.ChainConfig{
 				FeeConfig: params.DefaultFeeConfig,
-				NetworkUpgrades: params.NetworkUpgrades{
+				NetworkUpgrades: extras.NetworkUpgrades{
 					SubnetEVMTimestamp: utils.NewUint64(0),
 				},
-				GenesisPrecompiles: params.Precompiles{
+				GenesisPrecompiles: extras.Precompiles{
 					txallowlist.ConfigKey: txallowlist.NewConfig(utils.NewUint64(0), nil, nil, nil),
 				},
 			},

--- a/core/test_blockchain.go
+++ b/core/test_blockchain.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ava-labs/subnet-evm/core/state"
 	"github.com/ava-labs/subnet-evm/core/types"
 	"github.com/ava-labs/subnet-evm/params"
+	"github.com/ava-labs/subnet-evm/params/extras"
 	"github.com/ava-labs/subnet-evm/precompile/allowlist"
 	"github.com/ava-labs/subnet-evm/precompile/contracts/deployerallowlist"
 	"github.com/ava-labs/subnet-evm/precompile/contracts/feemanager"
@@ -1485,7 +1486,7 @@ func TestStatefulPrecompiles(t *testing.T, create func(db ethdb.Database, gspec 
 	genesisBalance := new(big.Int).Mul(big.NewInt(1000000), big.NewInt(params.Ether))
 	config := params.Copy(params.TestChainConfig)
 	// Set all of the required config parameters
-	params.GetExtra(&config).GenesisPrecompiles = params.Precompiles{
+	params.GetExtra(&config).GenesisPrecompiles = extras.Precompiles{
 		deployerallowlist.ConfigKey: deployerallowlist.NewConfig(utils.NewUint64(0), []common.Address{addr1}, nil, nil),
 		feemanager.ConfigKey:        feemanager.NewConfig(utils.NewUint64(0), []common.Address{addr1}, nil, nil, nil),
 	}

--- a/core/vm/runtime/runtime.go
+++ b/core/vm/runtime/runtime.go
@@ -37,6 +37,7 @@ import (
 	"github.com/ava-labs/subnet-evm/core/state"
 	"github.com/ava-labs/subnet-evm/core/types"
 	"github.com/ava-labs/subnet-evm/params"
+	"github.com/ava-labs/subnet-evm/params/extras"
 	"github.com/holiman/uint256"
 )
 
@@ -82,8 +83,8 @@ func setDefaults(cfg *Config) {
 				BerlinBlock:         new(big.Int),
 				LondonBlock:         new(big.Int),
 			},
-			&params.ChainConfigExtra{
-				NetworkUpgrades: params.NetworkUpgrades{
+			&extras.ChainConfig{
+				NetworkUpgrades: extras.NetworkUpgrades{
 					SubnetEVMTimestamp: new(uint64),
 				},
 			},

--- a/eth/gasprice/gasprice_test.go
+++ b/eth/gasprice/gasprice_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/ava-labs/subnet-evm/core/rawdb"
 	"github.com/ava-labs/subnet-evm/core/types"
 	"github.com/ava-labs/subnet-evm/params"
+	"github.com/ava-labs/subnet-evm/params/extras"
 	"github.com/ava-labs/subnet-evm/precompile/contracts/feemanager"
 	"github.com/ava-labs/subnet-evm/rpc"
 	"github.com/ava-labs/subnet-evm/utils"
@@ -392,7 +393,7 @@ func TestSuggestGasPriceAfterFeeConfigUpdate(t *testing.T) {
 	// create a chain config with fee manager enabled at genesis with [addr] as the admin
 	chainConfig := params.Copy(params.TestChainConfig)
 	chainConfigExtra := params.GetExtra(&chainConfig)
-	chainConfigExtra.GenesisPrecompiles = params.Precompiles{
+	chainConfigExtra.GenesisPrecompiles = extras.Precompiles{
 		feemanager.ConfigKey: feemanager.NewConfig(utils.NewUint64(0), []common.Address{addr}, nil, nil, nil),
 	}
 

--- a/eth/tracers/api_extra_test.go
+++ b/eth/tracers/api_extra_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ava-labs/subnet-evm/core/types"
 	"github.com/ava-labs/subnet-evm/internal/ethapi"
 	"github.com/ava-labs/subnet-evm/params"
+	"github.com/ava-labs/subnet-evm/params/extras"
 	"github.com/ava-labs/subnet-evm/precompile/contracts/txallowlist"
 	"github.com/ava-labs/subnet-evm/rpc"
 	"github.com/stretchr/testify/require"
@@ -42,17 +43,17 @@ func TestTraceBlockPrecompileActivation(t *testing.T) {
 	activateAllowlistBlock := 3
 	// assumes gap is 10 sec
 	activateAllowListTime := uint64(activateAllowlistBlock * 10)
-	activateTxAllowListConfig := params.PrecompileUpgrade{
+	activateTxAllowListConfig := extras.PrecompileUpgrade{
 		Config: txallowlist.NewConfig(&activateAllowListTime, []common.Address{accounts[0].addr}, nil, nil),
 	}
 
 	deactivateAllowlistBlock := activateAllowlistBlock + 3
 	deactivateAllowListTime := uint64(deactivateAllowlistBlock) * 10
-	deactivateTxAllowListConfig := params.PrecompileUpgrade{
+	deactivateTxAllowListConfig := extras.PrecompileUpgrade{
 		Config: txallowlist.NewDisableConfig(&deactivateAllowListTime),
 	}
 
-	params.GetExtra(genesis.Config).PrecompileUpgrades = []params.PrecompileUpgrade{
+	params.GetExtra(genesis.Config).PrecompileUpgrades = []extras.PrecompileUpgrade{
 		activateTxAllowListConfig,
 		deactivateTxAllowListConfig,
 	}
@@ -148,17 +149,17 @@ func TestTraceTransactionPrecompileActivation(t *testing.T) {
 	activateAllowlistBlock := uint64(2)
 	// assumes gap is 10 sec
 	activateAllowListTime := activateAllowlistBlock * 10
-	activateTxAllowListConfig := params.PrecompileUpgrade{
+	activateTxAllowListConfig := extras.PrecompileUpgrade{
 		Config: txallowlist.NewConfig(&activateAllowListTime, []common.Address{accounts[0].addr}, nil, nil),
 	}
 
 	deactivateAllowlistBlock := activateAllowlistBlock + 2
 	deactivateAllowListTime := deactivateAllowlistBlock * 10
-	deactivateTxAllowListConfig := params.PrecompileUpgrade{
+	deactivateTxAllowListConfig := extras.PrecompileUpgrade{
 		Config: txallowlist.NewDisableConfig(&deactivateAllowListTime),
 	}
 
-	params.GetExtra(genesis.Config).PrecompileUpgrades = []params.PrecompileUpgrade{
+	params.GetExtra(genesis.Config).PrecompileUpgrades = []extras.PrecompileUpgrade{
 		activateTxAllowListConfig,
 		deactivateTxAllowListConfig,
 	}
@@ -212,17 +213,17 @@ func TestTraceChainPrecompileActivation(t *testing.T) {
 	activateAllowlistBlock := uint64(20)
 	// assumes gap is 10 sec
 	activateAllowListTime := activateAllowlistBlock * 10
-	activateTxAllowListConfig := params.PrecompileUpgrade{
+	activateTxAllowListConfig := extras.PrecompileUpgrade{
 		Config: txallowlist.NewConfig(&activateAllowListTime, []common.Address{accounts[0].addr}, nil, nil),
 	}
 
 	deactivateAllowlistBlock := activateAllowlistBlock + 10
 	deactivateAllowListTime := deactivateAllowlistBlock * 10
-	deactivateTxAllowListConfig := params.PrecompileUpgrade{
+	deactivateTxAllowListConfig := extras.PrecompileUpgrade{
 		Config: txallowlist.NewDisableConfig(&deactivateAllowListTime),
 	}
 
-	params.GetExtra(genesis.Config).PrecompileUpgrades = []params.PrecompileUpgrade{
+	params.GetExtra(genesis.Config).PrecompileUpgrades = []extras.PrecompileUpgrade{
 		activateTxAllowListConfig,
 		deactivateTxAllowListConfig,
 	}
@@ -309,9 +310,9 @@ func TestTraceCallWithOverridesStateUpgrade(t *testing.T) {
 	activateStateUpgradeBlock := uint64(2)
 	// assumes gap is 10 sec
 	activateStateUpgradeTime := activateStateUpgradeBlock * 10
-	activateStateUpgradeConfig := params.StateUpgrade{
+	activateStateUpgradeConfig := extras.StateUpgrade{
 		BlockTimestamp: &activateStateUpgradeTime,
-		StateUpgradeAccounts: map[common.Address]params.StateUpgradeAccount{
+		StateUpgradeAccounts: map[common.Address]extras.StateUpgradeAccount{
 			accounts[2].addr: {
 				// deplete all balance
 				BalanceChange: (*math.HexOrDecimal256)(new(big.Int).Neg(big.NewInt(5 * params.Ether))),
@@ -319,7 +320,7 @@ func TestTraceCallWithOverridesStateUpgrade(t *testing.T) {
 		},
 	}
 
-	params.GetExtra(genesis.Config).StateUpgrades = []params.StateUpgrade{
+	params.GetExtra(genesis.Config).StateUpgrades = []extras.StateUpgrade{
 		activateStateUpgradeConfig,
 	}
 	genBlocks := 3

--- a/internal/ethapi/api_extra.go
+++ b/internal/ethapi/api_extra.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ava-labs/subnet-evm/core"
 	"github.com/ava-labs/subnet-evm/core/types"
 	"github.com/ava-labs/subnet-evm/params"
+	"github.com/ava-labs/subnet-evm/params/extras"
 	"github.com/ava-labs/subnet-evm/rpc"
 )
 
@@ -123,7 +124,7 @@ func (s *BlockChainAPI) FeeConfig(ctx context.Context, blockNrOrHash *rpc.BlockN
 
 // GetActivePrecompilesAt returns the active precompile configs at the given block timestamp.
 // DEPRECATED: Use GetActiveRulesAt instead.
-func (s *BlockChainAPI) GetActivePrecompilesAt(ctx context.Context, blockTimestamp *uint64) params.Precompiles {
+func (s *BlockChainAPI) GetActivePrecompilesAt(ctx context.Context, blockTimestamp *uint64) extras.Precompiles {
 	var timestamp uint64
 	if blockTimestamp == nil {
 		timestamp = s.b.CurrentHeader().Time
@@ -140,7 +141,7 @@ type ActivePrecompilesResult struct {
 
 type ActiveRulesResult struct {
 	EthRules          params.Rules                       `json:"ethRules"`
-	AvalancheRules    params.AvalancheRules              `json:"avalancheRules"`
+	AvalancheRules    extras.AvalancheRules              `json:"avalancheRules"`
 	ActivePrecompiles map[string]ActivePrecompilesResult `json:"precompiles"`
 }
 

--- a/params/config.go
+++ b/params/config.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ava-labs/avalanchego/upgrade"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	ethparams "github.com/ava-labs/libevm/params"
+	"github.com/ava-labs/subnet-evm/params/extras"
 	"github.com/ava-labs/subnet-evm/utils"
 )
 
@@ -55,11 +56,11 @@ var (
 			IstanbulBlock:       big.NewInt(0),
 			MuirGlacierBlock:    big.NewInt(0),
 		},
-		&ChainConfigExtra{
+		&extras.ChainConfig{
 			FeeConfig:          DefaultFeeConfig,
 			AllowFeeRecipients: false,
-			NetworkUpgrades:    getDefaultNetworkUpgrades(upgrade.GetConfig(constants.MainnetID)), // This can be changed to correct network (local, test) via VM.
-			GenesisPrecompiles: Precompiles{},
+			NetworkUpgrades:    extras.GetDefaultNetworkUpgrades(upgrade.GetConfig(constants.MainnetID)), // This can be changed to correct network (local, test) via VM.
+			GenesisPrecompiles: extras.Precompiles{},
 		},
 	)
 
@@ -80,14 +81,7 @@ var (
 			ShanghaiTime:        utils.TimeToNewUint64(upgrade.GetConfig(constants.UnitTestID).DurangoTime),
 			CancunTime:          utils.TimeToNewUint64(upgrade.GetConfig(constants.UnitTestID).EtnaTime),
 		},
-		&ChainConfigExtra{
-			AvalancheContext:   AvalancheContext{utils.TestSnowContext()},
-			FeeConfig:          DefaultFeeConfig,
-			AllowFeeRecipients: false,
-			NetworkUpgrades:    getDefaultNetworkUpgrades(upgrade.GetConfig(constants.UnitTestID)), // This can be changed to correct network (local, test) via VM.
-			GenesisPrecompiles: Precompiles{},
-			UpgradeConfig:      UpgradeConfig{},
-		},
+		extras.TestChainConfig,
 	)
 
 	TestPreSubnetEVMChainConfig = WithExtra(
@@ -105,17 +99,17 @@ var (
 			BerlinBlock:         big.NewInt(0),
 			LondonBlock:         big.NewInt(0),
 		},
-		&ChainConfigExtra{
-			AvalancheContext:   AvalancheContext{utils.TestSnowContext()},
+		&extras.ChainConfig{
+			AvalancheContext:   extras.AvalancheContext{SnowCtx: utils.TestSnowContext()},
 			FeeConfig:          DefaultFeeConfig,
 			AllowFeeRecipients: false,
-			NetworkUpgrades: NetworkUpgrades{
+			NetworkUpgrades: extras.NetworkUpgrades{
 				SubnetEVMTimestamp: utils.TimeToNewUint64(upgrade.UnscheduledActivationTime),
 				DurangoTimestamp:   utils.TimeToNewUint64(upgrade.UnscheduledActivationTime),
 				EtnaTimestamp:      utils.TimeToNewUint64(upgrade.UnscheduledActivationTime),
 			},
-			GenesisPrecompiles: Precompiles{},
-			UpgradeConfig:      UpgradeConfig{},
+			GenesisPrecompiles: extras.Precompiles{},
+			UpgradeConfig:      extras.UpgradeConfig{},
 		},
 	)
 
@@ -134,17 +128,17 @@ var (
 			BerlinBlock:         big.NewInt(0),
 			LondonBlock:         big.NewInt(0),
 		},
-		&ChainConfigExtra{
-			AvalancheContext:   AvalancheContext{utils.TestSnowContext()},
+		&extras.ChainConfig{
+			AvalancheContext:   extras.AvalancheContext{SnowCtx: utils.TestSnowContext()},
 			FeeConfig:          DefaultFeeConfig,
 			AllowFeeRecipients: false,
-			NetworkUpgrades: NetworkUpgrades{
+			NetworkUpgrades: extras.NetworkUpgrades{
 				SubnetEVMTimestamp: utils.NewUint64(0),
 				DurangoTimestamp:   utils.TimeToNewUint64(upgrade.UnscheduledActivationTime),
 				EtnaTimestamp:      utils.TimeToNewUint64(upgrade.UnscheduledActivationTime),
 			},
-			GenesisPrecompiles: Precompiles{},
-			UpgradeConfig:      UpgradeConfig{},
+			GenesisPrecompiles: extras.Precompiles{},
+			UpgradeConfig:      extras.UpgradeConfig{},
 		},
 	)
 
@@ -164,17 +158,17 @@ var (
 			LondonBlock:         big.NewInt(0),
 			ShanghaiTime:        utils.TimeToNewUint64(upgrade.InitiallyActiveTime),
 		},
-		&ChainConfigExtra{
-			AvalancheContext:   AvalancheContext{utils.TestSnowContext()},
+		&extras.ChainConfig{
+			AvalancheContext:   extras.AvalancheContext{SnowCtx: utils.TestSnowContext()},
 			FeeConfig:          DefaultFeeConfig,
 			AllowFeeRecipients: false,
-			NetworkUpgrades: NetworkUpgrades{
+			NetworkUpgrades: extras.NetworkUpgrades{
 				SubnetEVMTimestamp: utils.NewUint64(0),
 				DurangoTimestamp:   utils.TimeToNewUint64(upgrade.InitiallyActiveTime),
 				EtnaTimestamp:      utils.TimeToNewUint64(upgrade.UnscheduledActivationTime),
 			},
-			GenesisPrecompiles: Precompiles{},
-			UpgradeConfig:      UpgradeConfig{},
+			GenesisPrecompiles: extras.Precompiles{},
+			UpgradeConfig:      extras.UpgradeConfig{},
 		},
 	)
 
@@ -195,17 +189,17 @@ var (
 			ShanghaiTime:        utils.TimeToNewUint64(upgrade.InitiallyActiveTime),
 			CancunTime:          utils.TimeToNewUint64(upgrade.InitiallyActiveTime),
 		},
-		&ChainConfigExtra{
-			AvalancheContext:   AvalancheContext{utils.TestSnowContext()},
+		&extras.ChainConfig{
+			AvalancheContext:   extras.AvalancheContext{SnowCtx: utils.TestSnowContext()},
 			FeeConfig:          DefaultFeeConfig,
 			AllowFeeRecipients: false,
-			NetworkUpgrades: NetworkUpgrades{
+			NetworkUpgrades: extras.NetworkUpgrades{
 				SubnetEVMTimestamp: utils.NewUint64(0),
 				DurangoTimestamp:   utils.TimeToNewUint64(upgrade.InitiallyActiveTime),
 				EtnaTimestamp:      utils.TimeToNewUint64(upgrade.InitiallyActiveTime),
 			},
-			GenesisPrecompiles: Precompiles{},
-			UpgradeConfig:      UpgradeConfig{},
+			GenesisPrecompiles: extras.Precompiles{},
+			UpgradeConfig:      extras.UpgradeConfig{},
 		},
 	)
 	TestRules = TestChainConfig.Rules(new(big.Int), IsMergeTODO, 0)

--- a/params/config_extra.go
+++ b/params/config_extra.go
@@ -6,13 +6,9 @@ package params
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"math/big"
 
-	"github.com/ava-labs/avalanchego/snow"
-	"github.com/ava-labs/libevm/common"
-	ethparams "github.com/ava-labs/libevm/params"
-	"github.com/ava-labs/subnet-evm/commontype"
+	"github.com/ava-labs/subnet-evm/params/extras"
 	"github.com/ava-labs/subnet-evm/predicate"
 	"github.com/ava-labs/subnet-evm/utils"
 )
@@ -38,40 +34,11 @@ const (
 )
 
 var (
-	DefaultChainID = big.NewInt(43214)
-
-	DefaultFeeConfig = commontype.FeeConfig{
-		GasLimit:        big.NewInt(8_000_000),
-		TargetBlockRate: 2, // in seconds
-
-		MinBaseFee:               big.NewInt(25_000_000_000),
-		TargetGas:                big.NewInt(15_000_000),
-		BaseFeeChangeDenominator: big.NewInt(36),
-
-		MinBlockGasCost:  big.NewInt(0),
-		MaxBlockGasCost:  big.NewInt(1_000_000),
-		BlockGasCostStep: big.NewInt(200_000),
-	}
+	DefaultChainID   = big.NewInt(43214)
+	DefaultFeeConfig = extras.DefaultFeeConfig
 )
 
-// UpgradeConfig includes the following configs that may be specified in upgradeBytes:
-// - Timestamps that enable avalanche network upgrades,
-// - Enabling or disabling precompiles as network upgrades.
-type UpgradeConfig struct {
-	// Config for timestamps that enable network upgrades.
-	NetworkUpgradeOverrides *NetworkUpgrades `json:"networkUpgradeOverrides,omitempty"`
-
-	// Config for modifying state as a network upgrade.
-	StateUpgrades []StateUpgrade `json:"stateUpgrades,omitempty"`
-
-	// Config for enabling and disabling precompiles as network upgrades.
-	PrecompileUpgrades []PrecompileUpgrade `json:"precompileUpgrades,omitempty"`
-}
-
-// AvalancheContext provides Avalanche specific context directly into the EVM.
-type AvalancheContext struct {
-	SnowCtx *snow.Context
-}
+type ConfigCompatError = extras.ConfigCompatError
 
 // SetEthUpgrades enables Etheruem network upgrades using the same time as
 // the Avalanche network upgrade that enables them.
@@ -79,7 +46,7 @@ type AvalancheContext struct {
 // TODO: Prior to Cancun, Avalanche upgrades are referenced inline in the
 // code in place of their Ethereum counterparts. The original Ethereum names
 // should be restored for maintainability.
-func SetEthUpgrades(c *ChainConfig, avalancheUpgrades NetworkUpgrades) {
+func SetEthUpgrades(c *ChainConfig, avalancheUpgrades extras.NetworkUpgrades) {
 	if c.BerlinBlock == nil {
 		c.BerlinBlock = big.NewInt(0)
 	}
@@ -94,11 +61,11 @@ func SetEthUpgrades(c *ChainConfig, avalancheUpgrades NetworkUpgrades) {
 	}
 }
 
-func GetExtra(c *ChainConfig) *ChainConfigExtra {
-	ex := extras.FromChainConfig(c)
+func GetExtra(c *ChainConfig) *extras.ChainConfig {
+	ex := payloads.FromChainConfig(c)
 	if ex == nil {
-		ex = &ChainConfigExtra{}
-		extras.SetOnChainConfig(c, ex)
+		ex = &extras.ChainConfig{}
+		payloads.SetOnChainConfig(c, ex)
 	}
 	return ex
 }
@@ -110,236 +77,14 @@ func Copy(c *ChainConfig) ChainConfig {
 }
 
 // WithExtra sets the extra payload on `c` and returns the modified argument.
-func WithExtra(c *ChainConfig, extra *ChainConfigExtra) *ChainConfig {
-	extras.SetOnChainConfig(c, extra)
+func WithExtra(c *ChainConfig, extra *extras.ChainConfig) *ChainConfig {
+	payloads.SetOnChainConfig(c, extra)
 	return c
-}
-
-type ChainConfigExtra struct {
-	NetworkUpgrades // Config for timestamps that enable network upgrades. Skip encoding/decoding directly into ChainConfig.
-
-	AvalancheContext `json:"-"` // Avalanche specific context set during VM initialization. Not serialized.
-
-	FeeConfig          commontype.FeeConfig `json:"feeConfig"`                    // Set the configuration for the dynamic fee algorithm
-	AllowFeeRecipients bool                 `json:"allowFeeRecipients,omitempty"` // Allows fees to be collected by block builders.
-	GenesisPrecompiles Precompiles          `json:"-"`                            // Config for enabling precompiles from genesis. JSON encode/decode will be handled by the custom marshaler/unmarshaler.
-	UpgradeConfig      `json:"-"`           // Config specified in upgradeBytes (avalanche network upgrades or enable/disabling precompiles). Skip encoding/decoding directly into ChainConfig.
-}
-
-func (c *ChainConfigExtra) Description() string {
-	if c == nil {
-		return ""
-	}
-	var banner string
-
-	banner += "Avalanche Upgrades (timestamp based):\n"
-	banner += c.NetworkUpgrades.Description()
-	banner += "\n"
-
-	upgradeConfigBytes, err := json.Marshal(c.UpgradeConfig)
-	if err != nil {
-		upgradeConfigBytes = []byte("cannot marshal UpgradeConfig")
-	}
-	banner += fmt.Sprintf("Upgrade Config: %s", string(upgradeConfigBytes))
-	banner += "\n"
-	return banner
-}
-
-type fork struct {
-	name      string
-	block     *big.Int // some go-ethereum forks use block numbers
-	timestamp *uint64  // Avalanche forks use timestamps
-	optional  bool     // if true, the fork may be nil and next fork is still allowed
-}
-
-func (c *ChainConfigExtra) CheckConfigForkOrder() error {
-	if c == nil {
-		return nil
-	}
-	// Note: In Avalanche, hard forks must take place via block timestamps instead
-	// of block numbers since blocks are produced asynchronously. Therefore, we do not
-	// check that the block timestamps in the same way as for
-	// the block number forks since it would not be a meaningful comparison.
-	// Instead, we check only that Phases are enabled in order.
-	// Note: we do not add the optional stateful precompile configs in here because they are optional
-	// and independent, such that the ordering they are enabled does not impact the correctness of the
-	// chain config.
-	if err := checkForks(c.forkOrder(), false); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// checkForks checks that forks are enabled in order and returns an error if not
-// [blockFork] is true if the fork is a block number fork, false if it is a timestamp fork
-func checkForks(forks []fork, blockFork bool) error {
-	lastFork := fork{}
-	for _, cur := range forks {
-		if lastFork.name != "" {
-			switch {
-			// Non-optional forks must all be present in the chain config up to the last defined fork
-			case lastFork.block == nil && lastFork.timestamp == nil && (cur.block != nil || cur.timestamp != nil):
-				if cur.block != nil {
-					return fmt.Errorf("unsupported fork ordering: %v not enabled, but %v enabled at block %v",
-						lastFork.name, cur.name, cur.block)
-				} else {
-					return fmt.Errorf("unsupported fork ordering: %v not enabled, but %v enabled at timestamp %v",
-						lastFork.name, cur.name, cur.timestamp)
-				}
-
-			// Fork (whether defined by block or timestamp) must follow the fork definition sequence
-			case (lastFork.block != nil && cur.block != nil) || (lastFork.timestamp != nil && cur.timestamp != nil):
-				if lastFork.block != nil && lastFork.block.Cmp(cur.block) > 0 {
-					return fmt.Errorf("unsupported fork ordering: %v enabled at block %v, but %v enabled at block %v",
-						lastFork.name, lastFork.block, cur.name, cur.block)
-				} else if lastFork.timestamp != nil && *lastFork.timestamp > *cur.timestamp {
-					return fmt.Errorf("unsupported fork ordering: %v enabled at timestamp %v, but %v enabled at timestamp %v",
-						lastFork.name, lastFork.timestamp, cur.name, cur.timestamp)
-				}
-
-				// Timestamp based forks can follow block based ones, but not the other way around
-				if lastFork.timestamp != nil && cur.block != nil {
-					return fmt.Errorf("unsupported fork ordering: %v used timestamp ordering, but %v reverted to block ordering",
-						lastFork.name, cur.name)
-				}
-			}
-		}
-		// If it was optional and not set, then ignore it
-		if !cur.optional || (cur.block != nil || cur.timestamp != nil) {
-			lastFork = cur
-		}
-	}
-	return nil
-}
-
-func (c *ChainConfigExtra) CheckConfigCompatible(newcfg_ *ChainConfig, headNumber *big.Int, headTimestamp uint64) *ConfigCompatError {
-	if c == nil {
-		return nil
-	}
-	newcfg := GetExtra(newcfg_)
-
-	// Check avalanche network upgrades
-	if err := c.checkNetworkUpgradesCompatible(&newcfg.NetworkUpgrades, headTimestamp); err != nil {
-		return err
-	}
-
-	// Check that the precompiles on the new config are compatible with the existing precompile config.
-	if err := c.checkPrecompilesCompatible(newcfg.PrecompileUpgrades, headTimestamp); err != nil {
-		return err
-	}
-
-	// Check that the state upgrades on the new config are compatible with the existing state upgrade config.
-	if err := c.checkStateUpgradesCompatible(newcfg.StateUpgrades, headTimestamp); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// isForkTimestampIncompatible returns true if a fork scheduled at timestamp s1
-// cannot be rescheduled to timestamp s2 because head is already past the fork.
-func isForkTimestampIncompatible(s1, s2 *uint64, head uint64) bool {
-	return (isTimestampForked(s1, head) || isTimestampForked(s2, head)) && !configTimestampEqual(s1, s2)
-}
-
-// isTimestampForked returns whether a fork scheduled at timestamp s is active
-// at the given head timestamp. Whilst this method is the same as isBlockForked,
-// they are explicitly separate for clearer reading.
-func isTimestampForked(s *uint64, head uint64) bool {
-	if s == nil {
-		return false
-	}
-	return *s <= head
-}
-
-func configTimestampEqual(x, y *uint64) bool {
-	if x == nil {
-		return y == nil
-	}
-	if y == nil {
-		return x == nil
-	}
-	return *x == *y
-}
-
-// ConfigCompatError is raised if the locally-stored blockchain is initialised with a
-// ChainConfig that would alter the past.
-type ConfigCompatError = ethparams.ConfigCompatError
-
-func newTimestampCompatError(what string, storedtime, newtime *uint64) *ConfigCompatError {
-	var rew *uint64
-	switch {
-	case storedtime == nil:
-		rew = newtime
-	case newtime == nil || *storedtime < *newtime:
-		rew = storedtime
-	default:
-		rew = newtime
-	}
-	err := &ConfigCompatError{
-		What:         what,
-		StoredTime:   storedtime,
-		NewTime:      newtime,
-		RewindToTime: 0,
-	}
-	if rew != nil && *rew > 0 {
-		err.RewindToTime = *rew - 1
-	}
-	return err
-}
-
-// UnmarshalJSON parses the JSON-encoded data and stores the result in the
-// object pointed to by c.
-// This is a custom unmarshaler to handle the Precompiles field.
-// Precompiles was presented as an inline object in the JSON.
-// This custom unmarshaler ensures backwards compatibility with the old format.
-func (c *ChainConfigExtra) UnmarshalJSON(data []byte) error {
-	// Alias ChainConfigExtra to avoid recursion
-	type _ChainConfigExtra ChainConfigExtra
-	tmp := _ChainConfigExtra{}
-	if err := json.Unmarshal(data, &tmp); err != nil {
-		return err
-	}
-
-	// At this point we have populated all fields except PrecompileUpgrade
-	*c = ChainConfigExtra(tmp)
-
-	// Unmarshal inlined PrecompileUpgrade
-	return json.Unmarshal(data, &c.GenesisPrecompiles)
-}
-
-// MarshalJSON returns the JSON encoding of c.
-// This is a custom marshaler to handle the Precompiles field.
-func (c *ChainConfigExtra) MarshalJSON() ([]byte, error) {
-	// Alias ChainConfigExtra to avoid recursion
-	type _ChainConfigExtra ChainConfigExtra
-	tmp, err := json.Marshal(_ChainConfigExtra(*c))
-	if err != nil {
-		return nil, err
-	}
-
-	// To include PrecompileUpgrades, we unmarshal the json representing c
-	// then directly add the corresponding keys to the json.
-	raw := make(map[string]json.RawMessage)
-	if err := json.Unmarshal(tmp, &raw); err != nil {
-		return nil, err
-	}
-
-	for key, value := range c.GenesisPrecompiles {
-		conf, err := json.Marshal(value)
-		if err != nil {
-			return nil, err
-		}
-		raw[key] = conf
-	}
-
-	return json.Marshal(raw)
 }
 
 type ChainConfigWithUpgradesJSON struct {
 	ChainConfig
-	UpgradeConfig UpgradeConfig `json:"upgrades,omitempty"`
+	UpgradeConfig extras.UpgradeConfig `json:"upgrades,omitempty"`
 }
 
 // MarshalJSON implements json.Marshaler. This is a workaround for the fact that
@@ -358,7 +103,7 @@ func (cu ChainConfigWithUpgradesJSON) MarshalJSON() ([]byte, error) {
 	}
 
 	type upgrades struct {
-		UpgradeConfig UpgradeConfig `json:"upgrades"`
+		UpgradeConfig extras.UpgradeConfig `json:"upgrades"`
 	}
 
 	upgradeJSON, err := json.Marshal(upgrades{cu.UpgradeConfig})
@@ -384,7 +129,7 @@ func (cu *ChainConfigWithUpgradesJSON) UnmarshalJSON(input []byte) error {
 	}
 
 	type upgrades struct {
-		UpgradeConfig UpgradeConfig `json:"upgrades"`
+		UpgradeConfig extras.UpgradeConfig `json:"upgrades"`
 	}
 
 	var u upgrades
@@ -394,48 +139,6 @@ func (cu *ChainConfigWithUpgradesJSON) UnmarshalJSON(input []byte) error {
 	cu.ChainConfig = cc
 	cu.UpgradeConfig = u.UpgradeConfig
 	return nil
-}
-
-// Verify verifies chain config and returns error
-func (c *ChainConfigExtra) Verify() error {
-	if err := c.FeeConfig.Verify(); err != nil {
-		return err
-	}
-
-	// Verify the precompile upgrades are internally consistent given the existing chainConfig.
-	if err := c.verifyPrecompileUpgrades(); err != nil {
-		return fmt.Errorf("invalid precompile upgrades: %w", err)
-	}
-
-	// Verify the state upgrades are internally consistent given the existing chainConfig.
-	if err := c.verifyStateUpgrades(); err != nil {
-		return fmt.Errorf("invalid state upgrades: %w", err)
-	}
-
-	// Verify the network upgrades are internally consistent given the existing chainConfig.
-	if err := c.verifyNetworkUpgrades(c.SnowCtx.NetworkUpgrades); err != nil {
-		return fmt.Errorf("invalid network upgrades: %w", err)
-	}
-
-	return nil
-}
-
-// IsPrecompileEnabled returns whether precompile with [address] is enabled at [timestamp].
-func (c *ChainConfigExtra) IsPrecompileEnabled(address common.Address, timestamp uint64) bool {
-	config := c.getActivePrecompileConfig(address, timestamp)
-	return config != nil && !config.IsDisabled()
-}
-
-// GetFeeConfig returns the original FeeConfig contained in the genesis ChainConfig.
-// Implements precompile.ChainConfig interface.
-func (c *ChainConfigExtra) GetFeeConfig() commontype.FeeConfig {
-	return c.FeeConfig
-}
-
-// AllowedFeeRecipients returns the original AllowedFeeRecipients parameter contained in the genesis ChainConfig.
-// Implements precompile.ChainConfig interface.
-func (c *ChainConfigExtra) AllowedFeeRecipients() bool {
-	return c.AllowFeeRecipients
 }
 
 // ToWithUpgradesJSON converts the ChainConfig to ChainConfigWithUpgradesJSON with upgrades explicitly displayed.
@@ -477,26 +180,5 @@ func SetNetworkUpgradeDefaults(c *ChainConfig) {
 		c.MuirGlacierBlock = big.NewInt(0)
 	}
 
-	GetExtra(c).NetworkUpgrades.setDefaults(GetExtra(c).SnowCtx.NetworkUpgrades)
-}
-
-func ptrToString(val *uint64) string {
-	if val == nil {
-		return "nil"
-	}
-	return fmt.Sprintf("%d", *val)
-}
-
-// IsForkTransition returns true if [fork] activates during the transition from
-// [parent] to [current].
-// Taking [parent] as a pointer allows for us to pass nil when checking forks
-// that activate during genesis.
-// Note: this works for both block number and timestamp activated forks.
-func IsForkTransition(fork *uint64, parent *uint64, current uint64) bool {
-	var parentForked bool
-	if parent != nil {
-		parentForked = isTimestampForked(fork, *parent)
-	}
-	currentForked := isTimestampForked(fork, current)
-	return !parentForked && currentForked
+	GetExtra(c).NetworkUpgrades.SetDefaults(GetExtra(c).SnowCtx.NetworkUpgrades)
 }

--- a/params/config_libevm.go
+++ b/params/config_libevm.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ava-labs/libevm/common"
 	ethparams "github.com/ava-labs/libevm/params"
+	"github.com/ava-labs/subnet-evm/params/extras"
 	"github.com/ava-labs/subnet-evm/precompile/modules"
 	"github.com/ava-labs/subnet-evm/precompile/precompileconfig"
 )
@@ -15,19 +16,19 @@ import (
 // libevmInit would ideally be a regular init() function, but it MUST be run
 // before any calls to [ChainConfig.Rules]. See `config.go` for its call site.
 func libevmInit() any {
-	extras = ethparams.RegisterExtras(ethparams.Extras[*ChainConfigExtra, RulesExtra]{
+	payloads = ethparams.RegisterExtras(ethparams.Extras[*extras.ChainConfig, RulesExtra]{
 		ReuseJSONRoot: true, // Reuse the root JSON input when unmarshalling the extra payload.
 		NewRules:      constructRulesExtra,
 	})
 	return nil
 }
 
-var extras ethparams.ExtraPayloads[*ChainConfigExtra, RulesExtra]
+var payloads ethparams.ExtraPayloads[*extras.ChainConfig, RulesExtra]
 
 // constructRulesExtra acts as an adjunct to the [params.ChainConfig.Rules]
 // method. Its primary purpose is to construct the extra payload for the
 // [params.Rules] but it MAY also modify the [params.Rules].
-func constructRulesExtra(c *ethparams.ChainConfig, r *ethparams.Rules, cEx *ChainConfigExtra, blockNum *big.Int, isMerge bool, timestamp uint64) RulesExtra {
+func constructRulesExtra(c *ethparams.ChainConfig, r *ethparams.Rules, cEx *extras.ChainConfig, blockNum *big.Int, isMerge bool, timestamp uint64) RulesExtra {
 	var rules RulesExtra
 	if cEx == nil {
 		return rules
@@ -39,7 +40,7 @@ func constructRulesExtra(c *ethparams.ChainConfig, r *ethparams.Rules, cEx *Chai
 	rules.Predicaters = make(map[common.Address]precompileconfig.Predicater)
 	rules.AccepterPrecompiles = make(map[common.Address]precompileconfig.Accepter)
 	for _, module := range modules.RegisteredModules() {
-		if config := cEx.getActivePrecompileConfig(module.Address, timestamp); config != nil && !config.IsDisabled() {
+		if config := cEx.GetActivePrecompileConfig(module.Address, timestamp); config != nil && !config.IsDisabled() {
 			rules.Precompiles[module.Address] = config
 			if predicater, ok := config.(precompileconfig.Predicater); ok {
 				rules.Predicaters[module.Address] = predicater

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -35,6 +35,7 @@ import (
 	"time"
 
 	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/subnet-evm/params/extras"
 	"github.com/ava-labs/subnet-evm/precompile/contracts/nativeminter"
 	"github.com/ava-labs/subnet-evm/precompile/contracts/rewardmanager"
 	"github.com/ava-labs/subnet-evm/precompile/contracts/txallowlist"
@@ -152,8 +153,8 @@ func TestCheckCompatible(t *testing.T) {
 func TestConfigRules(t *testing.T) {
 	c := WithExtra(
 		&ChainConfig{},
-		&ChainConfigExtra{
-			NetworkUpgrades: NetworkUpgrades{
+		&extras.ChainConfig{
+			NetworkUpgrades: extras.NetworkUpgrades{
 				SubnetEVMTimestamp: utils.NewUint64(500),
 			},
 		},
@@ -242,14 +243,14 @@ func TestConfigUnmarshalJSON(t *testing.T) {
 func TestActivePrecompiles(t *testing.T) {
 	config := *WithExtra(
 		&ChainConfig{},
-		&ChainConfigExtra{
-			UpgradeConfig: UpgradeConfig{
-				PrecompileUpgrades: []PrecompileUpgrade{
+		&extras.ChainConfig{
+			UpgradeConfig: extras.UpgradeConfig{
+				PrecompileUpgrades: []extras.PrecompileUpgrade{
 					{
-						nativeminter.NewConfig(utils.NewUint64(0), nil, nil, nil, nil), // enable at genesis
+						Config: nativeminter.NewConfig(utils.NewUint64(0), nil, nil, nil, nil), // enable at genesis
 					},
 					{
-						nativeminter.NewDisableConfig(utils.NewUint64(1)), // disable at timestamp 1
+						Config: nativeminter.NewDisableConfig(utils.NewUint64(1)), // disable at timestamp 1
 					},
 				},
 			},
@@ -278,18 +279,18 @@ func TestChainConfigMarshalWithUpgrades(t *testing.T) {
 				IstanbulBlock:       big.NewInt(0),
 				MuirGlacierBlock:    big.NewInt(0),
 			},
-			&ChainConfigExtra{
+			&extras.ChainConfig{
 				FeeConfig:          DefaultFeeConfig,
 				AllowFeeRecipients: false,
-				NetworkUpgrades: NetworkUpgrades{
+				NetworkUpgrades: extras.NetworkUpgrades{
 					SubnetEVMTimestamp: utils.NewUint64(0),
 					DurangoTimestamp:   utils.NewUint64(0),
 				},
-				GenesisPrecompiles: Precompiles{},
+				GenesisPrecompiles: extras.Precompiles{},
 			},
 		),
-		UpgradeConfig: UpgradeConfig{
-			PrecompileUpgrades: []PrecompileUpgrade{
+		UpgradeConfig: extras.UpgradeConfig{
+			PrecompileUpgrades: []extras.PrecompileUpgrade{
 				{
 					Config: txallowlist.NewConfig(utils.NewUint64(100), nil, nil, nil),
 				},

--- a/params/extras/config.go
+++ b/params/extras/config.go
@@ -1,0 +1,352 @@
+// (c) 2024 Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package extras
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/big"
+
+	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/upgrade"
+	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/libevm/common"
+	ethparams "github.com/ava-labs/libevm/params"
+	"github.com/ava-labs/subnet-evm/commontype"
+	"github.com/ava-labs/subnet-evm/utils"
+)
+
+var (
+	DefaultFeeConfig = commontype.FeeConfig{
+		GasLimit:        big.NewInt(8_000_000),
+		TargetBlockRate: 2, // in seconds
+
+		MinBaseFee:               big.NewInt(25_000_000_000),
+		TargetGas:                big.NewInt(15_000_000),
+		BaseFeeChangeDenominator: big.NewInt(36),
+
+		MinBlockGasCost:  big.NewInt(0),
+		MaxBlockGasCost:  big.NewInt(1_000_000),
+		BlockGasCostStep: big.NewInt(200_000),
+	}
+
+	TestChainConfig = &ChainConfig{
+		AvalancheContext:   AvalancheContext{utils.TestSnowContext()},
+		FeeConfig:          DefaultFeeConfig,
+		AllowFeeRecipients: false,
+		NetworkUpgrades:    GetDefaultNetworkUpgrades(upgrade.GetConfig(constants.UnitTestID)), // This can be changed to correct network (local, test) via VM.
+		GenesisPrecompiles: Precompiles{},
+		UpgradeConfig:      UpgradeConfig{},
+	}
+)
+
+// UpgradeConfig includes the following configs that may be specified in upgradeBytes:
+// - Timestamps that enable avalanche network upgrades,
+// - Enabling or disabling precompiles as network upgrades.
+type UpgradeConfig struct {
+	// Config for timestamps that enable network upgrades.
+	NetworkUpgradeOverrides *NetworkUpgrades `json:"networkUpgradeOverrides,omitempty"`
+
+	// Config for modifying state as a network upgrade.
+	StateUpgrades []StateUpgrade `json:"stateUpgrades,omitempty"`
+
+	// Config for enabling and disabling precompiles as network upgrades.
+	PrecompileUpgrades []PrecompileUpgrade `json:"precompileUpgrades,omitempty"`
+}
+
+// AvalancheContext provides Avalanche specific context directly into the EVM.
+type AvalancheContext struct {
+	SnowCtx *snow.Context
+}
+
+type ChainConfig struct {
+	NetworkUpgrades // Config for timestamps that enable network upgrades.
+
+	AvalancheContext `json:"-"` // Avalanche specific context set during VM initialization. Not serialized.
+
+	FeeConfig          commontype.FeeConfig `json:"feeConfig"`                    // Set the configuration for the dynamic fee algorithm
+	AllowFeeRecipients bool                 `json:"allowFeeRecipients,omitempty"` // Allows fees to be collected by block builders.
+	GenesisPrecompiles Precompiles          `json:"-"`                            // Config for enabling precompiles from genesis. JSON encode/decode will be handled by the custom marshaler/unmarshaler.
+	UpgradeConfig      `json:"-"`           // Config specified in upgradeBytes (avalanche network upgrades or enable/disabling precompiles). Not serialized.
+}
+
+func (c *ChainConfig) CheckConfigCompatible(newcfg_ *ethparams.ChainConfig, headNumber *big.Int, headTimestamp uint64) *ConfigCompatError {
+	if c == nil {
+		return nil
+	}
+	newcfg, ok := newcfg_.Hooks().(*ChainConfig)
+	if !ok {
+		// Proper registration of the extras on libevm side should prevent this from happening.
+		// Return an error to prevent the chain from starting, just in case.
+		return newTimestampCompatError(
+			fmt.Sprintf("ChainConfig.Hooks() is not of the expected type *extras.ChainConfig, got %T", newcfg_.Hooks()),
+			utils.NewUint64(0),
+			nil,
+		)
+	}
+	return c.checkConfigCompatible(newcfg, headNumber, headTimestamp)
+}
+
+func (c *ChainConfig) checkConfigCompatible(newcfg *ChainConfig, headNumber *big.Int, headTimestamp uint64) *ConfigCompatError {
+	if err := c.checkNetworkUpgradesCompatible(&newcfg.NetworkUpgrades, headTimestamp); err != nil {
+		return err
+	}
+	// Check that the precompiles on the new config are compatible with the existing precompile config.
+	if err := c.checkPrecompilesCompatible(newcfg.PrecompileUpgrades, headTimestamp); err != nil {
+		return err
+	}
+
+	// Check that the state upgrades on the new config are compatible with the existing state upgrade config.
+	if err := c.checkStateUpgradesCompatible(newcfg.StateUpgrades, headTimestamp); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *ChainConfig) Description() string {
+	if c == nil {
+		return ""
+	}
+	var banner string
+
+	banner += "Avalanche Upgrades (timestamp based):\n"
+	banner += c.NetworkUpgrades.Description()
+	banner += "\n"
+
+	upgradeConfigBytes, err := json.Marshal(c.UpgradeConfig)
+	if err != nil {
+		upgradeConfigBytes = []byte("cannot marshal UpgradeConfig")
+	}
+	banner += fmt.Sprintf("Upgrade Config: %s", string(upgradeConfigBytes))
+	banner += "\n"
+	return banner
+}
+
+// isForkTimestampIncompatible returns true if a fork scheduled at timestamp s1
+// cannot be rescheduled to timestamp s2 because head is already past the fork.
+func isForkTimestampIncompatible(s1, s2 *uint64, head uint64) bool {
+	return (isTimestampForked(s1, head) || isTimestampForked(s2, head)) && !configTimestampEqual(s1, s2)
+}
+
+// isTimestampForked returns whether a fork scheduled at timestamp s is active
+// at the given head timestamp. Whilst this method is the same as isBlockForked,
+// they are explicitly separate for clearer reading.
+func isTimestampForked(s *uint64, head uint64) bool {
+	if s == nil {
+		return false
+	}
+	return *s <= head
+}
+
+func configTimestampEqual(x, y *uint64) bool {
+	if x == nil {
+		return y == nil
+	}
+	if y == nil {
+		return x == nil
+	}
+	return *x == *y
+}
+
+// ConfigCompatError is raised if the locally-stored blockchain is initialised with a
+// ChainConfig that would alter the past.
+type ConfigCompatError = ethparams.ConfigCompatError
+
+// newTimestampCompatError is taken verbatim from upstream.
+// TODO: export this function from upstream in libevm, so it can be used here.
+func newTimestampCompatError(what string, storedtime, newtime *uint64) *ConfigCompatError {
+	var rew *uint64
+	switch {
+	case storedtime == nil:
+		rew = newtime
+	case newtime == nil || *storedtime < *newtime:
+		rew = storedtime
+	default:
+		rew = newtime
+	}
+	err := &ConfigCompatError{
+		What:         what,
+		StoredTime:   storedtime,
+		NewTime:      newtime,
+		RewindToTime: 0,
+	}
+	if rew != nil && *rew > 0 {
+		err.RewindToTime = *rew - 1
+	}
+	return err
+}
+
+// UnmarshalJSON parses the JSON-encoded data and stores the result in the
+// object pointed to by c.
+// This is a custom unmarshaler to handle the Precompiles field.
+// Precompiles was presented as an inline object in the JSON.
+// This custom unmarshaler ensures backwards compatibility with the old format.
+func (c *ChainConfig) UnmarshalJSON(data []byte) error {
+	// Alias ChainConfigExtra to avoid recursion
+	type _ChainConfigExtra ChainConfig
+	tmp := _ChainConfigExtra{}
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+
+	// At this point we have populated all fields except PrecompileUpgrade
+	*c = ChainConfig(tmp)
+
+	// Unmarshal inlined PrecompileUpgrade
+	return json.Unmarshal(data, &c.GenesisPrecompiles)
+}
+
+// MarshalJSON returns the JSON encoding of c.
+// This is a custom marshaler to handle the Precompiles field.
+func (c *ChainConfig) MarshalJSON() ([]byte, error) {
+	// Alias ChainConfigExtra to avoid recursion
+	type _ChainConfigExtra ChainConfig
+	tmp, err := json.Marshal(_ChainConfigExtra(*c))
+	if err != nil {
+		return nil, err
+	}
+
+	// To include PrecompileUpgrades, we unmarshal the json representing c
+	// then directly add the corresponding keys to the json.
+	raw := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(tmp, &raw); err != nil {
+		return nil, err
+	}
+
+	for key, value := range c.GenesisPrecompiles {
+		conf, err := json.Marshal(value)
+		if err != nil {
+			return nil, err
+		}
+		raw[key] = conf
+	}
+
+	return json.Marshal(raw)
+}
+
+type fork struct {
+	name      string
+	block     *big.Int // some go-ethereum forks use block numbers
+	timestamp *uint64  // Avalanche forks use timestamps
+	optional  bool     // if true, the fork may be nil and next fork is still allowed
+}
+
+func (c *ChainConfig) CheckConfigForkOrder() error {
+	if c == nil {
+		return nil
+	}
+	// Note: In Avalanche, upgrades must take place via block timestamps instead
+	// of block numbers since blocks are produced asynchronously. Therefore, we do
+	// not check block timestamp forks in the same way as block number forks since
+	// it would not be a meaningful comparison. Instead, we only check that the
+	// Avalanche upgrades are enabled in order.
+	// Note: we do not add the precompile configs here because they are optional
+	// and independent, i.e. the order in which they are enabled does not impact
+	// the correctness of the chain config.
+	return checkForks(c.forkOrder(), false)
+}
+
+// checkForks checks that forks are enabled in order and returns an error if not.
+// [blockFork] is true if the fork is a block number fork, false if it is a timestamp fork
+// TODO: This code was adapted from CheckConfigForkOrder, consider refactoring to avoid duplication.
+func checkForks(forks []fork, blockFork bool) error {
+	lastFork := fork{}
+	for _, cur := range forks {
+		if lastFork.name != "" {
+			switch {
+			// Non-optional forks must all be present in the chain config up to the last defined fork
+			case lastFork.block == nil && lastFork.timestamp == nil && (cur.block != nil || cur.timestamp != nil):
+				if cur.block != nil {
+					return fmt.Errorf("unsupported fork ordering: %v not enabled, but %v enabled at block %v",
+						lastFork.name, cur.name, cur.block)
+				} else {
+					return fmt.Errorf("unsupported fork ordering: %v not enabled, but %v enabled at timestamp %v",
+						lastFork.name, cur.name, cur.timestamp)
+				}
+
+			// Fork (whether defined by block or timestamp) must follow the fork definition sequence
+			case (lastFork.block != nil && cur.block != nil) || (lastFork.timestamp != nil && cur.timestamp != nil):
+				if lastFork.block != nil && lastFork.block.Cmp(cur.block) > 0 {
+					return fmt.Errorf("unsupported fork ordering: %v enabled at block %v, but %v enabled at block %v",
+						lastFork.name, lastFork.block, cur.name, cur.block)
+				} else if lastFork.timestamp != nil && *lastFork.timestamp > *cur.timestamp {
+					return fmt.Errorf("unsupported fork ordering: %v enabled at timestamp %v, but %v enabled at timestamp %v",
+						lastFork.name, lastFork.timestamp, cur.name, cur.timestamp)
+				}
+
+				// Timestamp based forks can follow block based ones, but not the other way around
+				if lastFork.timestamp != nil && cur.block != nil {
+					return fmt.Errorf("unsupported fork ordering: %v used timestamp ordering, but %v reverted to block ordering",
+						lastFork.name, cur.name)
+				}
+			}
+		}
+		// If it was optional and not set, then ignore it
+		if !cur.optional || (cur.block != nil || cur.timestamp != nil) {
+			lastFork = cur
+		}
+	}
+	return nil
+}
+
+// Verify verifies chain config.
+func (c *ChainConfig) Verify() error {
+	// Verify the precompile upgrades are internally consistent given the existing chainConfig.
+	if err := c.verifyPrecompileUpgrades(); err != nil {
+		return fmt.Errorf("invalid precompile upgrades: %w", err)
+	}
+	// Verify the state upgrades are internally consistent given the existing chainConfig.
+	if err := c.verifyStateUpgrades(); err != nil {
+		return fmt.Errorf("invalid state upgrades: %w", err)
+	}
+
+	// Verify the network upgrades are internally consistent given the existing chainConfig.
+	if err := c.verifyNetworkUpgrades(c.SnowCtx.NetworkUpgrades); err != nil {
+		return fmt.Errorf("invalid network upgrades: %w", err)
+	}
+
+	return nil
+}
+
+// IsPrecompileEnabled returns whether precompile with [address] is enabled at [timestamp].
+func (c *ChainConfig) IsPrecompileEnabled(address common.Address, timestamp uint64) bool {
+	config := c.GetActivePrecompileConfig(address, timestamp)
+	return config != nil && !config.IsDisabled()
+}
+
+// GetFeeConfig returns the original FeeConfig contained in the genesis ChainConfig.
+// Implements precompile.ChainConfig interface.
+func (c *ChainConfig) GetFeeConfig() commontype.FeeConfig {
+	return c.FeeConfig
+}
+
+// AllowedFeeRecipients returns the original AllowedFeeRecipients parameter contained in the genesis ChainConfig.
+// Implements precompile.ChainConfig interface.
+func (c *ChainConfig) AllowedFeeRecipients() bool {
+	return c.AllowFeeRecipients
+}
+
+// IsForkTransition returns true if [fork] activates during the transition from
+// [parent] to [current].
+// Taking [parent] as a pointer allows for us to pass nil when checking forks
+// that activate during genesis.
+// Note: [parent] and [current] can be either both timestamp values, or both
+// block number values, since this function works for both block number and
+// timestamp activated forks.
+func IsForkTransition(fork *uint64, parent *uint64, current uint64) bool {
+	var parentForked bool
+	if parent != nil {
+		parentForked = isTimestampForked(fork, *parent)
+	}
+	currentForked := isTimestampForked(fork, current)
+	return !parentForked && currentForked
+}
+
+func ptrToString(val *uint64) string {
+	if val == nil {
+		return "nil"
+	}
+	return fmt.Sprintf("%d", *val)
+}

--- a/params/extras/config_extra_test.go
+++ b/params/extras/config_extra_test.go
@@ -1,7 +1,7 @@
 // (c) 2024 Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-package params
+package extras
 
 import (
 	"testing"

--- a/params/extras/network_upgrades.go
+++ b/params/extras/network_upgrades.go
@@ -1,7 +1,7 @@
 // (c) 2022, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-package params
+package extras
 
 import (
 	"fmt"
@@ -55,8 +55,8 @@ func (n *NetworkUpgrades) forkOrder() []fork {
 
 // setDefaults sets the default values for the network upgrades.
 // This overrides deactivating the network upgrade by providing a timestamp of nil value.
-func (n *NetworkUpgrades) setDefaults(agoUpgrades upgrade.Config) {
-	defaults := getDefaultNetworkUpgrades(agoUpgrades)
+func (n *NetworkUpgrades) SetDefaults(agoUpgrades upgrade.Config) {
+	defaults := GetDefaultNetworkUpgrades(agoUpgrades)
 	// If the network upgrade is not set, set it to the default value.
 	// If the network upgrade is set to 0, we also treat it as nil and set it default.
 	// This is because in prior versions, upgrades were not modifiable and were directly set to their default values.
@@ -75,7 +75,7 @@ func (n *NetworkUpgrades) setDefaults(agoUpgrades upgrade.Config) {
 
 // verifyNetworkUpgrades checks that the network upgrades are well formed.
 func (n *NetworkUpgrades) verifyNetworkUpgrades(agoUpgrades upgrade.Config) error {
-	defaults := getDefaultNetworkUpgrades(agoUpgrades)
+	defaults := GetDefaultNetworkUpgrades(agoUpgrades)
 	if err := verifyWithDefault(n.SubnetEVMTimestamp, defaults.SubnetEVMTimestamp); err != nil {
 		return fmt.Errorf("SubnetEVM fork block timestamp is invalid: %w", err)
 	}
@@ -140,9 +140,9 @@ func (n *NetworkUpgrades) GetAvalancheRules(time uint64) AvalancheRules {
 	}
 }
 
-// getDefaultNetworkUpgrades returns the network upgrades for the specified avalanchego upgrades.
+// GetDefaultNetworkUpgrades returns the network upgrades for the specified avalanchego upgrades.
 // These should not return nil values.
-func getDefaultNetworkUpgrades(agoUpgrade upgrade.Config) NetworkUpgrades {
+func GetDefaultNetworkUpgrades(agoUpgrade upgrade.Config) NetworkUpgrades {
 	return NetworkUpgrades{
 		SubnetEVMTimestamp: utils.NewUint64(0),
 		DurangoTimestamp:   utils.TimeToNewUint64(agoUpgrade.DurangoTime),

--- a/params/extras/network_upgrades_test.go
+++ b/params/extras/network_upgrades_test.go
@@ -1,7 +1,7 @@
 // (c) 2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-package params
+package extras
 
 import (
 	"testing"

--- a/params/extras/precompile_config_test.go
+++ b/params/extras/precompile_config_test.go
@@ -1,7 +1,7 @@
 // (c) 2022 Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-package params
+package extras
 
 import (
 	"encoding/json"
@@ -21,8 +21,8 @@ import (
 
 func TestVerifyWithChainConfig(t *testing.T) {
 	admins := []common.Address{{1}}
-	baseConfig := Copy(TestChainConfig)
-	config := GetExtra(&baseConfig)
+	copy := *TestChainConfig
+	config := &copy
 	config.GenesisPrecompiles = Precompiles{
 		txallowlist.ConfigKey: txallowlist.NewConfig(utils.NewUint64(2), nil, nil, nil),
 	}
@@ -66,8 +66,8 @@ func TestVerifyWithChainConfig(t *testing.T) {
 
 func TestVerifyWithChainConfigAtNilTimestamp(t *testing.T) {
 	admins := []common.Address{{0}}
-	baseConfig := Copy(TestChainConfig)
-	config := GetExtra(&baseConfig)
+	copy := *TestChainConfig
+	config := &copy
 	config.PrecompileUpgrades = []PrecompileUpgrade{
 		// this does NOT enable the precompile, so it should be upgradeable.
 		{Config: txallowlist.NewConfig(nil, nil, nil, nil)},
@@ -186,8 +186,8 @@ func TestVerifyPrecompileUpgrades(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
-			baseConfig := Copy(TestChainConfig)
-			config := GetExtra(&baseConfig)
+			copy := *TestChainConfig
+			config := &copy
 			config.PrecompileUpgrades = tt.upgrades
 
 			err := config.Verify()
@@ -230,8 +230,8 @@ func TestVerifyPrecompiles(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
-			baseConfig := Copy(TestChainConfig)
-			config := GetExtra(&baseConfig)
+			copy := *TestChainConfig
+			config := &copy
 			config.GenesisPrecompiles = tt.precompiles
 
 			err := config.Verify()
@@ -246,8 +246,7 @@ func TestVerifyPrecompiles(t *testing.T) {
 
 func TestVerifyRequiresSortedTimestamps(t *testing.T) {
 	admins := []common.Address{{1}}
-	baseConfig := Copy(TestChainConfig)
-	config := GetExtra(&baseConfig)
+	config := &ChainConfig{}
 	config.PrecompileUpgrades = []PrecompileUpgrade{
 		{
 			Config: txallowlist.NewConfig(utils.NewUint64(2), admins, nil, nil),
@@ -264,22 +263,21 @@ func TestVerifyRequiresSortedTimestamps(t *testing.T) {
 
 func TestGetPrecompileConfig(t *testing.T) {
 	require := require.New(t)
-	baseConfig := Copy(TestChainConfig)
-	config := GetExtra(&baseConfig)
+	config := &ChainConfig{}
 	config.GenesisPrecompiles = Precompiles{
 		deployerallowlist.ConfigKey: deployerallowlist.NewConfig(utils.NewUint64(10), nil, nil, nil),
 	}
 
-	deployerConfig := config.getActivePrecompileConfig(deployerallowlist.ContractAddress, 0)
+	deployerConfig := config.GetActivePrecompileConfig(deployerallowlist.ContractAddress, 0)
 	require.Nil(deployerConfig)
 
-	deployerConfig = config.getActivePrecompileConfig(deployerallowlist.ContractAddress, 10)
+	deployerConfig = config.GetActivePrecompileConfig(deployerallowlist.ContractAddress, 10)
 	require.NotNil(deployerConfig)
 
-	deployerConfig = config.getActivePrecompileConfig(deployerallowlist.ContractAddress, 11)
+	deployerConfig = config.GetActivePrecompileConfig(deployerallowlist.ContractAddress, 11)
 	require.NotNil(deployerConfig)
 
-	txAllowListConfig := config.getActivePrecompileConfig(txallowlist.ContractAddress, 0)
+	txAllowListConfig := config.GetActivePrecompileConfig(txallowlist.ContractAddress, 0)
 	require.Nil(txAllowListConfig)
 }
 

--- a/params/extras/precompiles.go
+++ b/params/extras/precompiles.go
@@ -1,7 +1,7 @@
 // (c) 2023 Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-package params
+package extras
 
 import (
 	"encoding/json"

--- a/params/extras/rules.go
+++ b/params/extras/rules.go
@@ -1,18 +1,14 @@
 // (c) 2024 Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-package params
+package extras
 
 import (
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/subnet-evm/precompile/precompileconfig"
 )
 
-func GetRulesExtra(r Rules) *RulesExtra {
-	return extras.PointerFromRules(&r)
-}
-
-type RulesExtra struct {
+type Rules struct {
 	// Rules for Avalanche releases
 	AvalancheRules
 
@@ -29,17 +25,17 @@ type RulesExtra struct {
 	AccepterPrecompiles map[common.Address]precompileconfig.Accepter
 }
 
-func (r *RulesExtra) PredicatersExist() bool {
+func (r *Rules) PredicatersExist() bool {
 	return len(r.Predicaters) > 0
 }
 
-func (r *RulesExtra) PredicaterExists(addr common.Address) bool {
+func (r *Rules) PredicaterExists(addr common.Address) bool {
 	_, ok := r.Predicaters[addr]
 	return ok
 }
 
 // IsPrecompileEnabled returns true if the precompile at [addr] is enabled for this rule set.
-func (r *RulesExtra) IsPrecompileEnabled(addr common.Address) bool {
+func (r *Rules) IsPrecompileEnabled(addr common.Address) bool {
 	_, ok := r.Precompiles[addr]
 	return ok
 }

--- a/params/extras/state_upgrade.go
+++ b/params/extras/state_upgrade.go
@@ -1,7 +1,7 @@
 // (c) 2023 Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-package params
+package extras
 
 import (
 	"fmt"
@@ -35,7 +35,7 @@ func (s *StateUpgrade) Equal(other *StateUpgrade) bool {
 
 // verifyStateUpgrades checks [c.StateUpgrades] is well formed:
 // - the specified blockTimestamps must monotonically increase
-func (c *ChainConfigExtra) verifyStateUpgrades() error {
+func (c *ChainConfig) verifyStateUpgrades() error {
 	var previousUpgradeTimestamp *uint64
 	for i, upgrade := range c.StateUpgrades {
 		upgradeTimestamp := upgrade.BlockTimestamp
@@ -58,7 +58,7 @@ func (c *ChainConfigExtra) verifyStateUpgrades() error {
 
 // GetActivatingStateUpgrades returns all state upgrades configured to activate during the
 // state transition from a block with timestamp [from] to a block with timestamp [to].
-func (c *ChainConfigExtra) GetActivatingStateUpgrades(from *uint64, to uint64, upgrades []StateUpgrade) []StateUpgrade {
+func (c *ChainConfig) GetActivatingStateUpgrades(from *uint64, to uint64, upgrades []StateUpgrade) []StateUpgrade {
 	activating := make([]StateUpgrade, 0)
 	for _, upgrade := range upgrades {
 		if IsForkTransition(upgrade.BlockTimestamp, from, to) {
@@ -69,7 +69,7 @@ func (c *ChainConfigExtra) GetActivatingStateUpgrades(from *uint64, to uint64, u
 }
 
 // checkStateUpgradesCompatible checks if [stateUpgrades] are compatible with [c] at [headTimestamp].
-func (c *ChainConfigExtra) checkStateUpgradesCompatible(stateUpgrades []StateUpgrade, lastTimestamp uint64) *ConfigCompatError {
+func (c *ChainConfig) checkStateUpgradesCompatible(stateUpgrades []StateUpgrade, lastTimestamp uint64) *ConfigCompatError {
 	// All active upgrades (from nil to [lastTimestamp]) must match.
 	activeUpgrades := c.GetActivatingStateUpgrades(nil, lastTimestamp, c.StateUpgrades)
 	newUpgrades := c.GetActivatingStateUpgrades(nil, lastTimestamp, stateUpgrades)

--- a/params/extras/state_upgrade_test.go
+++ b/params/extras/state_upgrade_test.go
@@ -1,7 +1,7 @@
 // (c) 2022, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-package params
+package extras
 
 import (
 	"encoding/json"
@@ -59,11 +59,11 @@ func TestVerifyStateUpgrades(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
-			baseConfig := Copy(TestChainConfig)
-			config := &baseConfig
-			GetExtra(config).StateUpgrades = tt.upgrades
+			copy := *TestChainConfig
+			config := &copy
+			config.StateUpgrades = tt.upgrades
 
-			err := GetExtra(config).Verify()
+			err := config.Verify()
 			if tt.expectedError == "" {
 				require.NoError(err)
 			} else {

--- a/params/hooks_libevm.go
+++ b/params/hooks_libevm.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/vm"
 	"github.com/ava-labs/libevm/libevm"
+	"github.com/ava-labs/subnet-evm/params/extras"
 	"github.com/ava-labs/subnet-evm/precompile/contract"
 	"github.com/ava-labs/subnet-evm/precompile/contracts/deployerallowlist"
 	"github.com/ava-labs/subnet-evm/precompile/modules"
@@ -19,9 +20,17 @@ import (
 	"github.com/holiman/uint256"
 )
 
+type RulesExtra extras.Rules
+
+func GetRulesExtra(r Rules) *extras.Rules {
+	rules := payloads.PointerFromRules(&r)
+	return (*extras.Rules)(rules)
+}
+
 func (r RulesExtra) CanCreateContract(ac *libevm.AddressContext, gas uint64, state libevm.StateReader) (uint64, error) {
 	// If the allow list is enabled, check that [ac.Origin] has permission to deploy a contract.
-	if r.IsPrecompileEnabled(deployerallowlist.ContractAddress) {
+	rules := (extras.Rules)(r)
+	if rules.IsPrecompileEnabled(deployerallowlist.ContractAddress) {
 		allowListRole := deployerallowlist.GetContractDeployerAllowListStatus(state, ac.Origin)
 		if !allowListRole.IsEnabled() {
 			gas = 0

--- a/plugin/evm/block.go
+++ b/plugin/evm/block.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ava-labs/subnet-evm/core/rawdb"
 	"github.com/ava-labs/subnet-evm/core/types"
 	"github.com/ava-labs/subnet-evm/params"
+	"github.com/ava-labs/subnet-evm/params/extras"
 	"github.com/ava-labs/subnet-evm/precompile/precompileconfig"
 	"github.com/ava-labs/subnet-evm/predicate"
 
@@ -79,7 +80,7 @@ func (b *Block) Accept(context.Context) error {
 
 // handlePrecompileAccept calls Accept on any logs generated with an active precompile address that implements
 // contract.Accepter
-func (b *Block) handlePrecompileAccept(rules params.RulesExtra) error {
+func (b *Block) handlePrecompileAccept(rules extras.Rules) error {
 	// Short circuit early if there are no precompile accepters to execute
 	if len(rules.AccepterPrecompiles) == 0 {
 		return nil

--- a/plugin/evm/block_test.go
+++ b/plugin/evm/block_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ava-labs/subnet-evm/core/rawdb"
 	"github.com/ava-labs/subnet-evm/core/types"
 	"github.com/ava-labs/subnet-evm/params"
+	"github.com/ava-labs/subnet-evm/params/extras"
 	"github.com/ava-labs/subnet-evm/precompile/precompileconfig"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -88,7 +89,7 @@ func TestHandlePrecompileAccept(t *testing.T) {
 
 	// Call handlePrecompileAccept
 	blk := vm.newBlock(ethBlock)
-	rules := params.RulesExtra{
+	rules := extras.Rules{
 		AccepterPrecompiles: map[common.Address]precompileconfig.Accepter{
 			precompileAddr: mockAccepter,
 		},

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -38,6 +38,7 @@ import (
 	"github.com/ava-labs/subnet-evm/miner"
 	"github.com/ava-labs/subnet-evm/node"
 	"github.com/ava-labs/subnet-evm/params"
+	"github.com/ava-labs/subnet-evm/params/extras"
 	"github.com/ava-labs/subnet-evm/peer"
 	"github.com/ava-labs/subnet-evm/plugin/evm/message"
 	"github.com/ava-labs/subnet-evm/plugin/evm/validators"
@@ -349,7 +350,7 @@ func (vm *VM) Initialize(
 
 	// Set the Avalanche Context on the ChainConfig
 	configExtra := params.GetExtra(g.Config)
-	configExtra.AvalancheContext = params.AvalancheContext{
+	configExtra.AvalancheContext = extras.AvalancheContext{
 		SnowCtx: chainCtx,
 	}
 
@@ -374,7 +375,7 @@ func (vm *VM) Initialize(
 	// Initializing the chain will verify upgradeBytes are compatible with existing values.
 	// This should be called before g.Verify().
 	if len(upgradeBytes) > 0 {
-		var upgradeConfig params.UpgradeConfig
+		var upgradeConfig extras.UpgradeConfig
 		if err := json.Unmarshal(upgradeBytes, &upgradeConfig); err != nil {
 			return fmt.Errorf("failed to parse upgrade bytes: %w", err)
 		}
@@ -1148,12 +1149,12 @@ func (vm *VM) GetCurrentNonce(address common.Address) (uint64, error) {
 	return state.GetNonce(address), nil
 }
 
-func (vm *VM) chainConfigExtra() *params.ChainConfigExtra {
+func (vm *VM) chainConfigExtra() *extras.ChainConfig {
 	return params.GetExtra(vm.chainConfig)
 }
 
 // currentRules returns the chain rules for the current block.
-func (vm *VM) currentRules() params.RulesExtra {
+func (vm *VM) currentRules() extras.Rules {
 	header := vm.eth.APIBackend.CurrentHeader()
 	rules := vm.chainConfig.Rules(header.Number, params.IsMergeTODO, header.Time)
 	return *params.GetRulesExtra(rules)

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -49,6 +49,7 @@ import (
 	"github.com/ava-labs/subnet-evm/eth"
 	"github.com/ava-labs/subnet-evm/metrics"
 	"github.com/ava-labs/subnet-evm/params"
+	"github.com/ava-labs/subnet-evm/params/extras"
 	"github.com/ava-labs/subnet-evm/precompile/allowlist"
 	"github.com/ava-labs/subnet-evm/precompile/contracts/deployerallowlist"
 	"github.com/ava-labs/subnet-evm/precompile/contracts/feemanager"
@@ -2031,7 +2032,7 @@ func TestBuildAllowListActivationBlock(t *testing.T) {
 	if err := genesis.UnmarshalJSON([]byte(genesisJSONSubnetEVM)); err != nil {
 		t.Fatal(err)
 	}
-	params.GetExtra(genesis.Config).GenesisPrecompiles = params.Precompiles{
+	params.GetExtra(genesis.Config).GenesisPrecompiles = extras.Precompiles{
 		deployerallowlist.ConfigKey: deployerallowlist.NewConfig(utils.TimeToNewUint64(time.Now()), testEthAddrs, nil, nil),
 	}
 
@@ -2100,7 +2101,7 @@ func TestTxAllowListSuccessfulTx(t *testing.T) {
 		t.Fatal(err)
 	}
 	// this manager role should not be activated because DurangoTimestamp is in the future
-	params.GetExtra(genesis.Config).GenesisPrecompiles = params.Precompiles{
+	params.GetExtra(genesis.Config).GenesisPrecompiles = extras.Precompiles{
 		txallowlist.ConfigKey: txallowlist.NewConfig(utils.NewUint64(0), testEthAddrs[0:1], nil, nil),
 	}
 	durangoTime := time.Now().Add(10 * time.Hour)
@@ -2113,8 +2114,8 @@ func TestTxAllowListSuccessfulTx(t *testing.T) {
 	// prepare the new upgrade bytes to disable the TxAllowList
 	disableAllowListTime := durangoTime.Add(10 * time.Hour)
 	reenableAllowlistTime := disableAllowListTime.Add(10 * time.Hour)
-	upgradeConfig := &params.UpgradeConfig{
-		PrecompileUpgrades: []params.PrecompileUpgrade{
+	upgradeConfig := &extras.UpgradeConfig{
+		PrecompileUpgrades: []extras.PrecompileUpgrade{
 			{
 				Config: txallowlist.NewDisableConfig(utils.TimeToNewUint64(disableAllowListTime)),
 			},
@@ -2254,7 +2255,7 @@ func TestVerifyManagerConfig(t *testing.T) {
 	durangoTimestamp := time.Now().Add(10 * time.Hour)
 	params.GetExtra(genesis.Config).DurangoTimestamp = utils.TimeToNewUint64(durangoTimestamp)
 	// this manager role should not be activated because DurangoTimestamp is in the future
-	params.GetExtra(genesis.Config).GenesisPrecompiles = params.Precompiles{
+	params.GetExtra(genesis.Config).GenesisPrecompiles = extras.Precompiles{
 		txallowlist.ConfigKey: txallowlist.NewConfig(utils.NewUint64(0), testEthAddrs[0:1], nil, []common.Address{testEthAddrs[1]}),
 	}
 
@@ -2282,8 +2283,8 @@ func TestVerifyManagerConfig(t *testing.T) {
 	genesisJSON, err = genesis.MarshalJSON()
 	require.NoError(t, err)
 	// use an invalid upgrade now with managers set before Durango
-	upgradeConfig := &params.UpgradeConfig{
-		PrecompileUpgrades: []params.PrecompileUpgrade{
+	upgradeConfig := &extras.UpgradeConfig{
+		PrecompileUpgrades: []extras.PrecompileUpgrade{
 			{
 				Config: txallowlist.NewConfig(utils.TimeToNewUint64(durangoTimestamp.Add(-time.Second)), nil, nil, []common.Address{testEthAddrs[1]}),
 			},
@@ -2317,7 +2318,7 @@ func TestTxAllowListDisablePrecompile(t *testing.T) {
 		t.Fatal(err)
 	}
 	enableAllowListTimestamp := upgrade.InitiallyActiveTime // enable at initially active time
-	params.GetExtra(genesis.Config).GenesisPrecompiles = params.Precompiles{
+	params.GetExtra(genesis.Config).GenesisPrecompiles = extras.Precompiles{
 		txallowlist.ConfigKey: txallowlist.NewConfig(utils.TimeToNewUint64(enableAllowListTimestamp), testEthAddrs[0:1], nil, nil),
 	}
 	genesisJSON, err := genesis.MarshalJSON()
@@ -2432,7 +2433,7 @@ func TestFeeManagerChangeFee(t *testing.T) {
 		t.Fatal(err)
 	}
 	configExtra := params.GetExtra(genesis.Config)
-	configExtra.GenesisPrecompiles = params.Precompiles{
+	configExtra.GenesisPrecompiles = extras.Precompiles{
 		feemanager.ConfigKey: feemanager.NewConfig(utils.NewUint64(0), testEthAddrs[0:1], nil, nil, nil),
 	}
 
@@ -2674,7 +2675,7 @@ func TestRewardManagerPrecompileSetRewardAddress(t *testing.T) {
 	genesis := &core.Genesis{}
 	require.NoError(t, genesis.UnmarshalJSON([]byte(genesisJSONSubnetEVM)))
 
-	params.GetExtra(genesis.Config).GenesisPrecompiles = params.Precompiles{
+	params.GetExtra(genesis.Config).GenesisPrecompiles = extras.Precompiles{
 		rewardmanager.ConfigKey: rewardmanager.NewConfig(utils.NewUint64(0), testEthAddrs[0:1], nil, nil, nil),
 	}
 	params.GetExtra(genesis.Config).AllowFeeRecipients = true // enable this in genesis to test if this is recognized by the reward manager
@@ -2816,7 +2817,7 @@ func TestRewardManagerPrecompileAllowFeeRecipients(t *testing.T) {
 	genesis := &core.Genesis{}
 	require.NoError(t, genesis.UnmarshalJSON([]byte(genesisJSONSubnetEVM)))
 
-	params.GetExtra(genesis.Config).GenesisPrecompiles = params.Precompiles{
+	params.GetExtra(genesis.Config).GenesisPrecompiles = extras.Precompiles{
 		rewardmanager.ConfigKey: rewardmanager.NewConfig(utils.NewUint64(0), testEthAddrs[0:1], nil, nil, nil),
 	}
 	params.GetExtra(genesis.Config).AllowFeeRecipients = false // disable this in genesis

--- a/plugin/evm/vm_upgrade_bytes_test.go
+++ b/plugin/evm/vm_upgrade_bytes_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/ava-labs/subnet-evm/core"
 	"github.com/ava-labs/subnet-evm/core/types"
 	"github.com/ava-labs/subnet-evm/metrics"
-	"github.com/ava-labs/subnet-evm/params"
+	"github.com/ava-labs/subnet-evm/params/extras"
 	"github.com/ava-labs/subnet-evm/precompile/contracts/txallowlist"
 	"github.com/ava-labs/subnet-evm/utils"
 	"github.com/ava-labs/subnet-evm/vmerrs"
@@ -38,8 +38,8 @@ var DefaultEtnaTime = uint64(upgrade.GetConfig(testNetworkID).EtnaTime.Unix())
 func TestVMUpgradeBytesPrecompile(t *testing.T) {
 	// Make a TxAllowListConfig upgrade at genesis and convert it to JSON to apply as upgradeBytes.
 	enableAllowListTimestamp := upgrade.InitiallyActiveTime // enable at initial time
-	upgradeConfig := &params.UpgradeConfig{
-		PrecompileUpgrades: []params.PrecompileUpgrade{
+	upgradeConfig := &extras.UpgradeConfig{
+		PrecompileUpgrades: []extras.PrecompileUpgrade{
 			{
 				Config: txallowlist.NewConfig(utils.TimeToNewUint64(enableAllowListTimestamp), testEthAddrs[0:1], nil, nil),
 			},
@@ -84,7 +84,7 @@ func TestVMUpgradeBytesPrecompile(t *testing.T) {
 	disableAllowListTimestamp := vm.clock.Time().Add(10 * time.Hour) // arbitrary choice
 	upgradeConfig.PrecompileUpgrades = append(
 		upgradeConfig.PrecompileUpgrades,
-		params.PrecompileUpgrade{
+		extras.PrecompileUpgrade{
 			Config: txallowlist.NewDisableConfig(utils.TimeToNewUint64(disableAllowListTimestamp)),
 		},
 	)
@@ -244,7 +244,7 @@ func TestVMStateUpgrade(t *testing.T) {
 	upgradedCodeStr := "0xdeadbeef" // this code will be applied during the upgrade
 	upgradedCode, err := hexutil.Decode(upgradedCodeStr)
 	// This modification will be applied to an existing account
-	genesisAccountUpgrade := &params.StateUpgradeAccount{
+	genesisAccountUpgrade := &extras.StateUpgradeAccount{
 		BalanceChange: (*math.HexOrDecimal256)(big.NewInt(100)),
 		Storage:       map[common.Hash]common.Hash{storageKey: {}},
 		Code:          upgradedCode,
@@ -253,7 +253,7 @@ func TestVMStateUpgrade(t *testing.T) {
 	// This modification will be applied to a new account
 	newAccount := common.Address{42}
 	require.NoError(t, err)
-	newAccountUpgrade := &params.StateUpgradeAccount{
+	newAccountUpgrade := &extras.StateUpgradeAccount{
 		BalanceChange: (*math.HexOrDecimal256)(big.NewInt(100)),
 		Storage:       map[common.Hash]common.Hash{storageKey: common.HexToHash("0x6666")},
 		Code:          upgradedCode,
@@ -349,8 +349,8 @@ func TestVMEupgradeActivatesCancun(t *testing.T) {
 			name:        "Later Etna activates Cancun",
 			genesisJSON: genesisJSONDurango,
 			upgradeJSON: func() string {
-				upgrade := &params.UpgradeConfig{
-					NetworkUpgradeOverrides: &params.NetworkUpgrades{
+				upgrade := &extras.UpgradeConfig{
+					NetworkUpgradeOverrides: &extras.NetworkUpgrades{
 						EtnaTimestamp: utils.NewUint64(DefaultEtnaTime + 2),
 					},
 				}
@@ -367,8 +367,8 @@ func TestVMEupgradeActivatesCancun(t *testing.T) {
 			name:        "Changed Etna changes Cancun",
 			genesisJSON: genesisJSONEtna,
 			upgradeJSON: func() string {
-				upgrade := &params.UpgradeConfig{
-					NetworkUpgradeOverrides: &params.NetworkUpgrades{
+				upgrade := &extras.UpgradeConfig{
+					NetworkUpgradeOverrides: &extras.NetworkUpgrades{
 						EtnaTimestamp: utils.NewUint64(DefaultEtnaTime + 2),
 					},
 				}

--- a/plugin/evm/vm_warp_test.go
+++ b/plugin/evm/vm_warp_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ava-labs/subnet-evm/core/types"
 	"github.com/ava-labs/subnet-evm/eth/tracers"
 	"github.com/ava-labs/subnet-evm/params"
+	"github.com/ava-labs/subnet-evm/params/extras"
 	"github.com/ava-labs/subnet-evm/plugin/evm/message"
 	"github.com/ava-labs/subnet-evm/precompile/contract"
 	warpcontract "github.com/ava-labs/subnet-evm/precompile/contracts/warp"
@@ -67,7 +68,7 @@ func TestSendWarpMessage(t *testing.T) {
 	require := require.New(t)
 	genesis := &core.Genesis{}
 	require.NoError(genesis.UnmarshalJSON([]byte(genesisJSONDurango)))
-	params.GetExtra(genesis.Config).GenesisPrecompiles = params.Precompiles{
+	params.GetExtra(genesis.Config).GenesisPrecompiles = extras.Precompiles{
 		warpcontract.ConfigKey: warpcontract.NewDefaultConfig(utils.TimeToNewUint64(upgrade.InitiallyActiveTime)),
 	}
 	genesisJSON, err := genesis.MarshalJSON()
@@ -264,7 +265,7 @@ func testWarpVMTransaction(t *testing.T, unsignedMessage *avalancheWarp.Unsigned
 	require := require.New(t)
 	genesis := &core.Genesis{}
 	require.NoError(genesis.UnmarshalJSON([]byte(genesisJSONDurango)))
-	params.GetExtra(genesis.Config).GenesisPrecompiles = params.Precompiles{
+	params.GetExtra(genesis.Config).GenesisPrecompiles = extras.Precompiles{
 		warpcontract.ConfigKey: warpcontract.NewDefaultConfig(utils.TimeToNewUint64(upgrade.InitiallyActiveTime)),
 	}
 	genesisJSON, err := genesis.MarshalJSON()
@@ -420,7 +421,7 @@ func TestReceiveWarpMessage(t *testing.T) {
 	require := require.New(t)
 	genesis := &core.Genesis{}
 	require.NoError(genesis.UnmarshalJSON([]byte(genesisJSONDurango)))
-	params.GetExtra(genesis.Config).GenesisPrecompiles = params.Precompiles{
+	params.GetExtra(genesis.Config).GenesisPrecompiles = extras.Precompiles{
 		// Note that warp is enabled without RequirePrimaryNetworkSigners
 		// by default in the genesis configuration.
 		warpcontract.ConfigKey: warpcontract.NewDefaultConfig(utils.TimeToNewUint64(upgrade.InitiallyActiveTime)),
@@ -440,8 +441,8 @@ func TestReceiveWarpMessage(t *testing.T) {
 		true, // RequirePrimaryNetworkSigners
 	)
 
-	upgradeConfig := params.UpgradeConfig{
-		PrecompileUpgrades: []params.PrecompileUpgrade{
+	upgradeConfig := extras.UpgradeConfig{
+		PrecompileUpgrades: []extras.PrecompileUpgrade{
 			{Config: disableConfig},
 			{Config: reEnableConfig},
 		},

--- a/stateupgrade/state_upgrade.go
+++ b/stateupgrade/state_upgrade.go
@@ -7,12 +7,12 @@ import (
 	"math/big"
 
 	"github.com/ava-labs/libevm/common"
-	"github.com/ava-labs/subnet-evm/params"
+	"github.com/ava-labs/subnet-evm/params/extras"
 	"github.com/holiman/uint256"
 )
 
 // Configure applies the state upgrade to the state.
-func Configure(stateUpgrade *params.StateUpgrade, chainConfig ChainContext, state StateDB, blockContext BlockContext) error {
+func Configure(stateUpgrade *extras.StateUpgrade, chainConfig ChainContext, state StateDB, blockContext BlockContext) error {
 	isEIP158 := chainConfig.IsEIP158(blockContext.Number())
 	for account, upgrade := range stateUpgrade.StateUpgradeAccounts {
 		if err := upgradeAccount(account, upgrade, state, isEIP158); err != nil {
@@ -23,7 +23,7 @@ func Configure(stateUpgrade *params.StateUpgrade, chainConfig ChainContext, stat
 }
 
 // upgradeAccount applies the state upgrade to the given account.
-func upgradeAccount(account common.Address, upgrade params.StateUpgradeAccount, state StateDB, isEIP158 bool) error {
+func upgradeAccount(account common.Address, upgrade extras.StateUpgradeAccount, state StateDB, isEIP158 bool) error {
 	// Create the account if it does not exist
 	if !state.Exist(account) {
 		state.CreateAccount(account)

--- a/tests/init.go
+++ b/tests/init.go
@@ -34,6 +34,7 @@ import (
 	"strings"
 
 	"github.com/ava-labs/subnet-evm/params"
+	"github.com/ava-labs/subnet-evm/params/extras"
 	"github.com/ava-labs/subnet-evm/utils"
 )
 
@@ -182,8 +183,8 @@ var Forks = map[string]*params.ChainConfig{
 			BerlinBlock:         big.NewInt(0),
 			LondonBlock:         big.NewInt(0),
 		},
-		&params.ChainConfigExtra{
-			NetworkUpgrades: params.NetworkUpgrades{
+		&extras.ChainConfig{
+			NetworkUpgrades: extras.NetworkUpgrades{
 				SubnetEVMTimestamp: utils.NewUint64(0),
 			},
 		},
@@ -202,8 +203,8 @@ var Forks = map[string]*params.ChainConfig{
 			BerlinBlock:         big.NewInt(0),
 			LondonBlock:         big.NewInt(0),
 		},
-		&params.ChainConfigExtra{
-			NetworkUpgrades: params.NetworkUpgrades{
+		&extras.ChainConfig{
+			NetworkUpgrades: extras.NetworkUpgrades{
 				SubnetEVMTimestamp: utils.NewUint64(0),
 				DurangoTimestamp:   utils.NewUint64(0),
 			},
@@ -225,8 +226,8 @@ var Forks = map[string]*params.ChainConfig{
 			ShanghaiTime:        utils.NewUint64(0),
 			CancunTime:          utils.NewUint64(0),
 		},
-		&params.ChainConfigExtra{
-			NetworkUpgrades: params.NetworkUpgrades{
+		&extras.ChainConfig{
+			NetworkUpgrades: extras.NetworkUpgrades{
 				SubnetEVMTimestamp: utils.NewUint64(0),
 				DurangoTimestamp:   utils.NewUint64(0),
 			},


### PR DESCRIPTION
Applies the same changes as were applied to coreth here: https://github.com/ava-labs/coreth/commit/a7f7061ce0662671eea01e973676c52879a4461c

I realized we could import most of these types back to params if we wanted, but explicit seems clearer + it's already like this in coreth.