### PR TITLE
sync: coreth PR #1323: wait for tx pool event loop

### DIFF
--- a/plugin/evm/block_builder.go
+++ b/plugin/evm/block_builder.go
@@ -47,6 +47,9 @@ type blockBuilder struct {
 	// but at least after a minimum delay of minBlockBuildingRetryDelay.
 	lastBuildParentHash common.Hash
 	lastBuildTime       time.Time
+
+	chainHeadHash   common.Hash
+	mempoolHeadHash common.Hash
 }
 
 func (vm *VM) NewBlockBuilder() *blockBuilder {
@@ -94,9 +97,13 @@ func (b *blockBuilder) awaitSubmittedTxs() {
 	txSubmitChan := make(chan core.NewTxsEvent)
 	b.txPool.SubscribeTransactions(txSubmitChan, true)
 
+	events := make(chan core.NewTxPoolReorgEvent)
+	sub := b.txPool.SubscribeNewReorgEvent(events)
+
 	b.shutdownWg.Add(1)
 	go b.ctx.Log.RecoverAndPanic(func() {
 		defer b.shutdownWg.Done()
+		defer sub.Unsubscribe()
 
 		for {
 			select {
@@ -105,6 +112,12 @@ func (b *blockBuilder) awaitSubmittedTxs() {
 				b.signalCanBuild()
 			case <-b.shutdownChan:
 				return
+			case event := <-events:
+				if event.Head == nil || event.Head.Number == nil {
+					log.Warn("nil head or block number in tx pool reorg event")
+					continue
+				}
+				b.setMempoolHeadHash(event.Head.Hash())
 			}
 		}
 	})
@@ -143,7 +156,7 @@ func (b *blockBuilder) waitForEvent(ctx context.Context, currentHeader *types.He
 func (b *blockBuilder) waitForNeedToBuild(ctx context.Context) (time.Time, common.Hash, error) {
 	b.buildBlockLock.Lock()
 	defer b.buildBlockLock.Unlock()
-	for !b.needToBuild() {
+	for !b.needToBuild() || b.pendingPoolUpdate() {
 		if err := b.pendingSignal.Wait(ctx); err != nil {
 			return time.Time{}, common.Hash{}, err
 		}
@@ -185,4 +198,34 @@ func minNextBlockTime(parent *types.Header) time.Time {
 	// so this should not overflow
 	requiredDelay := time.Duration(acp226DelayExcess.Delay()) * time.Millisecond
 	return parentTime.Add(requiredDelay)
+}
+
+func (b *blockBuilder) setChainHeadHash(hash common.Hash) {
+	b.buildBlockLock.Lock()
+	defer b.buildBlockLock.Unlock()
+
+	b.chainHeadHash = hash
+
+	if b.pendingPoolUpdate() {
+		return
+	}
+
+	b.pendingSignal.Broadcast()
+}
+
+func (b *blockBuilder) setMempoolHeadHash(hash common.Hash) {
+	b.buildBlockLock.Lock()
+	defer b.buildBlockLock.Unlock()
+
+	b.mempoolHeadHash = hash
+
+	if b.pendingPoolUpdate() {
+		return
+	}
+
+	b.pendingSignal.Broadcast()
+}
+
+func (b *blockBuilder) pendingPoolUpdate() bool {
+	return b.chainHeadHash != b.mempoolHeadHash
 }

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -891,6 +891,8 @@ func (vm *VM) onNormalOperationsStarted() error {
 	// NOTE: gossip network must be initialized first otherwise ETH tx gossip will not work.
 	vm.builderLock.Lock()
 	vm.builder = vm.NewBlockBuilder()
+	vm.builder.setChainHeadHash(vm.blockChain.CurrentBlock().Hash())
+	vm.builder.setMempoolHeadHash(vm.blockChain.CurrentBlock().Hash())
 	vm.builder.awaitSubmittedTxs()
 	vm.builderLock.Unlock()
 
@@ -1130,7 +1132,14 @@ func (vm *VM) SetPreference(ctx context.Context, blkID ids.ID) error {
 		return fmt.Errorf("failed to set preference to %s: %w", blkID, err)
 	}
 
-	return vm.blockChain.SetPreference(block.(*wrappedBlock).ethBlock)
+	wb, isWrappedBlock := block.(*wrappedBlock)
+	if !isWrappedBlock {
+		return fmt.Errorf("expected block %s to be of type *wrappedBlock but got %T", blkID, block)
+	}
+
+	vm.setPendingBlock(wb.GetEthBlock().Hash())
+
+	return vm.blockChain.SetPreference(wb.ethBlock)
 }
 
 // GetBlockIDAtHeight returns the canonical block at [height].
@@ -1368,6 +1377,17 @@ func attachEthService(handler *rpc.Server, apis []rpc.API, names []string) error
 	}
 
 	return nil
+}
+
+func (vm *VM) setPendingBlock(hash common.Hash) {
+	vm.builderLock.Lock()
+	defer vm.builderLock.Unlock()
+
+	if vm.builder == nil {
+		return
+	}
+
+	vm.builder.setChainHeadHash(hash)
 }
 
 func (vm *VM) Connected(ctx context.Context, nodeID ids.NodeID, version *version.Application) error {


### PR DESCRIPTION
## Why this should be merged

Currently whenever we ask the VM to wait for an event, it checks if the mempool has transactions in it, and if so, it proceeds to return a "pending transactions" event.

The mempool has or has not transactions in it according to the block that the VM is configured to build on top on.

When the VM is being told to change the preferred block to build the next block on, the mempool is asynchronously re-organized in the background according to the block preference change.

Since the mempool re-organization happens asynchronously and in the background, when a VM changes its preference and is immediately asked to build a new block, the mempool may still contain transactions in it, because the mempool re-organization is still being performed asynchronously in the background. This leads to a false positive, as the mempool may not have transactions in it after its re-organization, but the WaitForEvent API call may return that the mempool has transactions in it and would result in building a block that shouldn't have been built.


## How this works

This PR fixes the aforementioned false positive, as explained below:

When we set the preference in the VM, we mark the block chain head hash.

In parallel, we subscribe to updates from the mempool which are sent only once the re-org corresponding to a block has finished. Upon such an update, we mark the block's hash as the mempool head hash.

When the VM checks whether to build a block, additionally to checking whether there are transactions in the mempool, we now also check whether the mempool is pending a re-org. A mempool is pending a re-org if the block mempool head hash is not equal to the chain head hash.

## How this was tested

Unit tests

## Need to be documented?

## Need to update RELEASES.md?
