### PR TITLE
Disable non-security related dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,11 +15,6 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 0 # Disable non-security version updates
-    ignore:
-      - dependency-name: "ava-labs/avalanchego/.github/actions/run-monitored-tmpnet-cmd" # manually updated
-      - dependency-name: "golangci/golangci-lint-action"
-        versions:
-          - ">=7.0.0" # versions from 7.0.0 only support golangci-lint v2.x.x
   - package-ecosystem: "npm"
     directory: "/contracts"
     schedule:


### PR DESCRIPTION
Syncs [Disable non-security related dependabot PRs #1240](https://github.com/ava-labs/coreth/pull/1240). We discussed this in the last retro to be implemented. 