### PR TITLE
fix(cd): goreleaser picks non-rc tag and uses workflow config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,7 @@ jobs:
     steps:
       - name: Store current git commit in a variable
         id: vars
-        run: |
-          echo "GIT_COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
+        run: echo "GIT_COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
       - name: Git checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,6 @@ jobs:
     # needs: [lint_test, unit_test, e2e_test, simulator_test]
     runs-on: ubuntu-22.04
     steps:
-      - name: Store current git commit in a variable
-        id: vars
-        run: echo "GIT_COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
       - name: Git checkout
         uses: actions/checkout@v4
         with:
@@ -45,12 +42,6 @@ jobs:
           echo cd4f08a75577145b8f05245a2975f7c81401d75e9535dcffbb879ee1deefcbf4 tarballs/MacOSX11.3.sdk.tar.xz | sha256sum -c -
           UNATTENDED=1 ./build.sh
           echo "$PWD/target/bin" >> "$GITHUB_PATH"
-      - name: Checkout workflow head
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          path: subnet-evm
-          ref: ${{ steps.vars.outputs.GIT_COMMIT }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@90a3faa9d0182683851fbfa97ca1a2cb983bfca3 #v6.2.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,16 +47,12 @@ jobs:
         with:
           fetch-depth: 0
           path: goreleaser
-      - name: Override subnet-evm/.goreleaser.yml config with workflow event ref .goreleaser.yml
-        run: |
-          cp -f ./goreleaser/.goreleaser.yml ./subnet-evm/.goreleaser.yml
-          rm -rf ./goreleaser
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@90a3faa9d0182683851fbfa97ca1a2cb983bfca3 #v6.2.1
         with:
           distribution: goreleaser
           version: v2.5.1
-          args: release --clean
+          args: release --clean --config ../goreleaser/.goreleaser.yml
           workdir: ./subnet-evm/
         env:
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,15 @@ jobs:
           echo cd4f08a75577145b8f05245a2975f7c81401d75e9535dcffbb879ee1deefcbf4 tarballs/MacOSX11.3.sdk.tar.xz | sha256sum -c -
           UNATTENDED=1 ./build.sh
           echo "$PWD/target/bin" >> "$GITHUB_PATH"
+      - name: Git checkout workflow event ref for .goreleaser.yml only
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          path: goreleaser
+      - name: Override subnet-evm/.goreleaser.yml config with workflow event ref .goreleaser.yml
+        run: |
+          cp -f ./goreleaser/.goreleaser.yml ./subnet-evm/.goreleaser.yml
+          rm -rf ./goreleaser
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@90a3faa9d0182683851fbfa97ca1a2cb983bfca3 #v6.2.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,16 +15,12 @@ jobs:
     # needs: [lint_test, unit_test, e2e_test, simulator_test]
     runs-on: ubuntu-22.04
     steps:
-      - name: Goreleaser config 1
-        run: cat .goreleaser.yml
       - name: Git checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           path: subnet-evm
           ref: ${{ github.event.inputs.tag }}
-      - name: Goreleaser config 2
-        run: cat .goreleaser.yml
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -46,8 +42,6 @@ jobs:
           echo cd4f08a75577145b8f05245a2975f7c81401d75e9535dcffbb879ee1deefcbf4 tarballs/MacOSX11.3.sdk.tar.xz | sha256sum -c -
           UNATTENDED=1 ./build.sh
           echo "$PWD/target/bin" >> "$GITHUB_PATH"
-      - name: Goreleaser config 3
-        run: cat .goreleaser.yml
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@90a3faa9d0182683851fbfa97ca1a2cb983bfca3 #v6.2.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,16 @@ jobs:
     # needs: [lint_test, unit_test, e2e_test, simulator_test]
     runs-on: ubuntu-22.04
     steps:
+      - name: Goreleaser config 1
+        run: cat .goreleaser.yml
       - name: Git checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           path: subnet-evm
           ref: ${{ github.event.inputs.tag }}
+      - name: Goreleaser config 2
+        run: cat .goreleaser.yml
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -42,6 +46,8 @@ jobs:
           echo cd4f08a75577145b8f05245a2975f7c81401d75e9535dcffbb879ee1deefcbf4 tarballs/MacOSX11.3.sdk.tar.xz | sha256sum -c -
           UNATTENDED=1 ./build.sh
           echo "$PWD/target/bin" >> "$GITHUB_PATH"
+      - name: Goreleaser config 3
+        run: cat .goreleaser.yml
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@90a3faa9d0182683851fbfa97ca1a2cb983bfca3 #v6.2.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,10 @@ jobs:
     # needs: [lint_test, unit_test, e2e_test, simulator_test]
     runs-on: ubuntu-22.04
     steps:
+      - name: Store current git commit in a variable
+        id: vars
+        run: |
+          echo "GIT_COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
       - name: Git checkout
         uses: actions/checkout@v4
         with:
@@ -42,6 +46,12 @@ jobs:
           echo cd4f08a75577145b8f05245a2975f7c81401d75e9535dcffbb879ee1deefcbf4 tarballs/MacOSX11.3.sdk.tar.xz | sha256sum -c -
           UNATTENDED=1 ./build.sh
           echo "$PWD/target/bin" >> "$GITHUB_PATH"
+      - name: Checkout workflow head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          path: subnet-evm
+          ref: ${{ steps.vars.outputs.GIT_COMMIT }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@90a3faa9d0182683851fbfa97ca1a2cb983bfca3 #v6.2.1
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,4 +42,4 @@ release:
 git:
   # Avoid picking the wrong tag when there is an RC tag and a non-RC tag
   # pointing to the same commit.
-  prerelease_suffix: "-"
+  prerelease_suffix: "-rc"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,3 +37,8 @@ release:
   github:
     owner: ava-labs
     name: subnet-evm
+
+git:
+  # Avoid picking the wrong tag when there is an RC tag and a non-RC tag
+  # pointing to the same commit.
+  tag_sort: -version:creatordate

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 # ref. https://goreleaser.com/customization/build/
 builds:
   - id: subnet-evm
@@ -41,4 +42,4 @@ release:
 git:
   # Avoid picking the wrong tag when there is an RC tag and a non-RC tag
   # pointing to the same commit.
-  tag_sort: -version:creatordate
+  prerelease_suffix: "-"


### PR DESCRIPTION
## Why this should be merged

Fix issue when there is an RC tag and a non-RC tag pointing to the same commit

## How this works

- Use workflow event ref .goreleaser.yml config
- Use goreleaser git option `prerelease_suffix: "-rc"`

## How this was tested

v0.7.3 release goreleaser action run

## Need to be documented?

## Need to update RELEASES.md?
