### PR TITLE
updated template to use updated add log function

### DIFF
--- a/accounts/abi/bind/precompilebind/precompile_contract_template.go
+++ b/accounts/abi/bind/precompilebind/precompile_contract_template.go
@@ -42,6 +42,7 @@ import (
 	_ "embed"
 
 	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/core/vm"
 )
 {{$contract := .Contract}}
@@ -70,6 +71,7 @@ var (
 	_ = big.NewInt
 	_ = vm.ErrOutOfGas
 	_ = common.Big0
+	_ = types.Log{}
 )
 
 // Singleton StatefulPrecompiledContract and signatures.

--- a/accounts/abi/bind/precompilebind/precompile_event_template.go
+++ b/accounts/abi/bind/precompilebind/precompile_event_template.go
@@ -49,12 +49,12 @@ topics, data, err := PackMyEvent(
 if err != nil {
 	return nil, remainingGas, err
 }
-accessibleState.GetStateDB().AddLog(
-	ContractAddress,
-	topics,
-	data,
-	accessibleState.GetBlockContext().Number().Uint64(),
-)
+accessibleState.GetStateDB().AddLog(&types.Log{
+	Address:     ContractAddress,
+	Topics:      topics,
+	Data:        data,
+	BlockNumber: accessibleState.GetBlockContext().Number().Uint64(),
+})
 */
 {{range .Contract.Events}}
 	{{$event := .}}


### PR DESCRIPTION
The Add log function's interface is updated but the template file for generating a new pre compile was not updated to support the new format. This PR is resolving that. 