### PR TITLE
remove current state lock

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -69,9 +69,11 @@ const (
 	txMaxSize = 4 * txSlotSize // 128KB
 )
 
-// ErrTxPoolOverflow is returned if the transaction pool is full and can't accept
-// another remote transaction.
-var ErrTxPoolOverflow = errors.New("txpool is full")
+var (
+	// ErrTxPoolOverflow is returned if the transaction pool is full and can't accept
+	// another remote transaction.
+	ErrTxPoolOverflow = errors.New("txpool is full")
+)
 
 var (
 	evictionInterval      = time.Minute      // Time interval to check for evictable transactions
@@ -1073,7 +1075,7 @@ func (pool *LegacyPool) Add(txs []*types.Transaction, local, sync bool) []error 
 	newErrs, dirtyAddrs := pool.addTxsLocked(news, local)
 	pool.mu.Unlock()
 
-	nilSlot := 0
+	var nilSlot = 0
 	for _, err := range newErrs {
 		for errs[nilSlot] != nil {
 			nilSlot++


### PR DESCRIPTION
## Why this should be merged

https://github.com/ava-labs/coreth/pull/741

## How this works

This pull request includes several changes to the `core/txpool/legacypool/legacypool.go` file, primarily focused on simplifying the code by removing unnecessary locks and improving variable declarations.

Code simplification:

* Removed the `currentStateLock` mutex from the `LegacyPool` struct and all associated lock/unlock calls, as it is no longer needed for concurrent access. [[1]](diffhunk://#diff-3b03ebf997a1699ce8e84a53a4b3981e403e74e2f90128eb188ad4226703970cL233-L235) [[2]](diffhunk://#diff-3b03ebf997a1699ce8e84a53a4b3981e403e74e2f90128eb188ad4226703970cL691-L693) [[3]](diffhunk://#diff-3b03ebf997a1699ce8e84a53a4b3981e403e74e2f90128eb188ad4226703970cL1506-L1508) [[4]](diffhunk://#diff-3b03ebf997a1699ce8e84a53a4b3981e403e74e2f90128eb188ad4226703970cL1532-L1534) [[5]](diffhunk://#diff-3b03ebf997a1699ce8e84a53a4b3981e403e74e2f90128eb188ad4226703970cL1741-L1743)

## How this was tested

CI

## Need to be documented?

No

## Need to update RELEASES.md?

No
