### PR TITLE
Set gas price oracle `DefaultMinPrice` to `acp176.MinGasPrice` 

### DIFF
--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -33,6 +33,7 @@ import (
 	"sync"
 
 	"github.com/ava-labs/avalanchego/utils/timer/mockable"
+	"github.com/ava-labs/avalanchego/vms/evm/acp176"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/common/lru"
 	"github.com/ava-labs/libevm/core/types"
@@ -66,7 +67,7 @@ const (
 
 var (
 	DefaultMaxPrice           = big.NewInt(150 * params.GWei)
-	DefaultMinPrice           = big.NewInt(0 * params.GWei)
+	DefaultMinPrice           = big.NewInt(acp176.MinGasPrice)
 	DefaultMinBaseFee         = big.NewInt(legacy.BaseFee)
 	DefaultMinGasUsed         = big.NewInt(6_000_000) // block gas limit is 8,000,000
 	DefaultMaxLookbackSeconds = uint64(80)


### PR DESCRIPTION
## Why this should be merged
This PR is self explanatory - the min price was being set incorrectly prior (see https://github.com/ava-labs/subnet-evm/blob/master/eth/backend.go#L293). This PR correctly sets it to 1, and aligns it with coreth. 
