### PR TITLE
chore(predicate): fix typo in `PreparePredicateStorageSlots` comment

### DIFF
--- a/predicate/predicate_slots.go
+++ b/predicate/predicate_slots.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-// PreparePredicateStorageSlots populates the the predicate storage slots of a transaction's access list
+// PreparePredicateStorageSlots populates the predicate storage slots of a transaction's access list
 // Note: if an address is specified multiple times in the access list, each storage slot for that address is
 // appended to a slice of byte slices. Each byte slice represents a predicate, making it a slice of predicates
 // for each access list address, and every predicate in the slice goes through verification.


### PR DESCRIPTION
## Why this should be merged

remove redundant word in comment

## How this works

## How this was tested

## Need to be documented?

## Need to update RELEASES.md?
