### PR TITLE
ci: Add GH token

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,8 @@ jobs:
       - name: Check go.mod and go.sum are up-to-date
         run: ./scripts/run_task.sh check-go-mod-tidy
       - name: Ensure consistent avalanchego version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./scripts/run_task.sh check-avalanchego-version
 
   unit_test:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -173,4 +173,4 @@ tasks:
 
   update-avalanchego-version:
     desc: Update AvalancheGo version in go.mod and sync GitHub Actions workflow custom action version
-    cmd: ./scripts/update_avalanchego_version.sh # tests.yml
+    cmd: bash -x ./scripts/update_avalanchego_version.sh # tests.yml

--- a/latest-coreth-commit.txt
+++ b/latest-coreth-commit.txt
@@ -4,5 +4,8 @@ e8e848b2f0b2f4f206fc319700a420d83d19685c
 
 # Notes: 
 - Coreth PR 1029 has already been synced (ahead of schedule) - see https://github.com/ava-labs/subnet-evm/pull/1631
-- Coreth PR 1034 has already been synced (ahead of schedule) - see https://github.com/ava-labs/subnet-evm/pull/1622
+- Coreth PR 1034 has already been synced (ahead of schedule) - see https://github.com/ava-labs/subnet-evm/pull/162
+- Coreth PR 1003, `scripts/update_avalanchego_version.sh` has already been synced (ahead of schedule) - see https://github.com/ava-labs/subnet-evm/pull/16512
+- Coreth PR 1064 has already been synced (ahead of schedule) - see https://github.com/ava-labs/subnet-evm/pull/1651
+- Coreth PR 1066 has already been synced (ahead of schedule) - see https://github.com/ava-labs/subnet-evm/pull/1651
 - Last PR done is currently #1034

--- a/scripts/update_avalanchego_version.sh
+++ b/scripts/update_avalanchego_version.sh
@@ -29,9 +29,12 @@ CURL_ARGS=(curl -s)
 if [[ -n "${GITHUB_TOKEN:-}" ]]; then
   # Using an auth token avoids being rate limited when run in CI
   CURL_ARGS+=(-H "Authorization: token ${GITHUB_TOKEN}")
+else
+  echo "No GITHUB_TOKEN found, using unauthenticated requests"
 fi
-CURL_URL="https://api.github.com/repos/ava-labs/avalanchego/commits/${AVALANCHE_VERSION}"
-FULL_AVALANCHE_VERSION="$("${CURL_ARGS[@]}" "${CURL_URL}" | grep '"sha":' | head -n1 | cut -d'"' -f4)"
+
+GIT_COMMIT=$("${CURL_ARGS[@]}" "https://api.github.com/repos/ava-labs/avalanchego/commits/${AVALANCHE_VERSION}")
+FULL_AVALANCHE_VERSION="$(grep -m1 '"sha":' <<< "${GIT_COMMIT}" | cut -d'"' -f4)"
 
 # Ensure the custom action version matches the avalanche version
 WORKFLOW_PATH=".github/workflows/tests.yml"


### PR DESCRIPTION
## Why this should be merged

Ports the related changes from ava-labs/coreth#1003, as well as ava-labs/coreth#1064 and ava-labs/coreth#1066

## How this works

Adds debug printing back, moves github token in

## How this was tested

In coreth

## Need to be documented?

No

## Need to update RELEASES.md?

No