### PR TITLE
chore: Fix releases guide 

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -14,9 +14,10 @@ The plugin version is **updated** to 42 and is compatible with AvalancheGo versi
 
 ### Updates
 
-- Added maximum number of addresses (1000) to be queried in a single filter.
-- Demoted unnecessary error log in `core/txpool/legacypool.go` to warning, displaying unexpected but valid behavior
-- Use `state-history` eth config flag to designate the number of recent states queryable.
+- Demoted unnecessary error log in core/txpool/legacypool.go to warning, displaying unexpected but valid behavior
+- Added maximum number of addresses (1000) to be queried in a single filter by @ceyonur in #[1644](https://github.com/ava-labs/subnet-evm/pull/1642)
+- Use state-history eth config flag to designate the number of recent states queryable by @alarso16 in #[1642](https://github.com/ava-labs/subnet-evm/pull/1644)
+
 
 ## [v0.7.6](https://github.com/ava-labs/subnet-evm/releases/tag/v0.7.6)
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -15,8 +15,8 @@ The plugin version is **updated** to 42 and is compatible with AvalancheGo versi
 ### Updates
 
 - Demoted unnecessary error log in core/txpool/legacypool.go to warning, displaying unexpected but valid behavior
-- Added maximum number of addresses (1000) to be queried in a single filter by @ceyonur in #[1644](https://github.com/ava-labs/subnet-evm/pull/1642)
-- Use state-history eth config flag to designate the number of recent states queryable by @alarso16 in #[1642](https://github.com/ava-labs/subnet-evm/pull/1644)
+- Added maximum number of addresses (1000) to be queried in a single filter
+- Use state-history eth config flag to designate the number of recent states queryable
 
 
 ## [v0.7.6](https://github.com/ava-labs/subnet-evm/releases/tag/v0.7.6)

--- a/docs/releasing/README.md
+++ b/docs/releasing/README.md
@@ -84,7 +84,7 @@ export VERSION=v0.7.3
 1. Squash and merge your release branch into `master`, for example:
 
     ```bash
-    gh pr merge "releases/$VERSION" --squash --delete-branch --subject "chore: release $VERSION" --body "\n- Update AvalancheGo from v1.12.3 to v1.13.0"
+    gh pr merge "releases/$VERSION_RC" --squash --subject "chore: release $VERSION" --body "\n- Update AvalancheGo from v1.12.3 to v1.13.0"
     ```
 
 1. Create and push a tag from the `master` branch:

--- a/docs/releasing/README.md
+++ b/docs/releasing/README.md
@@ -84,8 +84,9 @@ export VERSION=v0.7.3
 1. Squash and merge your release branch into `master`, for example:
 
     ```bash
-    gh pr merge "releases/$VERSION_RC" --squash --subject "chore: release $VERSION" --body "\n- Update AvalancheGo from v1.12.3 to v1.13.0"
+    gh pr merge "releases/$VERSION_RC" --squash --subject "chore: release $VERSION_RC" --body "\n- Update AvalancheGo from v1.1X.X to v1.1X.X"
     ```
+    Ensure you properly label the AvalancheGo version.
 
 1. Create and push a tag from the `master` branch:
 

--- a/docs/releasing/README.md
+++ b/docs/releasing/README.md
@@ -18,6 +18,8 @@ export VERSION_RC=v0.7.3-rc.0
 export VERSION=v0.7.3
 ```
 
+Remember to use the appropriate versioning for your release. 
+
 1. Create your branch, usually from the tip of the `master` branch:
 
     ```bash
@@ -26,16 +28,16 @@ export VERSION=v0.7.3
     git checkout -b "releases/$VERSION_RC"
     ```
 
-1. Update the [RELEASES.md](../../RELEASES.md) file with the new release version `$VERSION`.
-1. Modify the [plugin/evm/version.go](../../plugin/evm/version.go) `Version` global string variable and set it to the desired `$VERSION`.
-1. Ensure the AvalancheGo version used in [go.mod](../../go.mod) is [its last release](https://github.com/ava-labs/avalanchego/releases). If not, upgrade it with, for example:
+2. Update the [RELEASES.md](../../RELEASES.md) file with the new release version `$VERSION`.
+3. Modify the [plugin/evm/version.go](../../plugin/evm/version.go) `Version` global string variable and set it to the desired `$VERSION`.
+4. Ensure the AvalancheGo version used in [go.mod](../../go.mod) is [its last release](https://github.com/ava-labs/avalanchego/releases). If not, upgrade it with, for example:
     ```bash
       go get github.com/ava-labs/avalanchego@v1.13.0
       go mod tidy
     ```
     And fix any errors that may arise from the upgrade. If it requires significant changes, you may want to create a separate PR for the upgrade and wait for it to be merged before continuing with this procedure.
 
-1. Add an entry in the object in [compatibility.json](../../compatibility.json), adding the target release `$VERSION` as key and the AvalancheGo RPC chain VM protocol version as value, to the `"rpcChainVMProtocolVersion"` JSON object. For example, we would add:
+5. Add an entry in the object in [compatibility.json](../../compatibility.json), adding the target release `$VERSION` as key and the AvalancheGo RPC chain VM protocol version as value, to the `"rpcChainVMProtocolVersion"` JSON object. For example, we would add:
 
     ```json
     "v0.7.3": 39,
@@ -54,14 +56,14 @@ export VERSION=v0.7.3
     ```
 
     This message can help you figure out what the correct RPC chain VM protocol version (here `39`) has to be in compatibility.json for your current release. Alternatively, you can refer to the [Avalanchego repository `version/compatibility.json` file](https://github.com/ava-labs/avalanchego/blob/main/version/compatibility.json) to find the RPC chain VM protocol version matching the AvalancheGo version we use here.
-1. Specify the AvalancheGo compatibility in the [README.md relevant section](../../README.md#avalanchego-compatibility). For example we would add:
+6. Specify the AvalancheGo compatibility in the [README.md relevant section](../../README.md#avalanchego-compatibility). For example we would add:
 
     ```text
     ...
     [v0.7.3] AvalancheGo@v1.12.2/1.13.0-fuji/1.13.0 (Protocol Version: 39)
     ```
 
-1. Commit your changes and push the branch
+7. Commit your changes and push the branch
 
     ```bash
     git add .
@@ -69,26 +71,26 @@ export VERSION=v0.7.3
     git push -u origin "releases/$VERSION_RC"
     ```
 
-1. Create a pull request (PR) from your branch targeting master, for example using [`gh`](https://cli.github.com/):
+8. Create a pull request (PR) from your branch targeting master, for example using [`gh`](https://cli.github.com/):
 
     ```bash
     gh pr create --repo github.com/ava-labs/subnet-evm --base master --title "chore: release $VERSION_RC"
     ```
 
-1. Wait for the PR checks to pass with
+9. Wait for the PR checks to pass with
 
     ```bash
     gh pr checks --watch
     ```
 
-1. Squash and merge your release branch into `master`, for example:
+10. Squash and merge your release branch into `master`, for example:
 
     ```bash
     gh pr merge "releases/$VERSION_RC" --squash --subject "chore: release $VERSION_RC" --body "\n- Update AvalancheGo from v1.1X.X to v1.1X.X"
     ```
     Ensure you properly label the AvalancheGo version.
 
-1. Create and push a tag from the `master` branch:
+11. Create and push a tag from the `master` branch:
 
     ```bash
     git fetch origin master:master
@@ -109,7 +111,7 @@ Once the tag is created, you need to test it on the Fuji testnet both locally an
 1. Find the Dispatch and Echo L1s blockchain ID and subnet ID:
     - [Dispatch L1 details](https://subnets-test.avax.network/dispatch/details). Its subnet id is `7WtoAMPhrmh5KosDUsFL9yTcvw7YSxiKHPpdfs4JsgW47oZT5`.
     - [Echo L1 details](https://subnets-test.avax.network/echo/details). Its subnet id is `i9gFpZQHPLcGfZaQLiwFAStddQD7iTKBpFfurPFJsXm1CkTZK`.
-1. Get the blockchain ID and VM ID of the Echo and Dispatch L1s with:
+2. Get the blockchain ID and VM ID of the Echo and Dispatch L1s with:
     - Dispatch:
 
         ```bash
@@ -150,13 +152,13 @@ Once the tag is created, you need to test it on the Fuji testnet both locally an
         VM id: meq3bv7qCMZZ69L8xZRLwyKnWp6chRwyscq8VPtHWignRQVVF
         ```
 
-1. In the subnet-evm directory, build the VM using
+3. In the subnet-evm directory, build the VM using
 
     ```bash
     ./scripts/build.sh vm.bin
     ```
 
-1. Copy the VM binary to the plugins directory, naming it with the VM ID:
+4. Copy the VM binary to the plugins directory, naming it with the VM ID:
 
     ```bash
     mkdir -p ~/.avalanchego/plugins
@@ -165,20 +167,20 @@ Once the tag is created, you need to test it on the Fuji testnet both locally an
     rm vm.bin
     ```
 
-1. Clone [AvalancheGo](https://github.com/ava-labs/avalanchego):
+5. Clone [AvalancheGo](https://github.com/ava-labs/avalanchego):
 
     ```bash
     git clone git@github.com:ava-labs/avalanchego.git
     ```
 
-1. Checkout correct AvalancheGo version, the version should match the one used in Subnet-EVM `go.mod` file
+6. Checkout correct AvalancheGo version, the version should match the one used in Subnet-EVM `go.mod` file
 
     ```bash
     cd avalanchego
     git checkout v1.13.0
     ```
 
-1. Get upgrades for each L1 and write them out to `~/.avalanchego/configs/chains/<blockchain-id>/upgrade.json`:
+7. Get upgrades for each L1 and write them out to `~/.avalanchego/configs/chains/<blockchain-id>/upgrade.json`:
 
     ```bash
     mkdir -p ~/.avalanchego/configs/chains/2D8RG4UpSXbPbvPCAWppNJyqTG2i2CAXSkTgmTBBvs7GKNZjsY
@@ -204,32 +206,32 @@ Once the tag is created, you need to test it on the Fuji testnet both locally an
     jq -r '.result.upgrades' > ~/.avalanchego/configs/chains/98qnjenm7MBd8G2cPZoRvZrgJC33JGSAAKghsQ6eojbLCeRNp/upgrade.json
     ```
 
-1. (Optional) You can tweak the `config.json` for each L1 if you want to test a particular feature for example.
+8. (Optional) You can tweak the `config.json` for each L1 if you want to test a particular feature for example.
     - Dispatch: `~/.avalanchego/configs/chains/2D8RG4UpSXbPbvPCAWppNJyqTG2i2CAXSkTgmTBBvs7GKNZjsY/config.json`
     - Echo: `~/.avalanchego/configs/chains/98qnjenm7MBd8G2cPZoRvZrgJC33JGSAAKghsQ6eojbLCeRNp/config.json`
-1. (Optional) If you want to reboostrap completely the chain, you can remove `~/.avalanchego/chainData/<blockchain-id>/db/pebbledb`, for example:
+9. (Optional) If you want to reboostrap completely the chain, you can remove `~/.avalanchego/chainData/<blockchain-id>/db/pebbledb`, for example:
     - Dispatch: `rm -r ~/.avalanchego/chainData/2D8RG4UpSXbPbvPCAWppNJyqTG2i2CAXSkTgmTBBvs7GKNZjsY/db/pebbledb`
     - Echo: `rm -r ~/.avalanchego/chainData/98qnjenm7MBd8G2cPZoRvZrgJC33JGSAAKghsQ6eojbLCeRNp/db/pebbledb`
 
     AvalancheGo keeps its database in `~/.avalanchego/db/fuji/v1.4.5/*.ldb` which you should not delete.
-1. Build AvalancheGo:
+10. Build AvalancheGo:
 
     ```bash
     ./scripts/build.sh
     ```
 
-1. Run AvalancheGo tracking the Dispatch and Echo Subnet IDs:
+11. Run AvalancheGo tracking the Dispatch and Echo Subnet IDs:
 
     ```bash
     ./build/avalanchego --network-id=fuji --partial-sync-primary-network --public-ip=127.0.0.1 \
     --track-subnets=7WtoAMPhrmh5KosDUsFL9yTcvw7YSxiKHPpdfs4JsgW47oZT5,i9gFpZQHPLcGfZaQLiwFAStddQD7iTKBpFfurPFJsXm1CkTZK
     ```
 
-1. Follow the logs and wait until you see the following lines:
+12. Follow the logs and wait until you see the following lines:
     - line stating the health `check started passing`
     - line containing `consensus started`
     - line containing `bootstrapped healthy nodes`
-1. In another terminal, check you can obtain the current block number for both chains:
+13. In another terminal, check you can obtain the current block number for both chains:
 
     - Dispatch:
 
@@ -263,11 +265,11 @@ Once the tag is created, you need to test it on the Fuji testnet both locally an
     git checkout -b "echo-dispatch-$VERSION_RC"
     ```
 
-1. Modify [`configs/dispatch.yml`] and [`configs/echo.yml`] similarly by:
+2. Modify [`configs/dispatch.yml`] and [`configs/echo.yml`] similarly by:
     - changing the `app_version` to `$VERSION_RC`
     - if necessary, change the `avalanchego_version`
     - if necessary, change the `golang_version`
-1. Commit your changes and push the branch
+3. Commit your changes and push the branch
 
     ```bash
     git add .
@@ -275,14 +277,14 @@ Once the tag is created, you need to test it on the Fuji testnet both locally an
     git push -u origin "echo-dispatch-$VERSION_RC"
     ```
 
-1. Open a pull request targeting `main`, for example using [`gh`](https://cli.github.com/):
+4. Open a pull request targeting `main`, for example using [`gh`](https://cli.github.com/):
 
     ```bash
     gh pr create --repo github.com/ava-labs/external-plugins-builder --base main --title "Bump echo and dispatch to $VERSION_RC"
     ```
 
-1. Once the PR checks pass, you can squash and merge it. The [Subnet EVM build Github action](https://github.com/ava-labs/external-plugins-builder/actions/workflows/subnet-evm-image-build.yaml) then creates [one or more pull requests in devops-argocd](https://github.com/ava-labs/devops-argocd/pulls), for example `Auto image update for testnet/echo` and `Auto image update for testnet/dispatch`.
-1. Once an automatically created pull request gets merged, it will be deployed, you can then monitor:
+5. Once the PR checks pass, you can squash and merge it. The [Subnet EVM build Github action](https://github.com/ava-labs/external-plugins-builder/actions/workflows/subnet-evm-image-build.yaml) then creates [one or more pull requests in devops-argocd](https://github.com/ava-labs/devops-argocd/pulls), for example `Auto image update for testnet/echo` and `Auto image update for testnet/dispatch`.
+6. Once an automatically created pull request gets merged, it will be deployed, you can then monitor:
     - For Dispatch:
         - [Deployment progress](https://app.datadoghq.com/container-images?query=short_image:dispatch)
         - [Logs](https://app.datadoghq.com/logs?query=subnet%3Adispatch%20%40logger%3A%2A&live=true)
@@ -293,12 +295,12 @@ Once the tag is created, you need to test it on the Fuji testnet both locally an
         - [Metrics](https://app.datadoghq.com/dashboard/jrv-mm2-vuc/echo-testnet-subnets?live=true)
 
     Note some metrics might be not showing up until a test transaction is ran.
-1. Launch a test transaction:
+7. Launch a test transaction:
     1. If you have no wallet setup, create a new one using the [Core wallet](https://core.app/)
     1. Go to the settings and enable **Testnet Mode**
     1. You need DIS (Dispatch) and ECH (Echo) testnet tokens. If you don't have one or the other, send your C-chain AVAX address to one of the team members who can send you some DIS/ECH testnet tokens. The portfolio section of the core wallet should then show the DIS and ECH tokens available.
-    1. For both Dispatch and Echo, in the "Command center", select **Send**, enter your own C-Chain AVAX address in the **Send To** field, set the **Amount** to 0 and click on **Send**. Finally, select a maximum network fee, usually *Slow* works, and click on **Approve**.
-1. You should then see the transaction impact the logs and metrics, for example
+    1. For both Dispatch and Echo, in the "Command center", select **Send**, enter your own C-Chain AVAX address in the **Send To** field, set the **Amount** to 1 and click on **Send**. Finally, select a maximum network fee, usually *Slow* works, and click on **Approve**.
+8. You should then see the transaction impact the logs and metrics, for example
 
     ```log
     Apr 03 10:35:00.000 i-0158b0eef8b774d39 subnets Commit new mining work
@@ -327,12 +329,12 @@ Following the previous example in the [Release candidate section](#release-candi
     git push origin "$VERSION"
     ```
 
-1. Create a new release on Github, either using:
+2. Create a new release on Github, either using:
     - the [Github web interface](https://github.com/ava-labs/subnet-evm/releases/new)
         1. In the "Choose a tag" box, select the tag previously created `$VERSION` (`v0.7.3`)
-        1. Pick the previous tag, for example as `v0.7.2`.
-        1. Set the "Release title" to `$VERSION` (`v0.7.3`)
-        1. Set the description using this format:
+        2. Pick the previous tag, for example as `v0.7.2`.
+        3. Set the "Release title" to `$VERSION` (`v0.7.3`)
+        4. Set the description using this format:
 
             ```markdown
             # AvalancheGo Compatibility
@@ -349,8 +351,8 @@ Following the previous example in the [Release candidate section](#release-candi
 
             ```
 
-        1. Only tick the box "Set as the latest release"
-        1. Click on the "Create release" button
+        5. Only tick the box "Set as the latest release"
+        6. Click on the "Create release" button
     - the Github CLI `gh`:
 
         ```bash
@@ -371,10 +373,10 @@ Following the previous example in the [Release candidate section](#release-candi
         gh release create "$VERSION" --notes-start-tag "$PREVIOUS_VERSION" --notes-from-tag "$VERSION" --title "$VERSION" --notes "$NOTES" --verify-tag
         ```
 
-1. Monitor the [release Github workflow](https://github.com/ava-labs/subnet-evm/actions/workflows/release.yml) to ensure the GoReleaser step succeeds and check the binaries are then published to [the releases page](https://github.com/ava-labs/subnet-evm/releases). In case this fails, you can trigger the workflow manually:
+3. Monitor the [release Github workflow](https://github.com/ava-labs/subnet-evm/actions/workflows/release.yml) to ensure the GoReleaser step succeeds and check the binaries are then published to [the releases page](https://github.com/ava-labs/subnet-evm/releases). In case this fails, you can trigger the workflow manually:
     1. Go to [github.com/ava-labs/subnet-evm/actions/workflows/release.yml](https://github.com/ava-labs/subnet-evm/actions/workflows/release.yml)
     1. Click on the "Run workflow" button
     1. Enter the branch name, usually with goreleaser related fixes
     1. Enter the tag name `$VERSION` (i.e. `v0.7.3`)
-1. Monitor the [Publish Docker image workflow](https://github.com/ava-labs/subnet-evm/actions/workflows/publish_docker.yml) succeeds. Note this workflow is triggered when pushing the tag, unlike Goreleaser which triggers when publishing the release.
-1. Finally, [create a release for precompile-evm](https://github.com/ava-labs/precompile-evm/blob/main/docs/releasing/README.md)
+4. Monitor the [Publish Docker image workflow](https://github.com/ava-labs/subnet-evm/actions/workflows/publish_docker.yml) succeeds. Note this workflow is triggered when pushing the tag, unlike Goreleaser which triggers when publishing the release.
+5. Finally, [create a release for precompile-evm](https://github.com/ava-labs/precompile-evm/blob/main/docs/releasing/README.md)


### PR DESCRIPTION
## Why this should be merged
- The wrong branch name is used in the merge command
- `--delete-branch` can not be used without an error when a merge queue is enabled
- 0 is not a valid amount of Dispatch or Echo to send (must be >0 as Core wallet will tell you)
- Make numbering more clear 