### PR TITLE
chore(all): fix different typos

### DIFF
--- a/core/evm.go
+++ b/core/evm.go
@@ -86,7 +86,7 @@ func NewEVMBlockContext(header *types.Header, chain ChainContext, author *common
 // NewEVMBlockContextWithPredicateResults creates a new context for use in the EVM with an override for the predicate results that is not present
 // in header.Extra.
 // This function is used to create a BlockContext when the header Extra data is not fully formed yet and it's more efficient to pass in predicateResults
-// directly rather than re-encode the latest results when executing each individaul transaction.
+// directly rather than re-encode the latest results when executing each individual transaction.
 func NewEVMBlockContextWithPredicateResults(header *types.Header, chain ChainContext, author *common.Address, predicateResults *predicate.Results) vm.BlockContext {
 	blockContext := NewEVMBlockContext(header, chain, author)
 	blockContext.PredicateResults = predicateResults

--- a/core/rawdb/accessors_metadata.go
+++ b/core/rawdb/accessors_metadata.go
@@ -265,7 +265,7 @@ func WritePruningDisabled(db ethdb.KeyValueStore) error {
 }
 
 // HasPruningDisabled returns true if there is a marker present indicating that
-// the node has run with pruning disabled at some pooint.
+// the node has run with pruning disabled at some point.
 func HasPruningDisabled(db ethdb.KeyValueStore) (bool, error) {
 	return db.Has(pruningDisabledKey)
 }

--- a/precompile/allowlist/allowlist.go
+++ b/precompile/allowlist/allowlist.go
@@ -81,7 +81,7 @@ func UnpackModifyAllowListInput(input []byte, r Role, useStrictMode bool) (commo
 }
 
 // createAllowListRoleSetter returns an execution function for setting the allow list status of the input address argument to [role].
-// This execution function is speciifc to [precompileAddr].
+// This execution function is specific to [precompileAddr].
 func createAllowListRoleSetter(precompileAddr common.Address, role Role) contract.RunStatefulPrecompileFunc {
 	return func(evm contract.AccessibleState, callerAddr, addr common.Address, input []byte, suppliedGas uint64, readOnly bool) (ret []byte, remainingGas uint64, err error) {
 		if remainingGas, err = contract.DeductGas(suppliedGas, ModifyAllowListGasCost); err != nil {

--- a/precompile/contracts/rewardmanager/contract.go
+++ b/precompile/contracts/rewardmanager/contract.go
@@ -72,7 +72,7 @@ func EnableAllowFeeRecipients(stateDB contract.StateDB) {
 	stateDB.SetState(ContractAddress, rewardAddressStorageKey, allowFeeRecipientsAddressValue)
 }
 
-// DisableRewardAddress disables rewards and burns them by sending to Blackhole Address.
+// DisableFeeRewards disables rewards and burns them by sending to Blackhole Address.
 func DisableFeeRewards(stateDB contract.StateDB) {
 	stateDB.SetState(ContractAddress, rewardAddressStorageKey, common.BytesToHash(constants.BlackholeAddr.Bytes()))
 }

--- a/sync/statesync/code_syncer.go
+++ b/sync/statesync/code_syncer.go
@@ -39,7 +39,7 @@ type CodeSyncerConfig struct {
 	DB ethdb.Database
 }
 
-// codeSyncer syncs code bytes from the network in a seprate thread.
+// codeSyncer syncs code bytes from the network in a separate thread.
 // Tracks outstanding requests in the DB, so that it will still fulfill them if interrupted.
 type codeSyncer struct {
 	lock sync.Mutex
@@ -193,7 +193,7 @@ func (c *codeSyncer) fulfillCodeRequest(ctx context.Context, codeHashes []common
 	c.lock.Unlock() // Release the lock before writing the batch
 
 	if err := batch.Write(); err != nil {
-		return fmt.Errorf("faild to write batch for fulfilled code requests: %w", err)
+		return fmt.Errorf("failed to write batch for fulfilled code requests: %w", err)
 	}
 	return nil
 }
@@ -223,7 +223,7 @@ func (c *codeSyncer) addCode(codeHashes []common.Hash) error {
 }
 
 // notifyAccountTrieCompleted notifies the code syncer that there will be no more incoming
-// code hashes from syncing the account trie, so it only needs to compelete its outstanding
+// code hashes from syncing the account trie, so it only needs to complete its outstanding
 // work.
 // Note: this allows the worker threads to exit and return a nil error.
 func (c *codeSyncer) notifyAccountTrieCompleted() {

--- a/utils/metered_cache.go
+++ b/utils/metered_cache.go
@@ -56,7 +56,7 @@ func NewMeteredCache(size int, namespace string, updateFrequency uint64) *Metere
 	return mc
 }
 
-// updateStats updates metrics from fastcache
+// updateStatsIfNeeded updates metrics from fastcache
 func (mc *MeteredCache) updateStatsIfNeeded() {
 	if mc.namespace == "" {
 		return


### PR DESCRIPTION
## Why this should be merged

EDIT: see [below comment](https://github.com/ava-labs/subnet-evm/pull/1506#issuecomment-2747346312), this "typo-accumulation-branch" approach is to be abandoned. Note the 3 commits of this branch will be preserved in the master branch, similarly if they would be merged individually in master directly.

---

Previous rationale:

We get a lot of typo fix PRs on this repository, and having tens of "fix typos" 2-lines commits in the master branch does some git history pollution as well as occupies the merge queue for not much reason.

This PR accumulates pull requests suggesting typo fixes into one PR to be squashed in a single co-authored commit
