### PR TITLE
use vm connected/disconnected methods

### DIFF
--- a/plugin/evm/vm_uptime_test.go
+++ b/plugin/evm/vm_uptime_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ava-labs/avalanchego/snow/engine/enginetest"
 	"github.com/ava-labs/avalanchego/snow/validators/validatorstest"
 	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
+	"github.com/ava-labs/avalanchego/version"
 	"github.com/ava-labs/avalanchego/vms/evm/uptimetracker"
 	"github.com/stretchr/testify/require"
 
@@ -86,7 +87,7 @@ func TestUptimeTracker(t *testing.T) {
 	require.Equal(baseTime, initialLastUpdated, "Initial lastUpdated should be baseTime")
 
 	// connect, time passes
-	require.NoError(vm.Connected(t.Context(), testNodeID, nil))
+	require.NoError(vm.Connected(t.Context(), testNodeID, version.Current))
 	clock.Set(baseTime.Add(1 * time.Hour))
 
 	// get uptime after 1 hour of being connected - uptime should have increased by 1 hour
@@ -106,7 +107,7 @@ func TestUptimeTracker(t *testing.T) {
 	require.Equal(baseTime.Add(2*time.Hour), lastUpdated, "lastUpdated should still advance")
 
 	// reconnect, time passes another 30 minutes
-	require.NoError(vm.Connected(t.Context(), testNodeID, nil))
+	require.NoError(vm.Connected(t.Context(), testNodeID, version.Current))
 	clock.Set(baseTime.Add(2*time.Hour + 30*time.Minute))
 
 	// get uptime - total uptime should be 1h30m


### PR DESCRIPTION
## Why this should be merged

@JonathanOppenheimer called the coverage was missing in this [comment](https://github.com/ava-labs/subnet-evm/pull/1679#discussion_r2577692891). Increased the coverage by using the VM methods.

## How this works

Uses `vm.Connected`/`vm.Disconnected` methods to increase the coverage.

## How this was tested

UT

## Need to be documented?

No

## Need to update RELEASES.md?

No
