### PR TITLE
pin goreleaser v2.5.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser
-          version: latest
+          version: v2.5.1
           args: release --clean
           workdir: ./subnet-evm/
         env:


### PR DESCRIPTION
A bug is introduced in 2.6.0 that ignores the environment overrides.