### PR TITLE
sync: coreth PR #1058: update numThreads to numWorkers

### DIFF
--- a/latest-coreth-commit.txt
+++ b/latest-coreth-commit.txt
@@ -1,12 +1,10 @@
 # This is the latest commit of coreth that is synced with the subnet-evm
 
-f2817601270f742d1a5cadcd74924680b07bfcbd
+204bdcf27dbf8982d7d61874c003aaf8b4daaa8b
 
 # Notes: 
-- Coreth PR 1062 has already been synced (ahead of scheudle) - see https://github.com/ava-labs/subnet-evm/pull/1658
-- Coreth PR 1064 has already been synced (ahead of schedule) - see https://github.com/ava-labs/subnet-evm/pull/1651
+- Last PR done is currently #1064 
 - Coreth PR 1066 has already been synced (ahead of schedule) - see https://github.com/ava-labs/subnet-evm/pull/1651
 - Coreth PR 1070 has already been synced (ahead of schedule) - see https://github.com/ava-labs/subnet-evm/pull/1652
 - Coreth PR 1071 has already been synced (ahead of schedule) - see https://github.com/ava-labs/subnet-evm/pull/1653
 - Coreth PR 1073 has already been synced (ahead of schedule) - see https://github.com/ava-labs/subnet-evm/pull/1659
-- Last PR done is currently #1052

--- a/sync/client/leaf_syncer.go
+++ b/sync/client/leaf_syncer.go
@@ -144,12 +144,12 @@ func (c *CallbackLeafSyncer) syncTask(ctx context.Context, task LeafSyncTask) er
 	}
 }
 
-// Start launches [numThreads] worker goroutines to process LeafSyncTasks from [c.tasks].
+// Start launches [numWorkers] worker goroutines to process LeafSyncTasks from [c.tasks].
 // onFailure is called if the sync completes with an error.
-func (c *CallbackLeafSyncer) Start(ctx context.Context, numThreads int, onFailure func(error) error) {
+func (c *CallbackLeafSyncer) Start(ctx context.Context, numWorkers int, onFailure func(error) error) {
 	// Start the worker threads with the desired context.
 	eg, egCtx := errgroup.WithContext(ctx)
-	for i := 0; i < numThreads; i++ {
+	for i := 0; i < numWorkers; i++ {
 		eg.Go(func() error {
 			return c.workerLoop(egCtx)
 		})


### PR DESCRIPTION
Syncs https://github.com/ava-labs/coreth/pull/1058

Note that as `subnet-evm` does not contain the `plugin/evm/atomic/` package, this sync is limited to aligned variable names to threads. There are no functional changes in this PR. 