### PR TITLE
Dynamic fees cleanup

### DIFF
--- a/consensus/dummy/consensus.go
+++ b/consensus/dummy/consensus.go
@@ -10,6 +10,7 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/ava-labs/avalanchego/utils/math"
 	"github.com/ava-labs/avalanchego/utils/timer/mockable"
 	"github.com/ava-labs/subnet-evm/consensus"
 	"github.com/ava-labs/subnet-evm/consensus/misc/eip4844"
@@ -141,13 +142,9 @@ func (eng *DummyEngine) verifyHeaderGasFields(config *params.ChainConfig, header
 		}
 	} else {
 		// Verify that the gas limit remains within allowed bounds
-		diff := int64(parent.GasLimit) - int64(header.GasLimit)
-		if diff < 0 {
-			diff *= -1
-		}
+		diff := math.AbsDiff(parent.GasLimit, header.GasLimit)
 		limit := parent.GasLimit / params.GasLimitBoundDivisor
-
-		if uint64(diff) >= limit || header.GasLimit < params.MinGasLimit {
+		if diff >= limit || header.GasLimit < params.MinGasLimit {
 			return fmt.Errorf("invalid gas limit: have %d, want %d += %d", header.GasLimit, parent.GasLimit, limit)
 		}
 		// Verify BaseFee is not present before Subnet EVM
@@ -160,22 +157,15 @@ func (eng *DummyEngine) verifyHeaderGasFields(config *params.ChainConfig, header
 		return nil
 	}
 
-	// Verify baseFee and rollupWindow encoding as part of header verification
-	// starting in Subnet EVM
-	expectedRollupWindowBytes, expectedBaseFee, err := CalcBaseFee(config, feeConfig, parent, header.Time)
+	// Verify header.Extra and header.BaseFee match their expected values.
+	expectedExtraPrefix, expectedBaseFee, err := CalcBaseFee(config, feeConfig, parent, header.Time)
 	if err != nil {
 		return fmt.Errorf("failed to calculate base fee: %w", err)
 	}
-	if len(header.Extra) < len(expectedRollupWindowBytes) || !bytes.Equal(expectedRollupWindowBytes, header.Extra[:len(expectedRollupWindowBytes)]) {
-		return fmt.Errorf("expected rollup window bytes: %x, found %x", expectedRollupWindowBytes, header.Extra)
+	if !bytes.HasPrefix(header.Extra, expectedExtraPrefix) {
+		return fmt.Errorf("expected header.Extra to have prefix: %x, found %x", expectedExtraPrefix, header.Extra)
 	}
-	if header.BaseFee == nil {
-		return errors.New("expected baseFee to be non-nil")
-	}
-	if bfLen := header.BaseFee.BitLen(); bfLen > 256 {
-		return fmt.Errorf("too large base fee: bitlen %d", bfLen)
-	}
-	if header.BaseFee.Cmp(expectedBaseFee) != 0 {
+	if !utils.BigEqual(header.BaseFee, expectedBaseFee) {
 		return fmt.Errorf("expected base fee (%d), found (%d)", expectedBaseFee, header.BaseFee)
 	}
 

--- a/consensus/dummy/consensus_test.go
+++ b/consensus/dummy/consensus_test.go
@@ -15,10 +15,12 @@ import (
 )
 
 var testFeeConfig = commontype.FeeConfig{
-	MinBlockGasCost:  big.NewInt(0),
-	MaxBlockGasCost:  big.NewInt(1_000_000),
-	TargetBlockRate:  2,
-	BlockGasCostStep: big.NewInt(50_000),
+	MinBlockGasCost:          big.NewInt(0),
+	MaxBlockGasCost:          big.NewInt(1_000_000),
+	TargetBlockRate:          2,
+	BlockGasCostStep:         big.NewInt(50_000),
+	TargetGas:                big.NewInt(10_000_000),
+	BaseFeeChangeDenominator: big.NewInt(12),
 }
 
 func TestVerifyBlockFee(t *testing.T) {

--- a/consensus/dummy/dynamic_fees.go
+++ b/consensus/dummy/dynamic_fees.go
@@ -16,8 +16,8 @@ import (
 )
 
 var (
-	MaxUint256Plus1                     = new(big.Int).Lsh(common.Big1, 256)
-	MaxUint256                          = new(big.Int).Sub(MaxUint256Plus1, common.Big1)
+	maxUint256Plus1                     = new(big.Int).Lsh(common.Big1, 256)
+	maxUint256                          = new(big.Int).Sub(maxUint256Plus1, common.Big1)
 	errEstimateBaseFeeWithoutActivation = errors.New("cannot estimate base fee for chain without activation")
 )
 
@@ -97,7 +97,7 @@ func CalcBaseFee(config *params.ChainConfig, feeConfig commontype.FeeConfig, par
 		baseFee.Sub(baseFee, baseFeeDelta)
 	}
 
-	baseFee = selectBigWithinBounds(feeConfig.MinBaseFee, baseFee, MaxUint256)
+	baseFee = selectBigWithinBounds(feeConfig.MinBaseFee, baseFee, maxUint256)
 
 	return dynamicFeeWindowBytes, baseFee, nil
 }

--- a/consensus/dummy/dynamic_fees.go
+++ b/consensus/dummy/dynamic_fees.go
@@ -14,6 +14,11 @@ import (
 	"github.com/ethereum/go-ethereum/common/math"
 )
 
+var (
+	MaxUint256Plus1 = new(big.Int).Lsh(common.Big1, 256)
+	MaxUint256      = new(big.Int).Sub(MaxUint256Plus1, common.Big1)
+)
+
 // CalcBaseFee takes the previous header and the timestamp of its child block
 // and calculates the expected base fee as well as the encoding of the past
 // pricing information for the child block.
@@ -90,7 +95,7 @@ func CalcBaseFee(config *params.ChainConfig, feeConfig commontype.FeeConfig, par
 		baseFee.Sub(baseFee, baseFeeDelta)
 	}
 
-	baseFee = selectBigWithinBounds(feeConfig.MinBaseFee, baseFee, nil)
+	baseFee = selectBigWithinBounds(feeConfig.MinBaseFee, baseFee, MaxUint256)
 
 	return dynamicFeeWindowBytes, baseFee, nil
 }

--- a/utils/numbers.go
+++ b/utils/numbers.go
@@ -38,6 +38,15 @@ func Uint64PtrEqual(x, y *uint64) bool {
 	return *x == *y
 }
 
+// BigEqual returns true if a is equal to b. If a and b are nil, it returns
+// true.
+func BigEqual(a, b *big.Int) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.Cmp(b) == 0
+}
+
 // BigEqualUint64 returns true if a is equal to b. If a is nil or not a uint64,
 // it returns false.
 func BigEqualUint64(a *big.Int, b uint64) bool {

--- a/utils/numbers_test.go
+++ b/utils/numbers_test.go
@@ -10,6 +10,48 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestBigEqual(t *testing.T) {
+	tests := []struct {
+		name string
+		a    *big.Int
+		b    *big.Int
+		want bool
+	}{
+		{
+			name: "nil_nil",
+			a:    nil,
+			b:    nil,
+			want: true,
+		},
+		{
+			name: "0_nil",
+			a:    big.NewInt(0),
+			b:    nil,
+			want: false,
+		},
+		{
+			name: "0_1",
+			a:    big.NewInt(0),
+			b:    big.NewInt(1),
+			want: false,
+		},
+		{
+			name: "1_1",
+			a:    big.NewInt(1),
+			b:    big.NewInt(1),
+			want: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			assert.Equal(test.want, BigEqual(test.a, test.b))
+			assert.Equal(test.want, BigEqual(test.b, test.a))
+		})
+	}
+}
+
 func TestBigEqualUint64(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Why this should be merged

Cherry picks following PR from Coreth and syncs coreth master up to [a9437e4](https://github.com/ava-labs/coreth/commit/a9437e4)

https://github.com/ava-labs/coreth/pull/794

https://github.com/ava-labs/coreth/pull/797

## How this was tested

Added relevant UTs for subnet-evm fee configs.

## Need to be documented?

No

## Need to update RELEASES.md?

No
