### PR TITLE
Simplify avalanchego version maintenance

### DIFF
--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -4,5 +4,25 @@
 # shellcheck disable=SC2034
 
 # Don't export them as they're used in the context of other calls
-AVALANCHE_VERSION=${AVALANCHE_VERSION:-'f1ec9a13'}
+
+if [[ -z ${AVALANCHE_VERSION:-} ]]; then
+  # Get module details from go.mod
+  MODULE_DETAILS="$(go list -m "github.com/ava-labs/avalanchego" 2>/dev/null)"
+
+  # Extract the version part
+  AVALANCHE_VERSION="$(echo "${MODULE_DETAILS}" | awk '{print $2}')"
+
+  # Check if the version matches the pattern where the last part is the module hash
+  # v*YYYYMMDDHHMMSS-abcdef123456
+  #
+  # If not, the value is assumed to represent a tag
+  if [[ "${AVALANCHE_VERSION}" =~ ^v.*[0-9]{14}-[0-9a-f]{12}$ ]]; then
+    # Extract module hash from version
+    MODULE_HASH="$(echo "${AVALANCHE_VERSION}" | cut -d'-' -f3)"
+
+    # The first 8 chars of the hash is used as the tag of avalanchego images
+    AVALANCHE_VERSION="${MODULE_HASH::8}"
+  fi
+fi
+
 GINKGO_VERSION=${GINKGO_VERSION:-'v2.2.0'}


### PR DESCRIPTION
## Why this should be merged

Previously it was necessary to manually maintain the avalanchego version in versions.sh. Now the version is automatically detected via go modules.

## How this works

 - updates versions.sh to automatically determine the version/SHA from go module

## How this was tested

- CI
- Manually checked the version used matched the go module version when invoking `bash -x scripts/build.sh`

## Need to be documented?

N/A

## Need to update RELEASES.md?

N/A