### PR TITLE
[docker] Update to debian12/bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 ARG AVALANCHEGO_NODE_IMAGE="invalid-image"
 
 # ============= Compilation Stage ================
-FROM --platform=$BUILDPLATFORM golang:1.23.6-bullseye AS builder
+FROM --platform=$BUILDPLATFORM golang:1.23.6-bookworm AS builder
 
 WORKDIR /build
 


### PR DESCRIPTION
## Why this should be merged

This change follows from a similar upgrade to avalanchego:

https://github.com/ava-labs/avalanchego/pull/3798

Will need to coordinate this PR with that update.

## How this was tested

CI

## Need to be documented?

N/A

## Need to update RELEASES.md?

N/A

## TODO

 - [x] Merge https://github.com/ava-labs/subnet-evm/pull/1440