### PR TITLE
Revert "chore(deps): bump avalanchego to v1.13.1-0.20250321174807-6c72dfc4254a (#1516)"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -151,7 +151,7 @@ jobs:
         shell: bash
         run: ./scripts/build.sh
       - name: Run Warp E2E Tests
-        uses: ava-labs/avalanchego/.github/actions/run-monitored-tmpnet-cmd@6c72dfc4254a3d157bba5c9c45135cb563b813e7
+        uses: ava-labs/avalanchego/.github/actions/run-monitored-tmpnet-cmd@50f1601bf39a106d066012b4ef470c1058f5005a
         with:
           run: ./scripts/run_ginkgo_warp.sh
           run_env: AVALANCHEGO_BUILD_PATH=/tmp/e2e-test/avalanchego
@@ -179,7 +179,7 @@ jobs:
         shell: bash
         run: ./scripts/build.sh
       - name: Run E2E Load Tests
-        uses: ava-labs/avalanchego/.github/actions/run-monitored-tmpnet-cmd@6c72dfc4254a3d157bba5c9c45135cb563b813e7
+        uses: ava-labs/avalanchego/.github/actions/run-monitored-tmpnet-cmd@50f1601bf39a106d066012b4ef470c1058f5005a
         with:
           run: ./scripts/run_ginkgo_load.sh
           run_env: AVALANCHEGO_BUILD_PATH=/tmp/e2e-test/avalanchego

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.6
 require (
 	github.com/VictoriaMetrics/fastcache v1.12.1
 	github.com/antithesishq/antithesis-sdk-go v0.3.8
-	github.com/ava-labs/avalanchego v1.13.1-0.20250321174807-6c72dfc4254a
+	github.com/ava-labs/avalanchego v1.12.3-0.20250321175346-50f1601bf39a
 	github.com/cespare/cp v0.1.0
 	github.com/crate-crypto/go-ipa v0.0.0-20231025140028-3c0104f4b233
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/antithesishq/antithesis-sdk-go v0.3.8/go.mod h1:IUpT2DPAKh6i/YhSbt6Gl
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/ava-labs/avalanchego v1.13.1-0.20250321174807-6c72dfc4254a h1:JiXcmzcosrMp35ow+lQ9DQxrWvX9y+AGgGFhAGZcfgA=
-github.com/ava-labs/avalanchego v1.13.1-0.20250321174807-6c72dfc4254a/go.mod h1:fpV/GmbfIB3P53gkq6zFpyeQtyAsJIuZCCKnm7TJ4sQ=
+github.com/ava-labs/avalanchego v1.12.3-0.20250321175346-50f1601bf39a h1:KSpG4lheMcV3oWrJJQyDyzx+JqSzjJPZEpi7UkSvE8I=
+github.com/ava-labs/avalanchego v1.12.3-0.20250321175346-50f1601bf39a/go.mod h1:fpV/GmbfIB3P53gkq6zFpyeQtyAsJIuZCCKnm7TJ4sQ=
 github.com/ava-labs/coreth v0.15.0-rc.0.0.20250321001337-7fa47ba3fa18 h1:OKWMFJZEalp9Kdw0tsKVU6Ky0inxqW/Wt0qCWQIxkZc=
 github.com/ava-labs/coreth v0.15.0-rc.0.0.20250321001337-7fa47ba3fa18/go.mod h1:2DHfOrbTkZiTyWG5xyZW/4zGV0+hnk92Fsbpfk6AJeg=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=


### PR DESCRIPTION
## Why this should be merged

We want to create a release tag v0.7.3 using the v0.12.3 based avalanchego version, and will re-upgrade the avalanchego version after that with #1536 

## How this works

This reverts commit 10aac5f734459f545172fd598d6ddd47d7d23f0b.

## How this was tested

## Need to be documented?

## Need to update RELEASES.md?
