### PR TITLE
Update CODEOWNERS with platform-evm maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,5 +6,7 @@
 
 # review whenever someone opens a pull request.
 
-* @ava-labs/platform-evm
+* @ava-labs/platform-evm-maintainer
+/.github/ @maru-ava @ava-labs/platform-evm-maintainer
+/triedb/firewood/ @alarso16 @ava-labs/platform-evm-maintainer
 


### PR DESCRIPTION
Mirrors: https://github.com/ava-labs/coreth/pull/1091

## Why this should be merged

This is the beginning of the alignment of the code owners file to align with the best sources of knowledge.

## How this works

- Restricts default ownership to the evm-maintainers group.
- Adds Austin as the owner of the firewood code

## How this was tested

N/A

## Need to be documented?

No.

## Need to update RELEASES.md?

No.