### PR TITLE
chore: remove deprecated genesis types

### DIFF
--- a/core/blockchain_ext_test.go
+++ b/core/blockchain_ext_test.go
@@ -241,7 +241,7 @@ func InsertChainAcceptSingleBlock(t *testing.T, create createFunc) {
 	genesisBalance := big.NewInt(1000000)
 	gspec := &Genesis{
 		Config: &params.ChainConfig{HomesteadBlock: new(big.Int)},
-		Alloc:  GenesisAlloc{addr1: {Balance: genesisBalance}},
+		Alloc:  types.GenesisAlloc{addr1: {Balance: genesisBalance}},
 	}
 	blockchain, err := create(chainDB, gspec, common.Hash{}, t.TempDir())
 	if err != nil {
@@ -718,7 +718,7 @@ func BuildOnVariousStages(t *testing.T, create createFunc) {
 	genesisBalance := big.NewInt(1000000)
 	gspec := &Genesis{
 		Config: &params.ChainConfig{HomesteadBlock: new(big.Int)},
-		Alloc: GenesisAlloc{
+		Alloc: types.GenesisAlloc{
 			addr1: {Balance: genesisBalance},
 			addr3: {Balance: genesisBalance},
 		},
@@ -875,7 +875,7 @@ func EmptyBlocks(t *testing.T, create createFunc) {
 
 	gspec := &Genesis{
 		Config: &params.ChainConfig{HomesteadBlock: new(big.Int)},
-		Alloc:  GenesisAlloc{},
+		Alloc:  types.GenesisAlloc{},
 	}
 
 	blockchain, err := create(chainDB, gspec, common.Hash{}, t.TempDir())
@@ -1396,7 +1396,7 @@ func GenerateChainInvalidBlockFee(t *testing.T, create createFunc) {
 	genesisBalance := new(big.Int).Mul(big.NewInt(1000000), big.NewInt(params.Ether))
 	gspec := &Genesis{
 		Config: params.TestChainConfig,
-		Alloc:  GenesisAlloc{addr1: {Balance: genesisBalance}},
+		Alloc:  types.GenesisAlloc{addr1: {Balance: genesisBalance}},
 	}
 
 	blockchain, err := create(chainDB, gspec, common.Hash{}, t.TempDir())
@@ -1437,7 +1437,7 @@ func InsertChainInvalidBlockFee(t *testing.T, create createFunc) {
 	genesisBalance := new(big.Int).Mul(big.NewInt(1000000), big.NewInt(params.Ether))
 	gspec := &Genesis{
 		Config: params.TestChainConfig,
-		Alloc:  GenesisAlloc{addr1: {Balance: genesisBalance}},
+		Alloc:  types.GenesisAlloc{addr1: {Balance: genesisBalance}},
 	}
 
 	blockchain, err := create(chainDB, gspec, common.Hash{}, t.TempDir())
@@ -1570,7 +1570,7 @@ func StatefulPrecompiles(t *testing.T, create createFunc) {
 	}
 	gspec := &Genesis{
 		Config: &config,
-		Alloc:  GenesisAlloc{addr1: {Balance: genesisBalance}},
+		Alloc:  types.GenesisAlloc{addr1: {Balance: genesisBalance}},
 	}
 
 	blockchain, err := create(chainDB, gspec, common.Hash{}, t.TempDir())

--- a/core/blockchain_log_test.go
+++ b/core/blockchain_log_test.go
@@ -44,7 +44,7 @@ func TestAcceptedLogsSubscription(t *testing.T) {
 		funds   = new(big.Int).Mul(big.NewInt(100), big.NewInt(params.Ether))
 		gspec   = &Genesis{
 			Config:  params.TestChainConfig,
-			Alloc:   GenesisAlloc{addr1: {Balance: funds}},
+			Alloc:   types.GenesisAlloc{addr1: {Balance: funds}},
 			BaseFee: big.NewInt(legacy.BaseFee),
 		}
 		contractAddress = crypto.CreateAddress(addr1, 0)

--- a/core/blockchain_repair_test.go
+++ b/core/blockchain_repair_test.go
@@ -546,7 +546,7 @@ func testRepairWithScheme(t *testing.T, tt *rewindTest, snapshots bool, scheme s
 		gspec   = &Genesis{
 			BaseFee: feeConfig.MinBaseFee,
 			Config:  &chainConfig,
-			Alloc:   GenesisAlloc{addr1: {Balance: big.NewInt(params.Ether)}},
+			Alloc:   types.GenesisAlloc{addr1: {Balance: big.NewInt(params.Ether)}},
 		}
 		signer = types.LatestSigner(gspec.Config)
 		engine = dummy.NewFullFaker()

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -60,12 +60,6 @@ import (
 
 var errGenesisNoConfig = errors.New("genesis has no chain configuration")
 
-// Deprecated: use types.Account instead.
-type GenesisAccount = types.Account
-
-// Deprecated: use types.GenesisAlloc instead.
-type GenesisAlloc = types.GenesisAlloc
-
 type Airdrop struct {
 	// Address strings are hex-formatted common.Address
 	Address common.Address `json:"address"`
@@ -434,7 +428,7 @@ func (g *Genesis) Verify() error {
 func GenesisBlockForTesting(db ethdb.Database, addr common.Address, balance *big.Int) *types.Block {
 	g := Genesis{
 		Config:  params.TestChainConfig,
-		Alloc:   GenesisAlloc{addr: {Balance: balance}},
+		Alloc:   types.GenesisAlloc{addr: {Balance: balance}},
 		BaseFee: big.NewInt(legacy.BaseFee),
 	}
 	return g.MustCommit(db, triedb.NewDatabase(db, triedb.HashDefaults))

--- a/core/state_processor_ext_test.go
+++ b/core/state_processor_ext_test.go
@@ -60,8 +60,8 @@ func TestBadTxAllowListBlock(t *testing.T) {
 
 		gspec = &Genesis{
 			Config: config,
-			Alloc: GenesisAlloc{
-				testAddr: GenesisAccount{
+			Alloc: types.GenesisAlloc{
+				testAddr: types.Account{
 					Balance: big.NewInt(1000000000000000000), // 1 ether
 					Nonce:   0,
 				},

--- a/core/txindexer_test.go
+++ b/core/txindexer_test.go
@@ -57,7 +57,7 @@ func TestTransactionIndices(t *testing.T) {
 		funds   = big.NewInt(10000000000000)
 		gspec   = &Genesis{
 			Config: &params.ChainConfig{HomesteadBlock: new(big.Int)},
-			Alloc:  GenesisAlloc{addr1: {Balance: funds}},
+			Alloc:  types.GenesisAlloc{addr1: {Balance: funds}},
 		}
 		signer = types.LatestSigner(gspec.Config)
 	)
@@ -177,7 +177,7 @@ func TestTransactionSkipIndexing(t *testing.T) {
 		funds   = big.NewInt(10000000000000)
 		gspec   = &Genesis{
 			Config: &params.ChainConfig{HomesteadBlock: new(big.Int)},
-			Alloc:  GenesisAlloc{addr1: {Balance: funds}},
+			Alloc:  types.GenesisAlloc{addr1: {Balance: funds}},
 		}
 		signer = types.LatestSigner(gspec.Config)
 	)


### PR DESCRIPTION
## Why this should be merged
These types are explicitly deprecated and just serve as a type alias. 

## How this was tested
Existing UTs

## Need to be documented?
No

## Need to update RELEASES.md?
No
