### PR TITLE
eliminate an impossible error case from state.WriteState

### DIFF
--- a/plugin/evm/validators/state/state.go
+++ b/plugin/evm/validators/state/state.go
@@ -203,7 +203,7 @@ func (s *state) WriteState() error {
 		return err
 	}
 	// we've successfully flushed the updates, clear the updated marker.
-	s.updatedData = make(map[ids.ID]dbUpdateStatus)
+	clear(s.updatedData)
 	return nil
 }
 

--- a/plugin/evm/validators/state/state.go
+++ b/plugin/evm/validators/state/state.go
@@ -197,13 +197,14 @@ func (s *state) WriteState() error {
 			if err := batch.Delete(vID[:]); err != nil {
 				return err
 			}
-		default:
-			return fmt.Errorf("unknown update status for %s", vID)
 		}
-		// we're done, remove the updated marker
-		delete(s.updatedData, vID)
 	}
-	return batch.Write()
+	if err := batch.Write(); err != nil {
+		return err
+	}
+	// we've successfully flushed the updates, clear the updated marker.
+	s.updatedData = make(map[ids.ID]dbUpdateStatus)
+	return nil
 }
 
 // SetStatus sets the active status of the validator with the given vID


### PR DESCRIPTION
## Why this should be merged
This PR removes an impossible error case from state.WriteState.

## How this works
The switch case was covering three states:
```golang
switch variable ( of type bool ) {
case false:
   ...
case true:
   ...
default:
   <generate error>
```
Given that a boolean can be either true or false, and nothing else, the default path is not possible.

## How this was tested
By the virtue of the error, this code change is not testable.

## Need to be documented?
no.

## Need to update RELEASES.md?
no.