### PR TITLE
use ctx in validatorsManager

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -5,6 +5,7 @@
 * Bump golangci-lint to v1.63 and add linters
 * Refactored trie_prefetcher.go to be structurally similar to upstream.
 * Remove legacy gossip handler and metrics
+* Fixed concurrency issue in validators/uptime manager
 
 ## [v0.7.0](https://github.com/ava-labs/subnet-evm/releases/tag/v0.7.0)
 

--- a/plugin/evm/validators/interfaces/interfaces.go
+++ b/plugin/evm/validators/interfaces/interfaces.go
@@ -13,7 +13,9 @@ import (
 )
 
 type ValidatorReader interface {
-	// GetValidatorAndUptime returns the uptime of the validator specified by validationID
+	// GetValidatorAndUptime returns the calculated uptime of the validator specified by validationID
+	// and the last updated time.
+	// GetValidatorAndUptime holds the chain context lock while performing the operation and can be called concurrently.
 	GetValidatorAndUptime(validationID ids.ID) (stateinterfaces.Validator, time.Duration, time.Time, error)
 }
 
@@ -21,10 +23,15 @@ type Manager interface {
 	stateinterfaces.State
 	avalancheuptime.Manager
 	ValidatorReader
-
-	// Sync updates the validator set managed
-	// by the manager
-	Sync(ctx context.Context) error
+	// Initialize initializes the validator manager
+	// by syncing the validator state with the current validator set
+	// and starting the uptime tracking.
+	// Initialize holds the chain context lock while performing the operation.
+	Initialize(ctx context.Context) error
+	// Shutdown stops the uptime tracking and writes the validator state to the database.
+	// Shutdown holds the chain context lock while performing the operation.
+	Shutdown() error
 	// DispatchSync starts the sync process
+	// DispatchSync holds the chain context lock while performing the sync.
 	DispatchSync(ctx context.Context)
 }

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -153,10 +153,6 @@ func setupGenesis(
 	atomicMemory := atomic.NewMemory(prefixdb.New([]byte{0}, baseDB))
 	ctx.SharedMemory = atomicMemory.NewSharedMemory(ctx.ChainID)
 
-	// NB: this lock is intentionally left locked when this function returns.
-	// The caller of this function is responsible for unlocking.
-	ctx.Lock.Lock()
-
 	issuer := make(chan commonEng.Message, 1)
 	prefixedDB := prefixdb.New([]byte{1}, baseDB)
 	return ctx, prefixedDB, genesisBytes, issuer, atomicMemory


### PR DESCRIPTION
## Why this should be merged

`snow.Context.Lock` provided by AvalancheGo(rpcchainvm) is not reliable for engine calls. Validator manager should not depend on that, and rather hold the ctx itself.

## How this works

Moves ctx lock management to validators manager, hold ctx lock in `Connected`, `Disconnected`

## How this was tested

UT, locally

## Need to be documented?

No

## Need to update RELEASES.md?

updated
