### PR TITLE
set minfee from state on mempool init 

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,6 +4,7 @@
 
 - Updated dockerhub image name to `avaplatform/subnet-evm_avalanchego` and tags to accommodate the new versioning scheme: {subnet-evm version}_{avalanchego version}
 - Updated golang version to 1.23.9
+- Fixed a bug in mempool where the min fee was not updated after restart
 
 ## [v0.7.3](https://github.com/ava-labs/subnet-evm/releases/tag/v0.7.3)
 

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -594,13 +594,18 @@ func (vm *VM) initializeChain(lastAcceptedHash common.Hash, ethConfig ethconfig.
 	}
 	vm.eth.SetEtherbase(ethConfig.Miner.Etherbase)
 	vm.txPool = vm.eth.TxPool()
-	vm.txPool.SetMinFee(vm.chainConfigExtra().FeeConfig.MinBaseFee)
-	vm.txPool.SetGasTip(big.NewInt(0))
 	vm.blockChain = vm.eth.BlockChain()
 	vm.miner = vm.eth.Miner()
+	lastAccepted := vm.blockChain.LastAcceptedBlock()
+	feeConfig, _, err := vm.blockChain.GetFeeConfigAt(lastAccepted.Header())
+	if err != nil {
+		return err
+	}
+	vm.txPool.SetMinFee(feeConfig.MinBaseFee)
+	vm.txPool.SetGasTip(big.NewInt(0))
 
 	vm.eth.Start()
-	return vm.initChainState(vm.blockChain.LastAcceptedBlock())
+	return vm.initChainState(lastAccepted)
 }
 
 // initializeStateSyncClient initializes the client for performing state sync.


### PR DESCRIPTION
## Why this should be merged

Mempool was not initialized correctly from the blockchain state and correct minfee was not applied.

## How this works

Reads the minfee from the state and then sets the mempool minfee accordingly

## How this was tested

added UT

## Need to be documented?

No

## Need to update RELEASES.md?

Yes
