### PR TITLE
Update avalanchego to v1.13.6-rc.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Setup Contracts
         run: ./scripts/run_task.sh setup-contracts
       - name: Run Warp E2E Tests
-        uses: ava-labs/avalanchego/.github/actions/run-monitored-tmpnet-cmd@63cc1a166a56e749f3c02856babbde596757f1e1
+        uses: ava-labs/avalanchego/.github/actions/run-monitored-tmpnet-cmd@8564a57d3ca61f976c90b4ad96e41640a2a3cdc4
         with:
           run: ./scripts/run_task.sh test-e2e-warp-ci
           artifact_prefix: warp
@@ -116,7 +116,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run E2E Load Tests
-        uses: ava-labs/avalanchego/.github/actions/run-monitored-tmpnet-cmd@63cc1a166a56e749f3c02856babbde596757f1e1
+        uses: ava-labs/avalanchego/.github/actions/run-monitored-tmpnet-cmd@8564a57d3ca61f976c90b4ad96e41640a2a3cdc4
         with:
           run: ./scripts/run_task.sh test-e2e-load-ci
           artifact_prefix: load

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.8
 require (
 	github.com/VictoriaMetrics/fastcache v1.12.1
 	github.com/antithesishq/antithesis-sdk-go v0.3.8
-	github.com/ava-labs/avalanchego v1.13.6-0.20251007213349-63cc1a166a56
+	github.com/ava-labs/avalanchego v1.13.6-rc.0
 	github.com/ava-labs/firewood-go-ethhash/ffi v0.0.12
 	github.com/ava-labs/libevm v1.13.15-0.20251002164226-35926db4d661
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
@@ -48,7 +48,7 @@ require (
 	github.com/DataDog/zstd v1.5.2 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/StephenButtolph/canoto v0.17.2 // indirect
-	github.com/ava-labs/coreth v0.15.4-rc.3.0.20251002221438-a857a64c28ea // indirect
+	github.com/ava-labs/coreth v0.15.4-rc.4 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.10.0 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.3.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -28,10 +28,10 @@ github.com/antithesishq/antithesis-sdk-go v0.3.8/go.mod h1:IUpT2DPAKh6i/YhSbt6Gl
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/ava-labs/avalanchego v1.13.6-0.20251007213349-63cc1a166a56 h1:Q4lnXtjMwsIheyRUkuOU7EZZ9WFf28vMWG4lPCmqhaE=
-github.com/ava-labs/avalanchego v1.13.6-0.20251007213349-63cc1a166a56/go.mod h1:EL0MGbL2liE9jp4QtCHR2thkNl8hCkD26DJ+7cmcaqs=
-github.com/ava-labs/coreth v0.15.4-rc.3.0.20251002221438-a857a64c28ea h1:vrHUSx6hlQgdVufhtT9LT9i7eHZcWmBEjH9cBozDLuc=
-github.com/ava-labs/coreth v0.15.4-rc.3.0.20251002221438-a857a64c28ea/go.mod h1:y/14LplmA0lLwIDlKiGAZ8OlxQ7OxhaU2dfkYcviLPM=
+github.com/ava-labs/avalanchego v1.13.6-rc.0 h1:n67ULn1TgHvot/XnlH+oTN/Mwgv6FDjksmZw+qT1opc=
+github.com/ava-labs/avalanchego v1.13.6-rc.0/go.mod h1:27SGpJ0L+3jVMfjY8X5nmgkZ3sFSc7vGeJj+SFjAKL0=
+github.com/ava-labs/coreth v0.15.4-rc.4 h1:ze7/IwDptWG1u2d32uUZz9Ix9ycVUtlB8JufuSKSSS4=
+github.com/ava-labs/coreth v0.15.4-rc.4/go.mod h1:yVwuMyPkZ48xzZ0y2OdIwaoUqvSsgPYoodyX9BZJ2uo=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.0.12 h1:aMcrLbpJ/dyu2kZDf/Di/4JIWsUcYPyTDKymiHpejt0=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.0.12/go.mod h1:cq89ua3iiZ5wPBALTEQS5eG8DIZcs7ov6OiL4YR1BVY=
 github.com/ava-labs/libevm v1.13.15-0.20251002164226-35926db4d661 h1:lt4yQE1HMvxWrdD5RFj+h9kWUsZK2rmNohvkeQsbG9M=


### PR DESCRIPTION
## Why this should be merged

Updates avalanchego to a version compatible with Granite.

## How this works

Version bump

## How this was tested

CI

## Need to be documented?

No

## Need to update RELEASES.md?

No