### PR TITLE
remove ctx locks and use chain locks

### DIFF
--- a/plugin/evm/admin.go
+++ b/plugin/evm/admin.go
@@ -30,8 +30,8 @@ func NewAdminService(vm *VM, performanceDir string) *Admin {
 func (p *Admin) StartCPUProfiler(_ *http.Request, _ *struct{}, _ *api.EmptyReply) error {
 	log.Info("Admin: StartCPUProfiler called")
 
-	p.vm.ctx.Lock.Lock()
-	defer p.vm.ctx.Lock.Unlock()
+	p.vm.chainLock.Lock()
+	defer p.vm.chainLock.Unlock()
 
 	return p.profiler.StartCPUProfiler()
 }
@@ -40,8 +40,8 @@ func (p *Admin) StartCPUProfiler(_ *http.Request, _ *struct{}, _ *api.EmptyReply
 func (p *Admin) StopCPUProfiler(r *http.Request, _ *struct{}, _ *api.EmptyReply) error {
 	log.Info("Admin: StopCPUProfiler called")
 
-	p.vm.ctx.Lock.Lock()
-	defer p.vm.ctx.Lock.Unlock()
+	p.vm.chainLock.Lock()
+	defer p.vm.chainLock.Unlock()
 
 	return p.profiler.StopCPUProfiler()
 }
@@ -50,8 +50,8 @@ func (p *Admin) StopCPUProfiler(r *http.Request, _ *struct{}, _ *api.EmptyReply)
 func (p *Admin) MemoryProfile(_ *http.Request, _ *struct{}, _ *api.EmptyReply) error {
 	log.Info("Admin: MemoryProfile called")
 
-	p.vm.ctx.Lock.Lock()
-	defer p.vm.ctx.Lock.Unlock()
+	p.vm.chainLock.Lock()
+	defer p.vm.chainLock.Unlock()
 
 	return p.profiler.MemoryProfile()
 }
@@ -60,8 +60,8 @@ func (p *Admin) MemoryProfile(_ *http.Request, _ *struct{}, _ *api.EmptyReply) e
 func (p *Admin) LockProfile(_ *http.Request, _ *struct{}, _ *api.EmptyReply) error {
 	log.Info("Admin: LockProfile called")
 
-	p.vm.ctx.Lock.Lock()
-	defer p.vm.ctx.Lock.Unlock()
+	p.vm.chainLock.Lock()
+	defer p.vm.chainLock.Unlock()
 
 	return p.profiler.LockProfile()
 }
@@ -69,8 +69,8 @@ func (p *Admin) LockProfile(_ *http.Request, _ *struct{}, _ *api.EmptyReply) err
 func (p *Admin) SetLogLevel(_ *http.Request, args *client.SetLogLevelArgs, reply *api.EmptyReply) error {
 	log.Info("EVM: SetLogLevel called", "logLevel", args.Level)
 
-	p.vm.ctx.Lock.Lock()
-	defer p.vm.ctx.Lock.Unlock()
+	p.vm.chainLock.Lock()
+	defer p.vm.chainLock.Unlock()
 
 	if err := p.vm.logger.SetLogLevel(args.Level); err != nil {
 		return fmt.Errorf("failed to parse log level: %w ", err)

--- a/plugin/evm/admin.go
+++ b/plugin/evm/admin.go
@@ -30,8 +30,8 @@ func NewAdminService(vm *VM, performanceDir string) *Admin {
 func (p *Admin) StartCPUProfiler(_ *http.Request, _ *struct{}, _ *api.EmptyReply) error {
 	log.Info("Admin: StartCPUProfiler called")
 
-	p.vm.chainLock.Lock()
-	defer p.vm.chainLock.Unlock()
+	p.vm.vmLock.Lock()
+	defer p.vm.vmLock.Unlock()
 
 	return p.profiler.StartCPUProfiler()
 }
@@ -40,8 +40,8 @@ func (p *Admin) StartCPUProfiler(_ *http.Request, _ *struct{}, _ *api.EmptyReply
 func (p *Admin) StopCPUProfiler(r *http.Request, _ *struct{}, _ *api.EmptyReply) error {
 	log.Info("Admin: StopCPUProfiler called")
 
-	p.vm.chainLock.Lock()
-	defer p.vm.chainLock.Unlock()
+	p.vm.vmLock.Lock()
+	defer p.vm.vmLock.Unlock()
 
 	return p.profiler.StopCPUProfiler()
 }
@@ -50,8 +50,8 @@ func (p *Admin) StopCPUProfiler(r *http.Request, _ *struct{}, _ *api.EmptyReply)
 func (p *Admin) MemoryProfile(_ *http.Request, _ *struct{}, _ *api.EmptyReply) error {
 	log.Info("Admin: MemoryProfile called")
 
-	p.vm.chainLock.Lock()
-	defer p.vm.chainLock.Unlock()
+	p.vm.vmLock.Lock()
+	defer p.vm.vmLock.Unlock()
 
 	return p.profiler.MemoryProfile()
 }
@@ -60,8 +60,8 @@ func (p *Admin) MemoryProfile(_ *http.Request, _ *struct{}, _ *api.EmptyReply) e
 func (p *Admin) LockProfile(_ *http.Request, _ *struct{}, _ *api.EmptyReply) error {
 	log.Info("Admin: LockProfile called")
 
-	p.vm.chainLock.Lock()
-	defer p.vm.chainLock.Unlock()
+	p.vm.vmLock.Lock()
+	defer p.vm.vmLock.Unlock()
 
 	return p.profiler.LockProfile()
 }
@@ -69,8 +69,8 @@ func (p *Admin) LockProfile(_ *http.Request, _ *struct{}, _ *api.EmptyReply) err
 func (p *Admin) SetLogLevel(_ *http.Request, args *client.SetLogLevelArgs, reply *api.EmptyReply) error {
 	log.Info("EVM: SetLogLevel called", "logLevel", args.Level)
 
-	p.vm.chainLock.Lock()
-	defer p.vm.chainLock.Unlock()
+	p.vm.vmLock.Lock()
+	defer p.vm.vmLock.Unlock()
 
 	if err := p.vm.logger.SetLogLevel(args.Level); err != nil {
 		return fmt.Errorf("failed to parse log level: %w ", err)

--- a/plugin/evm/service.go
+++ b/plugin/evm/service.go
@@ -18,8 +18,8 @@ type ValidatorsAPI struct {
 }
 
 func (api *ValidatorsAPI) GetCurrentValidators(_ *http.Request, req *client.GetCurrentValidatorsRequest, reply *client.GetCurrentValidatorsResponse) error {
-	api.vm.ctx.Lock.RLock()
-	defer api.vm.ctx.Lock.RUnlock()
+	api.vm.chainLock.RLock()
+	defer api.vm.chainLock.RUnlock()
 
 	var vIDs set.Set[ids.ID]
 	if len(req.NodeIDs) > 0 {

--- a/plugin/evm/service.go
+++ b/plugin/evm/service.go
@@ -18,8 +18,8 @@ type ValidatorsAPI struct {
 }
 
 func (api *ValidatorsAPI) GetCurrentValidators(_ *http.Request, req *client.GetCurrentValidatorsRequest, reply *client.GetCurrentValidatorsResponse) error {
-	api.vm.chainLock.RLock()
-	defer api.vm.chainLock.RUnlock()
+	api.vm.vmLock.RLock()
+	defer api.vm.vmLock.RUnlock()
 
 	var vIDs set.Set[ids.ID]
 	if len(req.NodeIDs) > 0 {

--- a/plugin/evm/validators/interfaces/interfaces.go
+++ b/plugin/evm/validators/interfaces/interfaces.go
@@ -16,7 +16,7 @@ import (
 type ValidatorReader interface {
 	// GetValidatorAndUptime returns the calculated uptime of the validator specified by validationID
 	// and the last updated time.
-	// GetValidatorAndUptime holds the chain context lock while performing the operation and can be called concurrently.
+	// GetValidatorAndUptime holds the VM lock while performing the operation and can be called concurrently.
 	GetValidatorAndUptime(validationID ids.ID) (stateinterfaces.Validator, time.Duration, time.Time, error)
 }
 

--- a/plugin/evm/validators/interfaces/interfaces.go
+++ b/plugin/evm/validators/interfaces/interfaces.go
@@ -5,6 +5,7 @@ package interfaces
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/ava-labs/avalanchego/ids"
@@ -20,18 +21,14 @@ type ValidatorReader interface {
 }
 
 type Manager interface {
-	stateinterfaces.State
+	stateinterfaces.StateReader
 	avalancheuptime.Manager
-	ValidatorReader
 	// Initialize initializes the validator manager
 	// by syncing the validator state with the current validator set
 	// and starting the uptime tracking.
-	// Initialize holds the chain context lock while performing the operation.
 	Initialize(ctx context.Context) error
 	// Shutdown stops the uptime tracking and writes the validator state to the database.
-	// Shutdown holds the chain context lock while performing the operation.
 	Shutdown() error
 	// DispatchSync starts the sync process
-	// DispatchSync holds the chain context lock while performing the sync.
-	DispatchSync(ctx context.Context)
+	DispatchSync(ctx context.Context, lock sync.Locker)
 }

--- a/plugin/evm/validators/locked_reader.go
+++ b/plugin/evm/validators/locked_reader.go
@@ -1,0 +1,51 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package validators
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/subnet-evm/plugin/evm/validators/interfaces"
+	stateinterfaces "github.com/ava-labs/subnet-evm/plugin/evm/validators/state/interfaces"
+)
+
+type lockedReader struct {
+	manager interfaces.Manager
+	lock    sync.Locker
+}
+
+func NewLockedValidatorReader(
+	manager interfaces.Manager,
+	lock sync.Locker,
+) interfaces.ValidatorReader {
+	return &lockedReader{
+		lock:    lock,
+		manager: manager,
+	}
+}
+
+// GetValidatorAndUptime returns the calculated uptime of the validator specified by validationID
+// and the last updated time.
+// GetValidatorAndUptime holds the chain context lock while performing the operation and can be called concurrently.
+func (l *lockedReader) GetValidatorAndUptime(validationID ids.ID) (stateinterfaces.Validator, time.Duration, time.Time, error) {
+	// lock the state
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
+	// Get validator first
+	vdr, err := l.manager.GetValidator(validationID)
+	if err != nil {
+		return stateinterfaces.Validator{}, 0, time.Time{}, fmt.Errorf("failed to get validator: %w", err)
+	}
+
+	uptime, lastUpdated, err := l.manager.CalculateUptime(vdr.NodeID)
+	if err != nil {
+		return stateinterfaces.Validator{}, 0, time.Time{}, fmt.Errorf("failed to get uptime: %w", err)
+	}
+
+	return vdr, uptime, lastUpdated, nil
+}

--- a/plugin/evm/validators/manager.go
+++ b/plugin/evm/validators/manager.go
@@ -109,7 +109,7 @@ func (m *manager) DispatchSync(ctx context.Context, lock sync.Locker) {
 
 // sync synchronizes the validator state with the current validator set
 // and writes the state to the database.
-// sync is not safe to call concurrently and should be called with the chain context locked.
+// sync is not safe to call concurrently and should be called with the VM locked.
 func (m *manager) sync(ctx context.Context) error {
 	now := time.Now()
 	log.Debug("performing validator sync")

--- a/plugin/evm/validators/manager.go
+++ b/plugin/evm/validators/manager.go
@@ -6,6 +6,7 @@ package validators
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/ava-labs/avalanchego/database"
@@ -14,7 +15,6 @@ import (
 	avalancheuptime "github.com/ava-labs/avalanchego/snow/uptime"
 	avalanchevalidators "github.com/ava-labs/avalanchego/snow/validators"
 	"github.com/ava-labs/avalanchego/utils/timer/mockable"
-	"github.com/ava-labs/subnet-evm/plugin/evm/validators/interfaces"
 	validators "github.com/ava-labs/subnet-evm/plugin/evm/validators/state"
 	stateinterfaces "github.com/ava-labs/subnet-evm/plugin/evm/validators/state/interfaces"
 	"github.com/ava-labs/subnet-evm/plugin/evm/validators/uptime"
@@ -35,11 +35,12 @@ type manager struct {
 
 // NewManager returns a new validator manager
 // that manages the validator state and the uptime manager.
+// Manager is not thread safe and should be used with the chain context locked.
 func NewManager(
 	ctx *snow.Context,
 	db database.Database,
 	clock *mockable.Clock,
-) (interfaces.Manager, error) {
+) (*manager, error) {
 	validatorState, err := validators.NewState(db)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize validator state: %w", err)
@@ -59,10 +60,7 @@ func NewManager(
 // Initialize initializes the validator manager
 // by syncing the validator state with the current validator set
 // and starting the uptime tracking.
-// Initialize holds the chain context lock while performing the operation.
 func (m *manager) Initialize(ctx context.Context) error {
-	m.chainCtx.Lock.Lock()
-	defer m.chainCtx.Lock.Unlock()
 	// sync validators first
 	if err := m.sync(ctx); err != nil {
 		return fmt.Errorf("failed to update validators: %w", err)
@@ -78,10 +76,7 @@ func (m *manager) Initialize(ctx context.Context) error {
 }
 
 // Shutdown stops the uptime tracking and writes the validator state to the database.
-// Shutdown holds the chain context lock while performing the operation.
 func (m *manager) Shutdown() error {
-	m.chainCtx.Lock.Lock()
-	defer m.chainCtx.Lock.Unlock()
 	vdrIDs := m.GetNodeIDs().List()
 	if err := m.StopTracking(vdrIDs); err != nil {
 		return fmt.Errorf("failed to stop tracking uptime: %w", err)
@@ -92,54 +87,20 @@ func (m *manager) Shutdown() error {
 	return nil
 }
 
-func (m *manager) Connect(nodeID ids.NodeID) error {
-	m.chainCtx.Lock.Lock()
-	defer m.chainCtx.Lock.Unlock()
-	return m.PausableManager.Connect(nodeID)
-}
-
-func (m *manager) Disconnect(nodeID ids.NodeID) error {
-	m.chainCtx.Lock.Lock()
-	defer m.chainCtx.Lock.Unlock()
-	return m.PausableManager.Disconnect(nodeID)
-}
-
-// GetValidatorAndUptime returns the calculated uptime of the validator specified by validationID
-// and the last updated time.
-// GetValidatorAndUptime holds the chain context lock while performing the operation and can be called concurrently.
-func (m *manager) GetValidatorAndUptime(validationID ids.ID) (stateinterfaces.Validator, time.Duration, time.Time, error) {
-	// lock the state
-	m.chainCtx.Lock.RLock()
-	defer m.chainCtx.Lock.RUnlock()
-
-	// Get validator first
-	vdr, err := m.GetValidator(validationID)
-	if err != nil {
-		return stateinterfaces.Validator{}, 0, time.Time{}, fmt.Errorf("failed to get validator: %w", err)
-	}
-
-	uptime, lastUpdated, err := m.CalculateUptime(vdr.NodeID)
-	if err != nil {
-		return stateinterfaces.Validator{}, 0, time.Time{}, fmt.Errorf("failed to get uptime: %w", err)
-	}
-
-	return vdr, uptime, lastUpdated, nil
-}
-
 // DispatchSync starts the sync process
-// DispatchSync holds the chain context lock while performing the sync.
-func (m *manager) DispatchSync(ctx context.Context) {
+// DispatchSync holds the given lock while performing the sync.
+func (m *manager) DispatchSync(ctx context.Context, lock sync.Locker) {
 	ticker := time.NewTicker(SyncFrequency)
 	defer ticker.Stop()
 
 	for {
 		select {
 		case <-ticker.C:
-			m.chainCtx.Lock.Lock()
+			lock.Lock()
 			if err := m.sync(ctx); err != nil {
 				log.Error("failed to sync validators", "error", err)
 			}
-			m.chainCtx.Lock.Unlock()
+			lock.Unlock()
 		case <-ctx.Done():
 			return
 		}

--- a/plugin/evm/validators/manager.go
+++ b/plugin/evm/validators/manager.go
@@ -35,7 +35,7 @@ type manager struct {
 
 // NewManager returns a new validator manager
 // that manages the validator state and the uptime manager.
-// Manager is not thread safe and should be used with the chain context locked.
+// Manager is not thread safe and should be used with the VM locked.
 func NewManager(
 	ctx *snow.Context,
 	db database.Database,

--- a/plugin/evm/validators/state/state.go
+++ b/plugin/evm/validators/state/state.go
@@ -197,13 +197,14 @@ func (s *state) WriteState() error {
 			if err := batch.Delete(vID[:]); err != nil {
 				return err
 			}
-		default:
-			return fmt.Errorf("unknown update status for %s", vID)
 		}
-		// we're done, remove the updated marker
-		delete(s.updatedData, vID)
 	}
-	return batch.Write()
+	if err := batch.Write(); err != nil {
+		return err
+	}
+	// we've successfully flushed the updates, clear the updated marker.
+	clear(s.updatedData)
+	return nil
 }
 
 // SetStatus sets the active status of the validator with the given vID

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -177,6 +177,8 @@ var legacyApiNames = map[string]string{
 // VM implements the snowman.ChainVM interface
 type VM struct {
 	ctx *snow.Context
+	// snow.Context.Lock is deprecated and should not be used in rpcchainvm.
+	chainLock sync.RWMutex
 	// [cancel] may be nil until [snow.NormalOp] starts
 	cancel context.CancelFunc
 	// *chain.State helps to implement the VM interface by wrapping blocks
@@ -521,7 +523,7 @@ func (vm *VM) Initialize(
 		vm.ctx.ChainID,
 		vm.ctx.WarpSigner,
 		vm,
-		vm.validatorsManager,
+		validators.NewLockedValidatorReader(vm.validatorsManager, vm.chainLock.RLocker()),
 		vm.warpDB,
 		meteredCache,
 		offchainWarpMessages,
@@ -680,6 +682,8 @@ func (vm *VM) initChainState(lastAcceptedBlock *types.Block) error {
 }
 
 func (vm *VM) SetState(_ context.Context, state snow.State) error {
+	vm.chainLock.Lock()
+	defer vm.chainLock.Unlock()
 	switch state {
 	case snow.StateSyncing:
 		vm.bootstrapped.Set(false)
@@ -728,7 +732,7 @@ func (vm *VM) onNormalOperationsStarted() error {
 	// dispatch validator set update
 	vm.shutdownWg.Add(1)
 	go func() {
-		vm.validatorsManager.DispatchSync(ctx)
+		vm.validatorsManager.DispatchSync(ctx, &vm.chainLock)
 		vm.shutdownWg.Done()
 	}()
 
@@ -862,6 +866,8 @@ func (vm *VM) setAppRequestHandlers() {
 
 // Shutdown implements the snowman.ChainVM interface
 func (vm *VM) Shutdown(context.Context) error {
+	vm.chainLock.Lock()
+	defer vm.chainLock.Unlock()
 	if vm.ctx == nil {
 		return nil
 	}
@@ -1254,6 +1260,9 @@ func attachEthService(handler *rpc.Server, apis []rpc.API, names []string) error
 }
 
 func (vm *VM) Connected(ctx context.Context, nodeID ids.NodeID, version *version.Application) error {
+	vm.chainLock.Lock()
+	defer vm.chainLock.Unlock()
+
 	if err := vm.validatorsManager.Connect(nodeID); err != nil {
 		return fmt.Errorf("uptime manager failed to connect node %s: %w", nodeID, err)
 	}
@@ -1261,6 +1270,9 @@ func (vm *VM) Connected(ctx context.Context, nodeID ids.NodeID, version *version
 }
 
 func (vm *VM) Disconnected(ctx context.Context, nodeID ids.NodeID) error {
+	vm.chainLock.Lock()
+	defer vm.chainLock.Unlock()
+
 	if err := vm.validatorsManager.Disconnect(nodeID); err != nil {
 		return fmt.Errorf("uptime manager failed to disconnect node %s: %w", nodeID, err)
 	}

--- a/plugin/evm/vm_validators_test.go
+++ b/plugin/evm/vm_validators_test.go
@@ -151,8 +151,8 @@ func TestValidatorState(t *testing.T) {
 
 	// new validator should be added to the state eventually after SyncFrequency
 	require.EventuallyWithT(func(c *assert.CollectT) {
-		vm.chainLock.Lock()
-		defer vm.chainLock.Unlock()
+		vm.vmLock.Lock()
+		defer vm.vmLock.Unlock()
 		assert.Len(c, vm.validatorsManager.GetNodeIDs(), 4)
 		newValidator, err := vm.validatorsManager.GetValidator(newValidationID)
 		assert.NoError(c, err)

--- a/plugin/evm/vm_validators_test.go
+++ b/plugin/evm/vm_validators_test.go
@@ -151,8 +151,8 @@ func TestValidatorState(t *testing.T) {
 
 	// new validator should be added to the state eventually after SyncFrequency
 	require.EventuallyWithT(func(c *assert.CollectT) {
-		vm.ctx.Lock.Lock()
-		defer vm.ctx.Lock.Unlock()
+		vm.chainLock.Lock()
+		defer vm.chainLock.Unlock()
 		assert.Len(c, vm.validatorsManager.GetNodeIDs(), 4)
 		newValidator, err := vm.validatorsManager.GetValidator(newValidationID)
 		assert.NoError(c, err)

--- a/warp/verifier_backend_test.go
+++ b/warp/verifier_backend_test.go
@@ -5,6 +5,7 @@ package warp
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -291,8 +292,10 @@ func TestUptimeSignatures(t *testing.T) {
 		clk := &mockable.Clock{}
 		validatorsManager, err := validators.NewManager(chainCtx, memdb.New(), clk)
 		require.NoError(t, err)
+		lock := &sync.RWMutex{}
+		newLockedValidatorManager := validators.NewLockedValidatorReader(validatorsManager, lock)
 		validatorsManager.StartTracking([]ids.NodeID{})
-		warpBackend, err := NewBackend(snowCtx.NetworkID, snowCtx.ChainID, warpSigner, warptest.EmptyBlockClient, validatorsManager, database, sigCache, nil)
+		warpBackend, err := NewBackend(snowCtx.NetworkID, snowCtx.ChainID, warpSigner, warptest.EmptyBlockClient, newLockedValidatorManager, database, sigCache, nil)
 		require.NoError(t, err)
 		handler := acp118.NewCachedHandler(sigCache, warpBackend, warpSigner)
 


### PR DESCRIPTION
## Why this should be merged

`snow.Context.Lock` is deprecated and rpchainvms should not depend on it. This PR changes ctx locks to chainLocks and updates validator manager.

## How this works

This pull request includes several changes to improve thread safety by replacing the use of `vm.ctx.Lock` with `vm.chainLock` across various files. Additionally, it introduces a new `lockedReader` type to handle validator operations with locking.

### Thread Safety Improvements:
* [`plugin/evm/admin.go`](diffhunk://#diff-33ca639e424bc2d90f5f568847a93aaef9e1f447d98a671c7f565983e8f22db7L33-R34): Replaced `vm.ctx.Lock` with `vm.chainLock` in methods `StartCPUProfiler`, `StopCPUProfiler`, `MemoryProfile`, and `LockProfile`. [[1]](diffhunk://#diff-33ca639e424bc2d90f5f568847a93aaef9e1f447d98a671c7f565983e8f22db7L33-R34) [[2]](diffhunk://#diff-33ca639e424bc2d90f5f568847a93aaef9e1f447d98a671c7f565983e8f22db7L43-R44) [[3]](diffhunk://#diff-33ca639e424bc2d90f5f568847a93aaef9e1f447d98a671c7f565983e8f22db7L53-R54) [[4]](diffhunk://#diff-33ca639e424bc2d90f5f568847a93aaef9e1f447d98a671c7f565983e8f22db7L63-R73)
* [`plugin/evm/service.go`](diffhunk://#diff-42f3e9fd1f7cfff775643d1bad698671c0a34b8e3d3e5ab867626fcc0fa6fb8fL21-R22): Updated `GetCurrentValidators` method to use `vm.chainLock` instead of `vm.ctx.Lock`.
* [`plugin/evm/validators/manager.go`](diffhunk://#diff-4a000f622b5cb58250d9989ec52fe74a72b1a539852a0f89f292d376b04c5f28R38-R43): Removed the use of `chainCtx.Lock` in various methods and updated `DispatchSync` to accept an external lock. [[1]](diffhunk://#diff-4a000f622b5cb58250d9989ec52fe74a72b1a539852a0f89f292d376b04c5f28R38-R43) [[2]](diffhunk://#diff-4a000f622b5cb58250d9989ec52fe74a72b1a539852a0f89f292d376b04c5f28L62-L65) [[3]](diffhunk://#diff-4a000f622b5cb58250d9989ec52fe74a72b1a539852a0f89f292d376b04c5f28L81-L84) [[4]](diffhunk://#diff-4a000f622b5cb58250d9989ec52fe74a72b1a539852a0f89f292d376b04c5f28L95-R103)
* [`plugin/evm/vm.go`](diffhunk://#diff-3be5ea9687f8af021d9baaa6584d174a7975b181b604e1a759e4ad2e40136912R180-R181): Added `chainLock` to `VM` struct and replaced `ctx.Lock` with `chainLock` in multiple methods including `SetState`, `onNormalOperationsStarted`, `Shutdown`, `Connected`, and `Disconnected`. [[1]](diffhunk://#diff-3be5ea9687f8af021d9baaa6584d174a7975b181b604e1a759e4ad2e40136912R180-R181) [[2]](diffhunk://#diff-3be5ea9687f8af021d9baaa6584d174a7975b181b604e1a759e4ad2e40136912L524-R526) [[3]](diffhunk://#diff-3be5ea9687f8af021d9baaa6584d174a7975b181b604e1a759e4ad2e40136912R685-R686) [[4]](diffhunk://#diff-3be5ea9687f8af021d9baaa6584d174a7975b181b604e1a759e4ad2e40136912L731-R735) [[5]](diffhunk://#diff-3be5ea9687f8af021d9baaa6584d174a7975b181b604e1a759e4ad2e40136912R869-R870) [[6]](diffhunk://#diff-3be5ea9687f8af021d9baaa6584d174a7975b181b604e1a759e4ad2e40136912R1263-R1275)

### New `lockedReader` Implementation:
* [`plugin/evm/validators/locked_reader.go`](diffhunk://#diff-a7753f5d83d6a31224229d1a214dd70112db24ae43ca5f032d5cd62e733cdfa1R1-R51): Introduced a new `lockedReader` type to encapsulate validator operations with locking.

### Updates to Interfaces:
* [`plugin/evm/validators/interfaces/interfaces.go`](diffhunk://#diff-d6ef68b1f8c96df2ac58099e7e2e6800889165e2e6caa8c8d73810515e78bd6aL23-R33): Modified `Manager` interface to accept a `sync.Locker` for `DispatchSync` and removed redundant methods.

### Test Adjustments:
* [`plugin/evm/vm_validators_test.go`](diffhunk://#diff-13f115874661406a5f25f006518e84293ed17e7dd4a9891e074b2726761e7e2bL154-R155): Updated tests to use `vm.chainLock` instead of `vm.ctx.Lock`.
* [`warp/verifier_backend_test.go`](diffhunk://#diff-71ba0931b47ff7554245a4ea01a15871b5dc4312ee4ae9a8bf2316264718c617R295-R298): Adjusted tests to use the new `lockedReader` for validator operations.

## How this was tested

Existing/modified UT should cover this.

## Need to be documented?

No

## Need to update RELEASES.md?

No

