### PR TITLE
chore: release v0.7.6-rc.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The Subnet EVM runs in a separate process from the main AvalancheGo process and 
 [v0.7.3] AvalancheGo@v1.12.2/1.13.0 (Protocol Version: 39)
 [v0.7.4] AvalancheGo@v1.13.1 (Protocol Version: 40)
 [v0.7.5] AvalancheGo@v1.13.2 (Protocol Version: 41)
+[v0.7.6] AvalancheGo@v1.13.3-rc.2 (Protocol Version: 42)
 ```
 
 ## API

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,8 +2,31 @@
 
 ## Pending Release
 
-- Removed static API handler: `subnetevm.decodeGenesis`, `subnetevm.buildGenesis`
-- Demoted unnecessary error log in `core/txpool/legacypool.go` to warning, displaying unexpected but valid behavior.
+... 
+
+## [v0.7.6](https://github.com/ava-labs/subnet-evm/releases/tag/v0.7.5)
+@TODO - write release notes here on what is in this release
+
+## [v0.7.5](https://github.com/ava-labs/subnet-evm/releases/tag/v0.7.5)
+
+This version is backwards compatible to v0.7.0. It is optional, but encouraged.
+
+### AvalancheGo Compatibility
+
+The plugin version is **updated** to 41 and is compatible with AvalancheGo version v1.13.2.
+
+### Breaking changes
+
+- Removed static API handler and functions: `subnetevm.decodeGenesis`, `subnetevm.buildGenesis`
+
+### Updates
+
+- Updated AvalancheGo dependency to v1.13.2
+- Updated libevm dependency to v1.13.14-0.3.0.rc.1
+- Reduced custom types and simplified VM tests
+- Fixed log structuring and removed handler special cases
+- Demoted unnecessary error log in `core/txpool/legacypool.go` to warning, displaying unexpected but valid behavior
+
 
 ## [v0.7.4](https://github.com/ava-labs/subnet-evm/releases/tag/v0.7.4)
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.9
 require (
 	github.com/VictoriaMetrics/fastcache v1.12.1
 	github.com/antithesishq/antithesis-sdk-go v0.3.8
-	github.com/ava-labs/avalanchego v1.13.3-rc.0
+	github.com/ava-labs/avalanchego v1.13.3-rc.2
 	github.com/ava-labs/libevm v1.13.14-0.3.0.rc.1
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckarep/golang-set/v2 v2.1.0
@@ -46,7 +46,7 @@ require (
 	github.com/DataDog/zstd v1.5.2 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/StephenButtolph/canoto v0.17.1 // indirect
-	github.com/ava-labs/coreth v0.15.3-rc.0 // indirect
+	github.com/ava-labs/coreth v0.15.3-rc.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.10.0 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -62,10 +62,12 @@ github.com/antithesishq/antithesis-sdk-go v0.3.8/go.mod h1:IUpT2DPAKh6i/YhSbt6Gl
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/ava-labs/avalanchego v1.13.3-rc.0 h1:4jRJ82q2J2jKtY2H29Gu0FncyBA1HqXMt4jf+wBKefw=
-github.com/ava-labs/avalanchego v1.13.3-rc.0/go.mod h1:nEBoxZj+UgyxVx0LBH83LRDyUTZ+gpGTb5qlIa9ijDA=
-github.com/ava-labs/coreth v0.15.3-rc.0 h1:OD554F6lyPP0y8emTW3ffKoPx7Dnn8tuNP/tD3OQVnA=
-github.com/ava-labs/coreth v0.15.3-rc.0/go.mod h1:vDlKR8FRuAtecXepgrZ7NPo5ZNb2LPTh+fb8yfouofA=
+github.com/ava-labs/avalanchego v1.13.3-rc.2 h1:P+XSQqfAuhNPq+RG/dwDQ07o3sMh9ZsyeSgH/OV4y5s=
+github.com/ava-labs/avalanchego v1.13.3-rc.2/go.mod h1:dXVZK6Sw3ZPIQ9sLjto0VMWeehExppNHFTWFwyUv5tk=
+github.com/ava-labs/coreth v0.15.3-rc.1 h1:v7CMNT3tVi1cFp/6I9Xlln372+e6ztwAaCzW6vSDSVY=
+github.com/ava-labs/coreth v0.15.3-rc.1/go.mod h1:80rG3mFUUPEfx9vj5QCAgKcrd1SH2UbbTAHKqYJfUpI=
+github.com/ava-labs/firewood-go-ethhash/ffi v0.0.8 h1:f0ZbAiRE1srMiv/0DuXvPQZwgYbLC9OgAWbQUCMebTE=
+github.com/ava-labs/firewood-go-ethhash/ffi v0.0.8/go.mod h1:j6spQFNSBAfcXKt9g0xbObW/8tMlGP4bFjPIsJmDg/o=
 github.com/ava-labs/libevm v1.13.14-0.3.0.rc.1 h1:vBMYo+Iazw0rGTr+cwjkBdh5eadLPlv4ywI4lKye3CA=
 github.com/ava-labs/libevm v1.13.14-0.3.0.rc.1/go.mod h1:+Iol+sVQ1KyoBsHf3veyrBmHCXr3xXRWq6ZXkgVfNLU=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -1153,8 +1153,22 @@ func (vm *VM) CreateHandlers(context.Context) (map[string]http.Handler, error) {
 	return apis, nil
 }
 
-func (*VM) CreateHTTP2Handler(context.Context) (http.Handler, error) {
-	return nil, nil
+// NewHTTPHandler implements the block.ChainVM interface
+func (vm *VM) NewHTTPHandler(ctx context.Context) (http.Handler, error) {
+	handlers, err := vm.CreateHandlers(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Return the main RPC handler as the primary HTTP handler
+	if handler, exists := handlers[ethRPCEndpoint]; exists {
+		return handler, nil
+	}
+
+	// Fallback to a default handler if no RPC handler exists
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "No HTTP handler available", http.StatusNotFound)
+	}), nil
 }
 
 /*


### PR DESCRIPTION
- **bump avalanchego version**
- **chore: release v0.7.6-rc.0**

## Why this should be merged

## How this works

## How this was tested

## Need to be documented?

## Need to update RELEASES.md?
