### PR TITLE
Fix `TestVMUpgradeBytesPrecompile` race condition flake 

### DIFF
--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -492,7 +492,7 @@ func (vm *VM) Initialize(
 		return err
 	}
 
-	go vm.ctx.Log.RecoverAndPanic(vm.startContinuousProfiler)
+	go chainCtx.Log.RecoverAndPanic(vm.startContinuousProfiler)
 
 	// Add p2p warp message warpHandler
 	warpHandler := acp118.NewCachedHandler(meteredCache, vm.warpBackend, vm.ctx.WarpSigner)


### PR DESCRIPTION
## Why this should be merged
Very very rarely this test hits a race condition on the continuous profiler that seems to be caused by simultaneous context access on Ubuntu. 

```
/Users/jonathan.oppenheimer/.go/bin/go test -timeout 30s -run ^TestVMUpgradeBytesPrecompile$ github.com/ava-labs/subnet-evm/plugin/evm -race -count=100
```

This PR fixes the issue by aligning the context in the initialization of the vm. 