### PR TITLE
remove Windows CI tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,16 +50,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-22.04, ubuntu-latest, windows-latest]
+        os: [macos-latest, ubuntu-22.04, ubuntu-latest]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
-      - name: Set timeout on Windows # Windows UT run slower and need a longer timeout
-        shell: bash
-        if: matrix.os == 'windows-latest'
-        run: echo "TIMEOUT=1200s" >> "$GITHUB_ENV"
       - run: go mod download
         shell: bash
       - name: fjl/gencodec generated files are up to date


### PR DESCRIPTION
## Why this should be merged
Mirror of [1028](https://github.com/ava-labs/coreth/pull/1028). [Windows is not supported anymore](https://github.com/ava-labs/avalanchego/pull/4031) and the Windows tests take a lot of time to run which is both annoying and costs money. As requested by @ceyonur. 

This is a very small change which removes the Windows option from the CI. 

## Need to be documented?
No 

## Need to update RELEASES.md?
No 
