### PR TITLE
chore(ci): add merge groups

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -3,6 +3,8 @@ name: Bench
 on:
   workflow_dispatch:
   pull_request:
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   bench:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,6 +17,8 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ master ]
+  merge_group:
+    types: [checks_requested]
   schedule:
     - cron: '44 11 * * 4'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,8 @@ on:
     tags:
       - "*"
   pull_request:
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   lint_test:


### PR DESCRIPTION
## Why this should be merged

Adds merge group actions to ci workflows.

## How this works

This pull request adds a new event type to the GitHub Actions workflows to trigger the workflows when checks are requested for a merge group. This change ensures that the workflows run in response to specific events related to merge groups.

Changes to GitHub Actions workflows:
This pull request includes updates to multiple GitHub Actions workflow files to add a new event type for triggering workflows. The changes ensure that workflows can be triggered when checks are requested for a merge group.

Updates to GitHub Actions workflows:

* [`.github/workflows/bench.yml`](diffhunk://#diff-a5e740be96415373789689f814583e93ff2a8f05eae6481e94505fd6cb6bc6a7R6-R7): Added `merge_group` event type with `checks_requested` to trigger the workflow.
* [`.github/workflows/codeql-analysis.yml`](diffhunk://#diff-63bd641104d10e25f141d518a16b22a151d125e12701df2f9e79734b23b90188R20-R21): Added `merge_group` event type with `checks_requested` to trigger the workflow.
* [`.github/workflows/tests.yml`](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fR10-R11): Added `merge_group` event type with `checks_requested` to trigger the workflow.

## How this was tested

Need to be tested with merge queue enabled

## Need to be documented?

No

## Need to update RELEASES.md?

No
