### PR TITLE
sync: coreth PR #1077: fix typo in sync client (#1077)

### DIFF
--- a/latest-coreth-commit.txt
+++ b/latest-coreth-commit.txt
@@ -1,11 +1,11 @@
 # This is the latest commit of coreth that is synced with the subnet-evm
 
-204bdcf27dbf8982d7d61874c003aaf8b4daaa8b
+6d5d72233bcfc1f3315628f2788f073148c78b46
 
 # Notes: 
-- Last PR done is currently #1066
-- Coreth PR 1070 has already been synced (ahead of schedule) - see https://github.com/ava-labs/subnet-evm/pull/1652
-- Coreth PR 1071 has already been synced (ahead of schedule) - see https://github.com/ava-labs/subnet-evm/pull/1653
-- Coreth PR 1073 has already been synced (ahead of schedule) - see https://github.com/ava-labs/subnet-evm/pull/1659
-- Coreth PR 1087 has already been synced (ahead of schedule) - see https://github.com/ava-labs/subnet-evm/pull/1672
-- Coreth PR 1088 has already been synced (ahead of schedule) - see https://github.com/ava-labs/subnet-evm/pull/1672
+- Last PR done is currently #1071
+- coreth PR 1073 has already been synced (ahead of schedule) - see https://github.com/ava-labs/subnet-evm/pull/1659
+- coreth PR 1077 has already been synced (ahead of schedule) - see https://github.com/ava-labs/subnet-evm/pull/1677
+- coreth PR 1087 has already been synced (ahead of schedule) - see https://github.com/ava-labs/subnet-evm/pull/1672
+- coreth PR 1088 has already been synced (ahead of schedule) - see https://github.com/ava-labs/subnet-evm/pull/1672
+- coreth PR 1091 has already been synced (ahead of schedule) - see https://github.com/ava-labs/subnet-evm/pull/1676

--- a/plugin/evm/syncervm_client.go
+++ b/plugin/evm/syncervm_client.go
@@ -45,12 +45,12 @@ type stateSyncClientConfig struct {
 
 	lastAcceptedHeight uint64
 
-	Chain      *eth.Ethereum
-	State      *chain.State
-	ChainDB    ethdb.Database
-	Acceptor   BlockAcceptor
-	VerDB      *versiondb.Database
-	MetadataDB database.Database
+	Chain           *eth.Ethereum
+	State           *chain.State
+	ChainDB         ethdb.Database
+	AcceptedBlockDB database.Database
+	VerDB           *versiondb.Database
+	MetadataDB      database.Database
 
 	client        syncclient.Client
 	stateSyncDone chan struct{}

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -681,9 +681,7 @@ func (vm *VM) initializeStateSyncClient(lastAcceptedHeight uint64) error {
 		ChainDB:              vm.chaindb,
 		VerDB:                vm.versiondb,
 		MetadataDB:           vm.metadataDB,
-		Acceptor:             vm,
-		Parser:               vm.extensionConfig.SyncableParser,
-		Extender:             vm.extensionConfig.SyncExtender,
+		AcceptedBlockDB:      vm.acceptedBlockDB,
 	})
 
 	// If StateSync is disabled, clear any ongoing summary so that we will not attempt to resume

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -661,8 +661,8 @@ func (vm *VM) initializeStateSyncClient(lastAcceptedHeight uint64) error {
 	}
 
 	vm.StateSyncClient = NewStateSyncClient(&stateSyncClientConfig{
-		chain:         vm.eth,
-		state:         vm.State,
+		Chain:         vm.eth,
+		State:         vm.State,
 		stateSyncDone: vm.stateSyncDone,
 		client: statesyncclient.NewClient(
 			&statesyncclient.ClientConfig{
@@ -678,10 +678,12 @@ func (vm *VM) initializeStateSyncClient(lastAcceptedHeight uint64) error {
 		stateSyncMinBlocks:   vm.config.StateSyncMinBlocks,
 		stateSyncRequestSize: vm.config.StateSyncRequestSize,
 		lastAcceptedHeight:   lastAcceptedHeight, // TODO clean up how this is passed around
-		chaindb:              vm.chaindb,
-		metadataDB:           vm.metadataDB,
-		acceptedBlockDB:      vm.acceptedBlockDB,
-		db:                   vm.versiondb,
+		ChainDB:              vm.chaindb,
+		VerDB:                vm.versiondb,
+		MetadataDB:           vm.metadataDB,
+		Acceptor:             vm,
+		Parser:               vm.extensionConfig.SyncableParser,
+		Extender:             vm.extensionConfig.SyncExtender,
 	})
 
 	// If StateSync is disabled, clear any ongoing summary so that we will not attempt to resume


### PR DESCRIPTION
Syncs https://github.com/ava-labs/coreth/pull/1077

Note that the title is misleading as there were minor unsynced changes beyond the typo between the two repositories. This PR aligns them. 