### PR TITLE
fix go mod path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: "go.mod"
+          go-version-file: "./subnet-evm/go.mod"
       - name: Set up arm64 cross compiler
         run: |
           sudo apt-get -y update


### PR DESCRIPTION
## Why this should be merged
Release action checks out repo to `subnet-evm` path. Go.mod path was wrong in release.yml.

## How this works

Fixed go.mod file path

## How this was tested

Manual CI trigger

## Need to be documented?

No

## Need to update RELEASES.md?

No
