### PR TITLE
chore: fix shellcheck directives

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -24,4 +24,5 @@ fi
 
 # Build Subnet EVM, which is run as a subprocess
 echo "Building Subnet EVM @ GitCommit: $SUBNET_EVM_COMMIT at $BINARY_PATH"
+# shellcheck disable=SC2153 # STATIC_LD_FLAGS is defined in constants.sh
 go build -ldflags "-X github.com/ava-labs/subnet-evm/plugin/evm.GitCommit=$SUBNET_EVM_COMMIT $STATIC_LD_FLAGS" -o "$BINARY_PATH" "plugin/"*.go

--- a/scripts/build_antithesis_images.sh
+++ b/scripts/build_antithesis_images.sh
@@ -15,6 +15,7 @@ SUBNET_EVM_PATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
 # TODO(marun) Support use of a released node image if using a release version of avalanchego
 
 source "${SUBNET_EVM_PATH}"/scripts/constants.sh
+# shellcheck source=/dev/null
 source "${SUBNET_EVM_PATH}"/scripts/lib_avalanchego_clone.sh
 
 clone_avalanchego "${AVALANCHE_VERSION}"

--- a/scripts/build_docker_image.sh
+++ b/scripts/build_docker_image.sh
@@ -92,6 +92,7 @@ if ! docker pull "${AVALANCHEGO_NODE_IMAGE}"; then
   AVALANCHEGO_NODE_IMAGE="${AVALANCHEGO_LOCAL_IMAGE_NAME}:${AVALANCHE_VERSION}"
   echo "Building ${AVALANCHEGO_NODE_IMAGE} locally"
 
+  # shellcheck source=/dev/null
   source "${SUBNET_EVM_PATH}"/scripts/lib_avalanchego_clone.sh
   clone_avalanchego "${AVALANCHE_VERSION}"
   SKIP_BUILD_RACE=1 \

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -19,6 +19,7 @@ grep -P 'lint.sh' scripts/lint.sh &>/dev/null || (
 )
 
 # Library for file list generation.
+# shellcheck source=/dev/null
 source ./scripts/lint_setup.sh
 
 # by default, "./scripts/lint.sh" runs all lint tests

--- a/scripts/lint_fix.sh
+++ b/scripts/lint_fix.sh
@@ -7,6 +7,7 @@ if ! [[ "$0" =~ scripts/lint_fix.sh ]]; then
   exit 255
 fi
 
+# shellcheck source=/dev/null
 source ./scripts/lint_setup.sh
 setup_lint
 go tool -modfile=tools/go.mod golangci-lint run --config .golangci.yml --fix


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Why this should be merged

These failures broke `./scripts/shellcheck.sh`, which was not caught in this repository's CI for some reason. This PR adds the correct directives. 

## How this was tested
Locally (CI doesn't catch)

## Need to be documented?
No

## Need to update RELEASES.md?
No 