### PR TITLE
sync: coreth PR #1148: Add time check for bootstrapping

### DIFF
--- a/params/hooks_libevm.go
+++ b/params/hooks_libevm.go
@@ -24,6 +24,10 @@ import (
 	customheader "github.com/ava-labs/subnet-evm/plugin/evm/header"
 )
 
+// invalidateDelegateTime is the Unix timestamp for August 2nd, 2025, midnight Eastern Time
+// (August 2nd, 2025, 04:00 UTC)
+const invalidateDelegateUnix = 1754107200
+
 type RulesExtra extras.Rules
 
 func GetRulesExtra(r Rules) *extras.Rules {
@@ -89,9 +93,14 @@ func makePrecompile(contract contract.StatefulPrecompiledContract) libevm.Precom
 			},
 		}
 
-		if callType := env.IncomingCallType(); callType == vm.DelegateCall || callType == vm.CallCode {
-			env.InvalidateExecution(fmt.Errorf("precompile cannot be called with %s", callType))
+		callType := env.IncomingCallType()
+		isDissallowedCallType := callType == vm.DelegateCall || callType == vm.CallCode
+		if env.BlockTime() >= invalidateDelegateUnix {
+			if isDissallowedCallType {
+				env.InvalidateExecution(fmt.Errorf("precompile cannot be called with %s", callType))
+			}
 		}
+
 		return contract.Run(accessibleState, env.Addresses().Caller, env.Addresses().Self, input, suppliedGas, env.ReadOnly())
 	}
 	return vm.NewStatefulPrecompile(legacy.PrecompiledStatefulContract(run).Upgrade())


### PR DESCRIPTION
## Why this should be merged
This PR establishes a time a check in `makePrecompile` to fix historical execution bootstrapping errors. 

```
// invalidateDelegateTime is the Unix timestamp for August 2nd, 2025, midnight Eastern Time
// (August 2nd, 2025, 04:00 UTC)
const invalidateDelegateTime = 1754107200
```

## How this was tested
Existing CI

## Need to be documented?
No

## Need to update RELEASES.md?
No