### PR TITLE
chore: release v0.7.7-rc.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Setup Contracts
         run: ./scripts/run_task.sh setup-contracts
       - name: Run Warp E2E Tests
-        uses: ava-labs/avalanchego/.github/actions/run-monitored-tmpnet-cmd@a88dc37b32b4728ae234310bdd936b300e6a55b5
+        uses: ava-labs/avalanchego/.github/actions/run-monitored-tmpnet-cmd@e2bcbaffcb771ed08eda454d03d3001e558438f1
         with:
           run: ./scripts/run_task.sh test-e2e-warp-ci
           artifact_prefix: warp
@@ -116,7 +116,7 @@ jobs:
         with:
           go-version-file: "go.mod"
       - name: Run E2E Load Tests
-        uses: ava-labs/avalanchego/.github/actions/run-monitored-tmpnet-cmd@a88dc37b32b4728ae234310bdd936b300e6a55b5
+        uses: ava-labs/avalanchego/.github/actions/run-monitored-tmpnet-cmd@e2bcbaffcb771ed08eda454d03d3001e558438f1
         with:
           run: ./scripts/run_task.sh test-e2e-load-ci
           artifact_prefix: load

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The Subnet EVM runs in a separate process from the main AvalancheGo process and 
 [v0.7.4] AvalancheGo@v1.13.1 (Protocol Version: 40)
 [v0.7.5] AvalancheGo@v1.13.2 (Protocol Version: 41)
 [v0.7.6] AvalancheGo@v1.13.3-rc.2 (Protocol Version: 42)
+[v0.7.7] AvalancheGo@v1.13.3 (Protocol Version: 42)
 ```
 
 ## API

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -18,6 +18,7 @@ The plugin version is **updated** to 42 and is compatible with AvalancheGo versi
 - Use `state-history` eth config flag to designate the number of recent states queryable.
 
 ## [v0.7.6](https://github.com/ava-labs/subnet-evm/releases/tag/v0.7.6)
+
 _This release should be skipped entirely in favor of 0.7.7 due to the use of a AvalancheGo release candidate version._
 
 ## [v0.7.5](https://github.com/ava-labs/subnet-evm/releases/tag/v0.7.5)

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,6 +1,7 @@
 # Release Notes
 
 ## Pending Release
+
 - Add pending releases here
 
 ## [v0.7.7](https://github.com/ava-labs/subnet-evm/releases/tag/v0.7.7)

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,12 +1,24 @@
 # Release Notes
 
 ## Pending Release
-- Added maximum number of addresses (1000) to be queried in a single filter.
+- Add pending releases here
 
-## [v0.7.6](https://github.com/ava-labs/subnet-evm/releases/tag/v0.7.6)
+## [v0.7.7](https://github.com/ava-labs/subnet-evm/releases/tag/v0.7.7)
+
+This version is backwards compatible to v0.7.0. It is optional, but encouraged.
+
+### AvalancheGo Compatibility
+
+The plugin version is **updated** to 42 and is compatible with AvalancheGo version v1.13.3.
+
+### Updates
+
+- Added maximum number of addresses (1000) to be queried in a single filter.
 - Demoted unnecessary error log in `core/txpool/legacypool.go` to warning, displaying unexpected but valid behavior
 - Use `state-history` eth config flag to designate the number of recent states queryable.
-- @TODO - write release notes here on what is in this release
+
+## [v0.7.6](https://github.com/ava-labs/subnet-evm/releases/tag/v0.7.6)
+_This release should be skipped entirely in favor of 0.7.7 due to the use of a AvalancheGo release candidate version._
 
 ## [v0.7.5](https://github.com/ava-labs/subnet-evm/releases/tag/v0.7.5)
 

--- a/compatibility.json
+++ b/compatibility.json
@@ -1,5 +1,6 @@
 {
   "rpcChainVMProtocolVersion": {
+    "v0.7.7": 42,
     "v0.7.6": 42,
     "v0.7.5": 41,
     "v0.7.4": 40,

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.9
 require (
 	github.com/VictoriaMetrics/fastcache v1.12.1
 	github.com/antithesishq/antithesis-sdk-go v0.3.8
-	github.com/ava-labs/avalanchego v1.13.3-rc.2
+	github.com/ava-labs/avalanchego v1.13.3
 	github.com/ava-labs/firewood-go-ethhash/ffi v0.0.8
 	github.com/ava-labs/libevm v1.13.14-0.3.0.rc.1
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/antithesishq/antithesis-sdk-go v0.3.8/go.mod h1:IUpT2DPAKh6i/YhSbt6Gl
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/ava-labs/avalanchego v1.13.3-rc.2 h1:P+XSQqfAuhNPq+RG/dwDQ07o3sMh9ZsyeSgH/OV4y5s=
-github.com/ava-labs/avalanchego v1.13.3-rc.2/go.mod h1:dXVZK6Sw3ZPIQ9sLjto0VMWeehExppNHFTWFwyUv5tk=
+github.com/ava-labs/avalanchego v1.13.3 h1:wYootDIqq1FG0FrrNI+yRqLB3szpvuTmW1j0i2RAjy0=
+github.com/ava-labs/avalanchego v1.13.3/go.mod h1:OKgu35RVcoX4M8TB0U6yNvcDNKc2CwvaHrU8PgXVq64=
 github.com/ava-labs/coreth v0.15.3-rc.1 h1:v7CMNT3tVi1cFp/6I9Xlln372+e6ztwAaCzW6vSDSVY=
 github.com/ava-labs/coreth v0.15.3-rc.1/go.mod h1:80rG3mFUUPEfx9vj5QCAgKcrd1SH2UbbTAHKqYJfUpI=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.0.8 h1:f0ZbAiRE1srMiv/0DuXvPQZwgYbLC9OgAWbQUCMebTE=

--- a/plugin/evm/version.go
+++ b/plugin/evm/version.go
@@ -9,7 +9,7 @@ var (
 	// GitCommit is set by the build script
 	GitCommit string
 	// Version is the version of Subnet EVM
-	Version string = "v0.7.6"
+	Version string = "v0.7.7"
 )
 
 func init() {


### PR DESCRIPTION
The release candidate for `subnet-evm v0.7.7` 