### PR TITLE
add fortuna default as nil

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -5,6 +5,7 @@
 * - IMPORTANT: `eth_getProof` calls for historical state will be rejected by default.
   - On archive nodes (`"pruning-enabled": false`): queries for historical proofs for state older than approximately 24 hours preceding the last accepted block will be rejected by default. This can be adjusted with the new option `historical-proof-query-window` which defines the number of blocks before the last accepted block which should be accepted for state proof queries, or set to `0` to accept any block number state query (previous behavior).
   - On `pruning` nodes: queries for proofs past the tip buffer (32 blocks) will be rejected. This is in support of moving to a path based storage scheme, which does not support historical state proofs.
+* Added `Fortuna` upgrade as optional and defaulting to a `nil` timestamp.
 
 ## [v0.7.2](https://github.com/ava-labs/subnet-evm/releases/tag/v0.7.2)
 

--- a/params/network_upgrades.go
+++ b/params/network_upgrades.go
@@ -171,7 +171,7 @@ func getDefaultNetworkUpgrades(agoUpgrade upgrade.Config) NetworkUpgrades {
 		SubnetEVMTimestamp: utils.NewUint64(0),
 		DurangoTimestamp:   utils.TimeToNewUint64(agoUpgrade.DurangoTime),
 		EtnaTimestamp:      utils.TimeToNewUint64(agoUpgrade.EtnaTime),
-		FortunaTimestamp:   nil, // Fortuna is optional and have no effect on Subnet-EVM
+		FortunaTimestamp:   nil, // Fortuna is optional and has no effect on Subnet-EVM
 	}
 }
 

--- a/params/network_upgrades.go
+++ b/params/network_upgrades.go
@@ -15,6 +15,7 @@ var errCannotBeNil = fmt.Errorf("timestamp cannot be nil")
 
 // NetworkUpgrades contains timestamps that enable network upgrades.
 // Avalanche specific network upgrades are also included here.
+// (nil = no fork, 0 = already activated)
 type NetworkUpgrades struct {
 	// SubnetEVMTimestamp is a placeholder that activates Avalanche Upgrades prior to ApricotPhase6
 	SubnetEVMTimestamp *uint64 `json:"subnetEVMTimestamp,omitempty"`
@@ -24,8 +25,7 @@ type NetworkUpgrades struct {
 	DurangoTimestamp *uint64 `json:"durangoTimestamp,omitempty"`
 	// Placeholder for EtnaTimestamp
 	EtnaTimestamp *uint64 `json:"etnaTimestamp,omitempty"`
-	// Fortuna is a placeholder for the next upgrade.
-	// (nil = no fork, 0 = already activated)
+	// Fortuna has no effect on Subnet-EVM by itself, but is included for completeness.
 	FortunaTimestamp *uint64 `json:"fortunaTimestamp,omitempty"`
 }
 

--- a/params/network_upgrades.go
+++ b/params/network_upgrades.go
@@ -55,7 +55,7 @@ func (n *NetworkUpgrades) forkOrder() []fork {
 		{name: "subnetEVMTimestamp", timestamp: n.SubnetEVMTimestamp},
 		{name: "durangoTimestamp", timestamp: n.DurangoTimestamp},
 		{name: "etnaTimestamp", timestamp: n.EtnaTimestamp},
-		{name: "fortunaTimestamp", timestamp: n.FortunaTimestamp},
+		{name: "fortunaTimestamp", timestamp: n.FortunaTimestamp, optional: true},
 	}
 }
 
@@ -77,6 +77,9 @@ func (n *NetworkUpgrades) setDefaults(agoUpgrades upgrade.Config) {
 	if n.EtnaTimestamp == nil || *n.EtnaTimestamp == 0 {
 		n.EtnaTimestamp = defaults.EtnaTimestamp
 	}
+	if n.FortunaTimestamp == nil || *n.FortunaTimestamp == 0 {
+		n.FortunaTimestamp = defaults.FortunaTimestamp
+	}
 }
 
 // verifyNetworkUpgrades checks that the network upgrades are well formed.
@@ -91,6 +94,9 @@ func (n *NetworkUpgrades) verifyNetworkUpgrades(agoUpgrades upgrade.Config) erro
 	if err := verifyWithDefault(n.EtnaTimestamp, defaults.EtnaTimestamp); err != nil {
 		return fmt.Errorf("Etna fork block timestamp is invalid: %w", err)
 	}
+	if err := verifyWithDefault(n.FortunaTimestamp, defaults.FortunaTimestamp); err != nil {
+		return fmt.Errorf("Fortuna fork block timestamp is invalid: %w", err)
+	}
 	return nil
 }
 
@@ -103,6 +109,9 @@ func (n *NetworkUpgrades) Override(o *NetworkUpgrades) {
 	}
 	if o.EtnaTimestamp != nil {
 		n.EtnaTimestamp = o.EtnaTimestamp
+	}
+	if o.FortunaTimestamp != nil {
+		n.FortunaTimestamp = o.FortunaTimestamp
 	}
 }
 
@@ -134,8 +143,8 @@ func (n *NetworkUpgrades) Description() string {
 	var banner string
 	banner += fmt.Sprintf(" - SubnetEVM Timestamp:          @%-10v (https://github.com/ava-labs/avalanchego/releases/tag/v1.10.0)\n", ptrToString(n.SubnetEVMTimestamp))
 	banner += fmt.Sprintf(" - Durango Timestamp:            @%-10v (https://github.com/ava-labs/avalanchego/releases/tag/v1.11.0)\n", ptrToString(n.DurangoTimestamp))
-	banner += fmt.Sprintf(" - Etna Timestamp:           @%-10v (https://github.com/ava-labs/avalanchego/releases/tag/v1.12.0)\n", ptrToString(n.EtnaTimestamp))
-	banner += fmt.Sprintf(" - Fortuna Timestamp:              @%-10v (Unscheduled)\n", ptrToString(n.FortunaTimestamp))
+	banner += fmt.Sprintf(" - Etna Timestamp:               @%-10v (https://github.com/ava-labs/avalanchego/releases/tag/v1.12.0)\n", ptrToString(n.EtnaTimestamp))
+	banner += fmt.Sprintf(" - Fortuna Timestamp:            @%-10v (https://github.com/ava-labs/avalanchego/releases/tag/v1.13.0)\n", ptrToString(n.FortunaTimestamp))
 	return banner
 }
 
@@ -156,18 +165,22 @@ func (n *NetworkUpgrades) GetAvalancheRules(time uint64) AvalancheRules {
 }
 
 // getDefaultNetworkUpgrades returns the network upgrades for the specified avalanchego upgrades.
-// These should not return nil values.
+// Nil values are used to indicate optional upgrades.
 func getDefaultNetworkUpgrades(agoUpgrade upgrade.Config) NetworkUpgrades {
 	return NetworkUpgrades{
 		SubnetEVMTimestamp: utils.NewUint64(0),
 		DurangoTimestamp:   utils.TimeToNewUint64(agoUpgrade.DurangoTime),
 		EtnaTimestamp:      utils.TimeToNewUint64(agoUpgrade.EtnaTime),
-		FortunaTimestamp:   utils.TimeToNewUint64(agoUpgrade.FortunaTime),
+		FortunaTimestamp:   nil, // Fortuna is optional and have no effect on Subnet-EVM
 	}
 }
 
 // verifyWithDefault checks that the provided timestamp is greater than or equal to the default timestamp.
 func verifyWithDefault(configTimestamp *uint64, defaultTimestamp *uint64) error {
+	if defaultTimestamp == nil {
+		return nil
+	}
+
 	if configTimestamp == nil {
 		return errCannotBeNil
 	}

--- a/params/network_upgrades_test.go
+++ b/params/network_upgrades_test.go
@@ -259,7 +259,7 @@ func TestVerifyNetworkUpgrades(t *testing.T) {
 				SubnetEVMTimestamp: utils.NewUint64(0),
 				DurangoTimestamp:   utils.TimeToNewUint64(upgrade.GetConfig(constants.MainnetID).DurangoTime),
 			},
-			avagoUpgrades: upgrade.Mainnet,
+			avagoUpgrades: upgrade.Fuji,
 			valid:         false,
 		},
 		{

--- a/params/network_upgrades_test.go
+++ b/params/network_upgrades_test.go
@@ -79,7 +79,7 @@ func TestCheckNetworkUpgradesCompatible(t *testing.T) {
 		upgrades1 *NetworkUpgrades
 		upgrades2 *NetworkUpgrades
 		time      uint64
-		expected  bool
+		valid     bool
 	}{
 		{
 			name: "Compatible same NetworkUpgrades",
@@ -91,8 +91,8 @@ func TestCheckNetworkUpgradesCompatible(t *testing.T) {
 				SubnetEVMTimestamp: utils.NewUint64(1),
 				DurangoTimestamp:   utils.NewUint64(2),
 			},
-			time:     1,
-			expected: true,
+			time:  1,
+			valid: true,
 		},
 		{
 			name: "Compatible different NetworkUpgrades",
@@ -104,8 +104,8 @@ func TestCheckNetworkUpgradesCompatible(t *testing.T) {
 				SubnetEVMTimestamp: utils.NewUint64(1),
 				DurangoTimestamp:   utils.NewUint64(3),
 			},
-			time:     1,
-			expected: true,
+			time:  1,
+			valid: true,
 		},
 		{
 			name: "Compatible nil NetworkUpgrades",
@@ -117,8 +117,8 @@ func TestCheckNetworkUpgradesCompatible(t *testing.T) {
 				SubnetEVMTimestamp: utils.NewUint64(1),
 				DurangoTimestamp:   nil,
 			},
-			time:     1,
-			expected: true,
+			time:  1,
+			valid: true,
 		},
 		{
 			name: "Incompatible rewinded NetworkUpgrades",
@@ -130,8 +130,8 @@ func TestCheckNetworkUpgradesCompatible(t *testing.T) {
 				SubnetEVMTimestamp: utils.NewUint64(1),
 				DurangoTimestamp:   utils.NewUint64(1),
 			},
-			time:     1,
-			expected: false,
+			time:  1,
+			valid: false,
 		},
 		{
 			name: "Incompatible fastforward NetworkUpgrades",
@@ -143,8 +143,8 @@ func TestCheckNetworkUpgradesCompatible(t *testing.T) {
 				SubnetEVMTimestamp: utils.NewUint64(1),
 				DurangoTimestamp:   utils.NewUint64(3),
 			},
-			time:     4,
-			expected: false,
+			time:  4,
+			valid: false,
 		},
 		{
 			name: "Incompatible nil NetworkUpgrades",
@@ -156,14 +156,42 @@ func TestCheckNetworkUpgradesCompatible(t *testing.T) {
 				SubnetEVMTimestamp: utils.NewUint64(1),
 				DurangoTimestamp:   nil,
 			},
-			time:     2,
-			expected: false,
+			time:  2,
+			valid: false,
+		},
+		{
+			name: "Incompatible fastforward nil NetworkUpgrades",
+			upgrades1: func() *NetworkUpgrades {
+				upgrades := getDefaultNetworkUpgrades(upgrade.Fuji)
+				return &upgrades
+			}(),
+			upgrades2: func() *NetworkUpgrades {
+				upgrades := getDefaultNetworkUpgrades(upgrade.Fuji)
+				upgrades.EtnaTimestamp = nil
+				return &upgrades
+			}(),
+			time:  uint64(upgrade.Fuji.EtnaTime.Unix()),
+			valid: false,
+		},
+		{
+			name: "Compatible Fortuna fastforward nil NetworkUpgrades",
+			upgrades1: func() *NetworkUpgrades {
+				upgrades := getDefaultNetworkUpgrades(upgrade.Fuji)
+				return &upgrades
+			}(),
+			upgrades2: func() *NetworkUpgrades {
+				upgrades := getDefaultNetworkUpgrades(upgrade.Fuji)
+				upgrades.FortunaTimestamp = nil
+				return &upgrades
+			}(),
+			time:  uint64(upgrade.Fuji.FortunaTime.Unix()),
+			valid: true,
 		},
 	}
 	for _, test := range testcases {
 		t.Run(test.name, func(t *testing.T) {
 			err := test.upgrades1.CheckNetworkUpgradesCompatible(test.upgrades2, test.time)
-			if test.expected {
+			if test.valid {
 				require.Nil(t, err)
 			} else {
 				require.NotNil(t, err)
@@ -177,7 +205,7 @@ func TestVerifyNetworkUpgrades(t *testing.T) {
 		name          string
 		upgrades      *NetworkUpgrades
 		avagoUpgrades upgrade.Config
-		expected      bool
+		valid         bool
 	}{
 		{
 			name: "ValidNetworkUpgrades for latest network",
@@ -187,7 +215,7 @@ func TestVerifyNetworkUpgrades(t *testing.T) {
 				EtnaTimestamp:      utils.NewUint64(1607144400),
 			},
 			avagoUpgrades: upgradetest.GetConfig(upgradetest.Latest),
-			expected:      true,
+			valid:         true,
 		},
 		{
 			name: "Invalid Durango nil upgrade",
@@ -195,8 +223,8 @@ func TestVerifyNetworkUpgrades(t *testing.T) {
 				SubnetEVMTimestamp: utils.NewUint64(1),
 				DurangoTimestamp:   nil,
 			},
-			avagoUpgrades: upgrade.GetConfig(constants.MainnetID),
-			expected:      false,
+			avagoUpgrades: upgrade.Mainnet,
+			valid:         false,
 		},
 		{
 			name: "Invalid Subnet-EVM non-zero",
@@ -204,8 +232,8 @@ func TestVerifyNetworkUpgrades(t *testing.T) {
 				SubnetEVMTimestamp: utils.NewUint64(1),
 				DurangoTimestamp:   utils.NewUint64(2),
 			},
-			avagoUpgrades: upgrade.GetConfig(constants.MainnetID),
-			expected:      false,
+			avagoUpgrades: upgrade.Mainnet,
+			valid:         false,
 		},
 		{
 			name: "Invalid Durango before default upgrade",
@@ -213,8 +241,8 @@ func TestVerifyNetworkUpgrades(t *testing.T) {
 				SubnetEVMTimestamp: utils.NewUint64(0),
 				DurangoTimestamp:   utils.NewUint64(1),
 			},
-			avagoUpgrades: upgrade.GetConfig(constants.MainnetID),
-			expected:      false,
+			avagoUpgrades: upgrade.Mainnet,
+			valid:         false,
 		},
 		{
 			name: "Invalid Mainnet Durango reconfigured to Fuji",
@@ -222,8 +250,8 @@ func TestVerifyNetworkUpgrades(t *testing.T) {
 				SubnetEVMTimestamp: utils.NewUint64(0),
 				DurangoTimestamp:   utils.TimeToNewUint64(upgrade.GetConfig(constants.FujiID).DurangoTime),
 			},
-			avagoUpgrades: upgrade.GetConfig(constants.MainnetID),
-			expected:      false,
+			avagoUpgrades: upgrade.Mainnet,
+			valid:         false,
 		},
 		{
 			name: "Valid Fuji Durango reconfigured to Mainnet",
@@ -231,34 +259,45 @@ func TestVerifyNetworkUpgrades(t *testing.T) {
 				SubnetEVMTimestamp: utils.NewUint64(0),
 				DurangoTimestamp:   utils.TimeToNewUint64(upgrade.GetConfig(constants.MainnetID).DurangoTime),
 			},
-			avagoUpgrades: upgrade.GetConfig(constants.FujiID),
-			expected:      false,
+			avagoUpgrades: upgrade.Mainnet,
+			valid:         false,
 		},
 		{
 			name: "Invalid Etna nil",
 			upgrades: &NetworkUpgrades{
 				SubnetEVMTimestamp: utils.NewUint64(0),
-				DurangoTimestamp:   utils.NewUint64(2),
+				DurangoTimestamp:   utils.TimeToNewUint64(upgrade.Mainnet.DurangoTime),
 				EtnaTimestamp:      nil,
 			},
-			avagoUpgrades: upgrade.GetConfig(constants.MainnetID),
-			expected:      false,
+			avagoUpgrades: upgrade.Mainnet,
+			valid:         false,
 		},
 		{
 			name: "Invalid Etna before Durango",
 			upgrades: &NetworkUpgrades{
 				SubnetEVMTimestamp: utils.NewUint64(0),
-				DurangoTimestamp:   utils.NewUint64(2),
-				EtnaTimestamp:      utils.NewUint64(1),
+				DurangoTimestamp:   utils.TimeToNewUint64(upgrade.Mainnet.DurangoTime),
+				EtnaTimestamp:      utils.TimeToNewUint64(upgrade.Mainnet.DurangoTime.Add(-1)),
 			},
-			avagoUpgrades: upgrade.GetConfig(constants.MainnetID),
-			expected:      false,
+			avagoUpgrades: upgrade.Mainnet,
+			valid:         false,
+		},
+		{
+			name: "Valid Fortuna nil",
+			upgrades: &NetworkUpgrades{
+				SubnetEVMTimestamp: utils.NewUint64(0),
+				DurangoTimestamp:   utils.TimeToNewUint64(upgrade.Fuji.DurangoTime),
+				EtnaTimestamp:      utils.TimeToNewUint64(upgrade.Fuji.EtnaTime),
+				FortunaTimestamp:   nil,
+			},
+			avagoUpgrades: upgrade.Fuji,
+			valid:         true,
 		},
 	}
 	for _, test := range testcases {
 		t.Run(test.name, func(t *testing.T) {
 			err := test.upgrades.verifyNetworkUpgrades(test.avagoUpgrades)
-			if test.expected {
+			if test.valid {
 				require.Nil(t, err)
 			} else {
 				require.NotNil(t, err)

--- a/params/network_upgrades_test.go
+++ b/params/network_upgrades_test.go
@@ -82,7 +82,7 @@ func TestCheckNetworkUpgradesCompatible(t *testing.T) {
 		valid     bool
 	}{
 		{
-			name: "Compatible same NetworkUpgrades",
+			name: "Compatible_same_NetworkUpgrades",
 			upgrades1: &NetworkUpgrades{
 				SubnetEVMTimestamp: utils.NewUint64(1),
 				DurangoTimestamp:   utils.NewUint64(2),
@@ -95,7 +95,7 @@ func TestCheckNetworkUpgradesCompatible(t *testing.T) {
 			valid: true,
 		},
 		{
-			name: "Compatible different NetworkUpgrades",
+			name: "Compatible_different_NetworkUpgrades",
 			upgrades1: &NetworkUpgrades{
 				SubnetEVMTimestamp: utils.NewUint64(1),
 				DurangoTimestamp:   utils.NewUint64(2),
@@ -108,7 +108,7 @@ func TestCheckNetworkUpgradesCompatible(t *testing.T) {
 			valid: true,
 		},
 		{
-			name: "Compatible nil NetworkUpgrades",
+			name: "Compatible_nil_NetworkUpgrades",
 			upgrades1: &NetworkUpgrades{
 				SubnetEVMTimestamp: utils.NewUint64(1),
 				DurangoTimestamp:   utils.NewUint64(2),
@@ -121,7 +121,7 @@ func TestCheckNetworkUpgradesCompatible(t *testing.T) {
 			valid: true,
 		},
 		{
-			name: "Incompatible rewinded NetworkUpgrades",
+			name: "Incompatible_rewinded_NetworkUpgrades",
 			upgrades1: &NetworkUpgrades{
 				SubnetEVMTimestamp: utils.NewUint64(1),
 				DurangoTimestamp:   utils.NewUint64(2),
@@ -134,7 +134,7 @@ func TestCheckNetworkUpgradesCompatible(t *testing.T) {
 			valid: false,
 		},
 		{
-			name: "Incompatible fastforward NetworkUpgrades",
+			name: "Incompatible_fastforward_NetworkUpgrades",
 			upgrades1: &NetworkUpgrades{
 				SubnetEVMTimestamp: utils.NewUint64(1),
 				DurangoTimestamp:   utils.NewUint64(2),
@@ -147,7 +147,7 @@ func TestCheckNetworkUpgradesCompatible(t *testing.T) {
 			valid: false,
 		},
 		{
-			name: "Incompatible nil NetworkUpgrades",
+			name: "Incompatible_nil_NetworkUpgrades",
 			upgrades1: &NetworkUpgrades{
 				SubnetEVMTimestamp: utils.NewUint64(1),
 				DurangoTimestamp:   utils.NewUint64(2),
@@ -160,7 +160,7 @@ func TestCheckNetworkUpgradesCompatible(t *testing.T) {
 			valid: false,
 		},
 		{
-			name: "Incompatible fastforward nil NetworkUpgrades",
+			name: "Incompatible_fastforward_nil_NetworkUpgrades",
 			upgrades1: func() *NetworkUpgrades {
 				upgrades := getDefaultNetworkUpgrades(upgrade.Fuji)
 				return &upgrades
@@ -174,7 +174,7 @@ func TestCheckNetworkUpgradesCompatible(t *testing.T) {
 			valid: false,
 		},
 		{
-			name: "Compatible Fortuna fastforward nil NetworkUpgrades",
+			name: "Compatible_Fortuna_fastforward_nil_NetworkUpgrades",
 			upgrades1: func() *NetworkUpgrades {
 				upgrades := getDefaultNetworkUpgrades(upgrade.Fuji)
 				return &upgrades
@@ -208,7 +208,7 @@ func TestVerifyNetworkUpgrades(t *testing.T) {
 		valid         bool
 	}{
 		{
-			name: "ValidNetworkUpgrades for latest network",
+			name: "ValidNetworkUpgrades_for_latest_network",
 			upgrades: &NetworkUpgrades{
 				SubnetEVMTimestamp: utils.NewUint64(0),
 				DurangoTimestamp:   utils.NewUint64(1607144400),
@@ -218,7 +218,7 @@ func TestVerifyNetworkUpgrades(t *testing.T) {
 			valid:         true,
 		},
 		{
-			name: "Invalid Durango nil upgrade",
+			name: "Invalid_Durango_nil_upgrade",
 			upgrades: &NetworkUpgrades{
 				SubnetEVMTimestamp: utils.NewUint64(1),
 				DurangoTimestamp:   nil,
@@ -227,7 +227,7 @@ func TestVerifyNetworkUpgrades(t *testing.T) {
 			valid:         false,
 		},
 		{
-			name: "Invalid Subnet-EVM non-zero",
+			name: "Invalid_Subnet-EVM_non-zero",
 			upgrades: &NetworkUpgrades{
 				SubnetEVMTimestamp: utils.NewUint64(1),
 				DurangoTimestamp:   utils.NewUint64(2),
@@ -236,7 +236,7 @@ func TestVerifyNetworkUpgrades(t *testing.T) {
 			valid:         false,
 		},
 		{
-			name: "Invalid Durango before default upgrade",
+			name: "Invalid_Durango_before_default_upgrade",
 			upgrades: &NetworkUpgrades{
 				SubnetEVMTimestamp: utils.NewUint64(0),
 				DurangoTimestamp:   utils.NewUint64(1),
@@ -245,7 +245,7 @@ func TestVerifyNetworkUpgrades(t *testing.T) {
 			valid:         false,
 		},
 		{
-			name: "Invalid Mainnet Durango reconfigured to Fuji",
+			name: "Invalid_Mainnet_Durango_reconfigured_to_Fuji",
 			upgrades: &NetworkUpgrades{
 				SubnetEVMTimestamp: utils.NewUint64(0),
 				DurangoTimestamp:   utils.TimeToNewUint64(upgrade.GetConfig(constants.FujiID).DurangoTime),
@@ -254,7 +254,7 @@ func TestVerifyNetworkUpgrades(t *testing.T) {
 			valid:         false,
 		},
 		{
-			name: "Valid Fuji Durango reconfigured to Mainnet",
+			name: "Valid_Fuji_Durango_reconfigured_to_Mainnet",
 			upgrades: &NetworkUpgrades{
 				SubnetEVMTimestamp: utils.NewUint64(0),
 				DurangoTimestamp:   utils.TimeToNewUint64(upgrade.GetConfig(constants.MainnetID).DurangoTime),
@@ -263,7 +263,7 @@ func TestVerifyNetworkUpgrades(t *testing.T) {
 			valid:         false,
 		},
 		{
-			name: "Invalid Etna nil",
+			name: "Invalid_Etna_nil",
 			upgrades: &NetworkUpgrades{
 				SubnetEVMTimestamp: utils.NewUint64(0),
 				DurangoTimestamp:   utils.TimeToNewUint64(upgrade.Mainnet.DurangoTime),
@@ -273,7 +273,7 @@ func TestVerifyNetworkUpgrades(t *testing.T) {
 			valid:         false,
 		},
 		{
-			name: "Invalid Etna before Durango",
+			name: "Invalid_Etna_before_Durango",
 			upgrades: &NetworkUpgrades{
 				SubnetEVMTimestamp: utils.NewUint64(0),
 				DurangoTimestamp:   utils.TimeToNewUint64(upgrade.Mainnet.DurangoTime),
@@ -283,7 +283,7 @@ func TestVerifyNetworkUpgrades(t *testing.T) {
 			valid:         false,
 		},
 		{
-			name: "Valid Fortuna nil",
+			name: "Valid_Fortuna_nil",
 			upgrades: &NetworkUpgrades{
 				SubnetEVMTimestamp: utils.NewUint64(0),
 				DurangoTimestamp:   utils.TimeToNewUint64(upgrade.Fuji.DurangoTime),


### PR DESCRIPTION
## Why this should be merged

Fortuna is currently activated on Fuji. We have no corresponding Subnet-EVM version as Fortuna have no effect on subnet-evm networks. Therefore we should keep the default as nil so that it won't break when nodes update to any newer Subnet-EVM version. 

Fortuna is still kept as a defined upgrade in Subnet-EVM to reduce diff between Coreth. 

## How this works

* Adds a nil default for Fortuna
* returns nil error if default ts is nil in `verifyWithDefault`.

## How this was tested

Added UT

## Need to be documented?

Not probably

## Need to update RELEASES.md?

Updated
