### PR TITLE
perf: upgrade Firewood

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/VictoriaMetrics/fastcache v1.12.1
 	github.com/antithesishq/antithesis-sdk-go v0.3.8
 	github.com/ava-labs/avalanchego v1.13.4
-	github.com/ava-labs/firewood-go-ethhash/ffi v0.0.9
+	github.com/ava-labs/firewood-go-ethhash/ffi v0.0.11
 	github.com/ava-labs/libevm v1.13.14-0.3.0.rc.6
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckarep/golang-set/v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/ava-labs/avalanchego v1.13.4 h1:H7bI1qx9qaOddJ3E2J9KkLvTe7d613K821eST
 github.com/ava-labs/avalanchego v1.13.4/go.mod h1:pMPIH9KeyXFsdxuF6sy06sztq3p2rI4XeePXvGeg9Ew=
 github.com/ava-labs/coreth v0.15.3-rc.5 h1:zGk1LaFeZOEkA6uPF1g9BNCjbZOrONx9fm5WtiH5NWg=
 github.com/ava-labs/coreth v0.15.3-rc.5/go.mod h1:sEqzSu2f4FJEGFL7CP3zNOQtQ0MupWJdzTp7W65EDf8=
-github.com/ava-labs/firewood-go-ethhash/ffi v0.0.9 h1:zw0g+cUbZDsGdWx1PKmBChkpy+ixL3QgiI86DUOuXvo=
-github.com/ava-labs/firewood-go-ethhash/ffi v0.0.9/go.mod h1:cq89ua3iiZ5wPBALTEQS5eG8DIZcs7ov6OiL4YR1BVY=
+github.com/ava-labs/firewood-go-ethhash/ffi v0.0.11 h1:V9XDirIJ0oveor+sAPuOB0WMQ+b7FoDStScMdyGlBQ4=
+github.com/ava-labs/firewood-go-ethhash/ffi v0.0.11/go.mod h1:cq89ua3iiZ5wPBALTEQS5eG8DIZcs7ov6OiL4YR1BVY=
 github.com/ava-labs/libevm v1.13.14-0.3.0.rc.6 h1:tyM659nDOknwTeU4A0fUVsGNIU7k0v738wYN92nqs/Y=
 github.com/ava-labs/libevm v1.13.14-0.3.0.rc.6/go.mod h1:zP/DOcABRWargBmUWv1jXplyWNcfmBy9cxr0lw3LW3g=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=

--- a/latest-coreth-commit.txt
+++ b/latest-coreth-commit.txt
@@ -5,7 +5,6 @@
 # Notes: 
 - Last PR done in chronological order is currently #1071
 - The following PRs have already been synced 
-  - coreth PR 1059 (https://github.com/ava-labs/subnet-evm/pull/1678)
   - coreth PR 1073 (https://github.com/ava-labs/subnet-evm/pull/1659)
   - coreth PR 1077 (https://github.com/ava-labs/subnet-evm/pull/1677)
   - coreth PR 1086 (https://github.com/ava-labs/subnet-evm/pull/1671)
@@ -15,3 +14,4 @@
   - coreth PR 1117 (https://github.com/ava-labs/subnet-evm/1691)
   - coreth PR 1122 (https://github.com/ava-labs/subnet-evm/1690)
   - coreth PR 1123 (https://github.com/ava-labs/subnet-evm/1690)
+  - coreth PR 1134 (https://github.com/ava-labs/subnet-evm/1692)

--- a/triedb/firewood/database.go
+++ b/triedb/firewood/database.go
@@ -504,9 +504,6 @@ type reader struct {
 // Node retrieves the trie node with the given node hash. No error will be
 // returned if the node is not found.
 func (reader *reader) Node(_ common.Hash, path []byte, _ common.Hash) ([]byte, error) {
-	// TODO: remove these locks once Firewood supports concurrent reads and commits.
-	reader.db.proposalLock.RLock()
-	defer reader.db.proposalLock.RUnlock()
 	// This function relies on Firewood's internal locking to ensure concurrent reads are safe.
 	// This is safe even if a proposal is being committed concurrently.
 	start := time.Now()


### PR DESCRIPTION
## Why this should be merged

The most recent version of Firewood has a fix for the concurrency bug (see the one code change)

Mirrors ava-labs/coreth#1134

## How this works

Update go.mod and go.sum

## How this was tested

CI - but also ran with race checker locally to ensure that the race condition no longer exists

## Need to be documented?

No

## Need to update RELEASES.md?

No
