### PR TITLE
Switch from `go install` to `go run` to avoid cluttering shared bin path

### DIFF
--- a/bin/ginkgo
+++ b/bin/ginkgo
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Ensure the go command is run from the root of the repository so that its go.mod file is used
+REPO_ROOT=$(cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
+cd "${REPO_ROOT}"
+
+# If an explicit version is not specified, go run uses the ginkgo version from go.mod
+go run github.com/onsi/ginkgo/v2/ginkgo "${@}"

--- a/scripts/actionlint.sh
+++ b/scripts/actionlint.sh
@@ -2,6 +2,4 @@
 
 set -euo pipefail
 
-go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.1
-
-actionlint
+go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.1 "${@}"

--- a/scripts/run_ginkgo_load.sh
+++ b/scripts/run_ginkgo_load.sh
@@ -15,10 +15,6 @@ source "$SUBNET_EVM_PATH"/scripts/constants.sh
 
 source "$SUBNET_EVM_PATH"/scripts/versions.sh
 
-# Build ginkgo
-# to install the ginkgo binary (required for test build and run)
-go install -v github.com/onsi/ginkgo/v2/ginkgo@"${GINKGO_VERSION}"
-
 EXTRA_ARGS=()
 AVALANCHEGO_BUILD_PATH="${AVALANCHEGO_BUILD_PATH:-}"
 if [[ -n "${AVALANCHEGO_BUILD_PATH}" ]]; then
@@ -26,4 +22,4 @@ if [[ -n "${AVALANCHEGO_BUILD_PATH}" ]]; then
   echo "Running with extra args:" "${EXTRA_ARGS[@]}"
 fi
 
-ginkgo -vv --label-filter="${GINKGO_LABEL_FILTER:-}" ./tests/load -- "${EXTRA_ARGS[@]}"
+"${SUBNET_EVM_PATH}"/bin/ginkgo -vv --label-filter="${GINKGO_LABEL_FILTER:-}" ./tests/load -- "${EXTRA_ARGS[@]}"

--- a/scripts/run_ginkgo_precompile.sh
+++ b/scripts/run_ginkgo_precompile.sh
@@ -15,15 +15,11 @@ source "$SUBNET_EVM_PATH"/scripts/constants.sh
 
 source "$SUBNET_EVM_PATH"/scripts/versions.sh
 
-# Build ginkgo
-# to install the ginkgo binary (required for test build and run)
-go install -v github.com/onsi/ginkgo/v2/ginkgo@"${GINKGO_VERSION}"
-
 TEST_SOURCE_ROOT=$(pwd)
 
 # By default, it runs all e2e test cases!
 # Use "--ginkgo.skip" to skip tests.
 # Use "--ginkgo.focus" to select tests.
-TEST_SOURCE_ROOT="$TEST_SOURCE_ROOT" ginkgo run -procs=5 tests/precompile \
+TEST_SOURCE_ROOT="$TEST_SOURCE_ROOT" "${SUBNET_EVM_PATH}"/bin/ginkgo run -procs=5 tests/precompile \
   --ginkgo.vv \
   --ginkgo.label-filter="${GINKGO_LABEL_FILTER:-""}"

--- a/scripts/run_ginkgo_warp.sh
+++ b/scripts/run_ginkgo_warp.sh
@@ -16,10 +16,6 @@ source "$SUBNET_EVM_PATH"/scripts/constants.sh
 
 source "$SUBNET_EVM_PATH"/scripts/versions.sh
 
-# Build ginkgo
-# to install the ginkgo binary (required for test build and run)
-go install -v github.com/onsi/ginkgo/v2/ginkgo@"${GINKGO_VERSION}"
-
 EXTRA_ARGS=()
 AVALANCHEGO_BUILD_PATH="${AVALANCHEGO_BUILD_PATH:-}"
 if [[ -n "${AVALANCHEGO_BUILD_PATH}" ]]; then
@@ -27,4 +23,4 @@ if [[ -n "${AVALANCHEGO_BUILD_PATH}" ]]; then
   echo "Running with extra args:" "${EXTRA_ARGS[@]}"
 fi
 
-ginkgo -vv --label-filter="${GINKGO_LABEL_FILTER:-}" ./tests/warp -- "${EXTRA_ARGS[@]}"
+"${SUBNET_EVM_PATH}"/bin/ginkgo -vv --label-filter="${GINKGO_LABEL_FILTER:-}" ./tests/warp -- "${EXTRA_ARGS[@]}"

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -24,5 +24,3 @@ if [[ -z ${AVALANCHE_VERSION:-} ]]; then
     AVALANCHE_VERSION="${MODULE_HASH::8}"
   fi
 fi
-
-GINKGO_VERSION=${GINKGO_VERSION:-'v2.2.0'}


### PR DESCRIPTION
## Why this should be merged

Using `go run` invokes the chosen command without the side-effect of installing tooling dependencies to the global $GOPATH/bin path. This attempts to ensure a degree of tooling isolation between projects.

## How this was tested

CI

## Need to be documented?

N/A

## Need to update RELEASES.md?

N/A